### PR TITLE
vsr: rename repair commands

### DIFF
--- a/docs/internals/sync.md
+++ b/docs/internals/sync.md
@@ -106,7 +106,7 @@ State sync is triggered when a replica receives a `view` message with a more adv
 checkpoint.
 
 If a replica isn't making progress committing because a grid block or a prepare can't be repaired
-for some time, the replica proactively sends `request_view` to initiate the sync (see
+for some time, the replica proactively sends `get_view` to initiate the sync (see
 `repair_sync_timeout`).
 
 ### 5: Conclusion

--- a/docs/internals/vsr.md
+++ b/docs/internals/vsr.md
@@ -212,7 +212,7 @@ During repair, missing/damaged prepares are requested & repaired chronologically
 
 In response to a `get_prepare`:
 
-- Reply with the `command=prepare` message with the requested prepare, if available and valid.
+- Respond with the `command=prepare` message with the requested prepare, if available and valid.
 - Otherwise do not reply. (e.g. the corresponding slot in the WAL is corrupt)
 
 Per [PAR's CTRL Protocol](https://www.usenix.org/system/files/conference/fast18/fast18-alagappan.pdf), we do not nack corrupt entries, since they _might_ be the prepare being requested.
@@ -228,7 +228,7 @@ During repair, corrupt client replies are requested & repaired.
 
 In response to a `get_reply`:
 
-- Reply with the `command=reply` message (the requested reply), if available and valid.
+- Respond with the `command=reply` message (the requested reply), if available and valid.
 - Otherwise do not reply.
 
 ### Protocol: Client

--- a/docs/internals/vsr.md
+++ b/docs/internals/vsr.md
@@ -40,14 +40,14 @@ Storage:
 |                  `commit` | primary |       backup | [Normal](#protocol-normal)                                                                                                                 |
 |               `exit_view` | replica | all replicas | [Start-View-Change](#protocol-start-view-change)                                                                                           |
 |               `join_view` | replica | all replicas | [View-Change](#protocol-view-change)                                                                                                       |
-|                    `view` | primary |       backup | [Request/View](#protocol-request-view), [State Sync](./sync.md)                                                                 |
-|            `request_view` |  backup |      primary | [Request/View](#protocol-request-view)                                                                                          |
-|         `request_headers` | replica |      replica | [Repair Journal](#protocol-repair-journal)                                                                                                 |
-|         `request_prepare` | replica |      replica | [Repair WAL](#protocol-repair-wal)                                                                                                         |
-|           `request_reply` | replica |      replica | [Repair Client Replies](#protocol-repair-client-replies), [Sync Client Replies](#protocol-sync-client-replies)                             |
+|                    `view` | primary |       backup | [Request/View](#protocol-request-view), [State Sync](./sync.md)                                                                            |
+|                `get_view` |  backup |      primary | [Request/View](#protocol-request-view)                                                                                                     |
+|             `get_headers` | replica |      replica | [Repair Journal](#protocol-repair-journal)                                                                                                 |
+|             `get_prepare` | replica |      replica | [Repair WAL](#protocol-repair-wal)                                                                                                         |
+|               `get_reply` | replica |      replica | [Repair Client Replies](#protocol-repair-client-replies), [Sync Client Replies](#protocol-sync-client-replies)                             |
 |                 `headers` | replica |      replica | [Repair Journal](#protocol-repair-journal)                                                                                                 |
 |                `eviction` | primary |       client | [Client](#protocol-client)                                                                                                                 |
-|          `request_blocks` | replica |      replica | [Sync Forest](#protocol-sync-forest), [Repair Grid](#protocol-repair-grid)                                                                 |
+|              `get_blocks` | replica |      replica | [Sync Forest](#protocol-sync-forest), [Repair Grid](#protocol-repair-grid)                                                                 |
 |                   `block` | replica |      replica | [Sync Forest](#protocol-sync-forest), [Repair Grid](#protocol-repair-grid)                                                                 |
 
 ### Recovery
@@ -158,9 +158,9 @@ When the primary collects its JV quorum:
 
 ### Protocol: Request/View
 
-#### `request_view`
+#### `get_view`
 
-A backup sends a `command=request_view` to the primary of a view when any of the following occur:
+A backup sends a `command=get_view` to the primary of a view when any of the following occur:
 
 - the backup learns about a newer view via a `command=commit` message, or
 - the backup learns about a newer view via a `command=prepare` message, or
@@ -170,7 +170,7 @@ A backup sends a `command=request_view` to the primary of a view when any of the
 
 #### `view`
 
-When a `status=normal` primary receives `command=request_view`, it replies with a `command=view`.
+When a `status=normal` primary receives `command=get_view`, it replies with a `command=view`.
 `command=view` includes:
 - The view's current suffix — the headers of the latest messages in the view.
 - The current checkpoint (see [State Sync](./sync.md)).
@@ -187,7 +187,7 @@ A `view` contains the following headers (which may overlap):
 
 ### Protocol: Repair Journal
 
-`request_headers` and `headers` repair gaps or breaks in a replica's journal headers.
+`get_headers` and `headers` repair gaps or breaks in a replica's journal headers.
 Repaired headers are a prerequisite for [repairing prepares](#protocol-repair-wal).
 
 Because the headers are repaired backwards (from the head) by hash-chaining, it is safe for both backups and transitioning primaries.
@@ -210,9 +210,9 @@ During repair, missing/damaged prepares are requested & repaired chronologically
 - improves the chances that older entries will be available, i.e. not yet overwritten
 - enables better pipelining of repair and commit.
 
-In response to a `request_prepare`:
+In response to a `get_prepare`:
 
-- Reply the `command=prepare` with the requested prepare, if available and valid.
+- Reply with the `command=prepare` message with the requested prepare, if available and valid.
 - Otherwise do not reply. (e.g. the corresponding slot in the WAL is corrupt)
 
 Per [PAR's CTRL Protocol](https://www.usenix.org/system/files/conference/fast18/fast18-alagappan.pdf), we do not nack corrupt entries, since they _might_ be the prepare being requested.
@@ -226,9 +226,9 @@ The replica stores the latest reply to each active client.
 
 During repair, corrupt client replies are requested & repaired.
 
-In response to a `request_reply`:
+In response to a `get_reply`:
 
-- Respond with the `command=reply` (the requested reply), if available and valid.
+- Reply with the `command=reply` message (the requested reply), if available and valid.
 - Otherwise do not reply.
 
 ### Protocol: Client
@@ -249,8 +249,8 @@ See also:
 
 Grid repair is triggered when a replica discovers a corrupt (or missing) grid block.
 
-1. The repairing replica sends a `command=request_blocks` to any other replica. The message body contains a list of block `address`/`checksum`s.
-2. Upon receiving a `command=request_blocks`, a replica reads its own grid to check for the requested blocks. For each matching block found, reply with the `command=block` message (the block itself).
+1. The repairing replica sends a `command=get_blocks` to any other replica. The message body contains a list of block `address`/`checksum`s.
+2. Upon receiving a `command=get_blocks`, a replica reads its own grid to check for the requested blocks. For each matching block found, reply with the `command=block` message (the block itself).
 3. Upon receiving a `command=block`, a replica writes the block to its grid, and resolves the reads that were blocked on it.
 
 Note that _both sides_ of grid repair can run while the grid is being opened during replica startup.

--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -283,7 +283,7 @@ const ReflectionHelper = struct {
     var request_class: jni.JClass = null;
     var request_send_buffer_field_id: jni.JFieldID = null;
     var request_send_buffer_len_field_id: jni.JFieldID = null;
-    var request_reply_buffer_field_id: jni.JFieldID = null;
+    var reply_buffer_field_id: jni.JFieldID = null;
     var request_operation_method_id: jni.JMethodID = null;
     var request_end_request_method_id: jni.JMethodID = null;
 
@@ -296,7 +296,7 @@ const ReflectionHelper = struct {
         assert(request_class == null);
         assert(request_send_buffer_field_id == null);
         assert(request_send_buffer_len_field_id == null);
-        assert(request_reply_buffer_field_id == null);
+        assert(reply_buffer_field_id == null);
         assert(request_operation_method_id == null);
         assert(request_end_request_method_id == null);
 
@@ -337,7 +337,7 @@ const ReflectionHelper = struct {
             "sendBufferLen",
             "J",
         );
-        request_reply_buffer_field_id = JNIHelper.find_field(
+        reply_buffer_field_id = JNIHelper.find_field(
             env,
             request_class,
             "replyBuffer",
@@ -364,7 +364,7 @@ const ReflectionHelper = struct {
         assert(request_class != null);
         assert(request_send_buffer_field_id != null);
         assert(request_send_buffer_len_field_id != null);
-        assert(request_reply_buffer_field_id != null);
+        assert(reply_buffer_field_id != null);
         assert(request_operation_method_id != null);
         assert(request_end_request_method_id != null);
     }
@@ -382,7 +382,7 @@ const ReflectionHelper = struct {
         request_class = null;
         request_send_buffer_field_id = null;
         request_send_buffer_len_field_id = null;
-        request_reply_buffer_field_id = null;
+        reply_buffer_field_id = null;
         request_operation_method_id = null;
         request_end_request_method_id = null;
     }
@@ -492,7 +492,7 @@ const ReflectionHelper = struct {
         reply: []const u8,
     ) void {
         assert(this_obj != null);
-        assert(request_reply_buffer_field_id != null);
+        assert(reply_buffer_field_id != null);
         assert(reply.len > 0);
 
         const reply_buffer_obj = env.new_byte_array(
@@ -527,7 +527,7 @@ const ReflectionHelper = struct {
         // Setting the request with the reply.
         env.set_object_field(
             this_obj,
-            request_reply_buffer_field_id,
+            reply_buffer_field_id,
             reply_buffer_obj,
         );
     }

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -316,20 +316,20 @@ comptime {
     assert(view_headers_max > view_change_headers_suffix_max);
 }
 
-/// The maximum number of headers to include with a response to a command=request_headers message.
-pub const request_headers_max = @min(
+/// The maximum number of headers to include with a response to a command=get_headers message.
+pub const get_headers_max = @min(
     @divFloor(message_body_size_max, @sizeOf(vsr.Header)),
     64,
 );
 
 comptime {
-    assert(request_headers_max > 0);
+    assert(get_headers_max > 0);
 }
 
-/// The maximum number of block addresses/checksums requested by a single command=request_blocks.
+/// The maximum number of block addresses/checksums requested by a single command=get_blocks.
 pub const grid_repair_request_max = config.process.grid_repair_request_max;
 
-/// The number of grid reads allocated to handle incoming command=request_blocks messages.
+/// The number of grid reads allocated to handle incoming command=get_blocks messages.
 pub const grid_repair_reads_max = config.process.grid_repair_reads_max;
 
 /// Immediately after state sync we want access to all of the grid's write bandwidth to rapidly sync

--- a/src/message_pool.zig
+++ b/src/message_pool.zig
@@ -119,13 +119,13 @@ pub const MessagePool = struct {
         pub const ExitView = CommandMessageType(.exit_view);
         pub const JoinView = CommandMessageType(.join_view);
         pub const View = CommandMessageType(.view);
-        pub const RequestView = CommandMessageType(.request_view);
-        pub const RequestHeaders = CommandMessageType(.request_headers);
-        pub const RequestPrepare = CommandMessageType(.request_prepare);
-        pub const RequestReply = CommandMessageType(.request_reply);
+        pub const GetView = CommandMessageType(.get_view);
+        pub const GetHeaders = CommandMessageType(.get_headers);
+        pub const GetPrepare = CommandMessageType(.get_prepare);
+        pub const GetReply = CommandMessageType(.get_reply);
         pub const Headers = CommandMessageType(.headers);
         pub const Eviction = CommandMessageType(.eviction);
-        pub const RequestBlocks = CommandMessageType(.request_blocks);
+        pub const GetBlocks = CommandMessageType(.get_blocks);
         pub const Block = CommandMessageType(.block);
 
         // TODO Avoid the extra level of indirection.

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -246,16 +246,17 @@ pub const Command = enum(u8) {
 
     exit_view = 10,
     join_view = 11,
+    get_view = 13,
 
-    request_view = 13,
-    request_headers = 14,
-    request_prepare = 15,
-    request_reply = 16,
+    get_headers = 14,
+    get_prepare = 15,
+    get_reply = 16,
+    get_blocks = 19,
+
     headers = 17,
 
     eviction = 18,
 
-    request_blocks = 19,
     block = 20,
 
     view = 24,

--- a/src/vsr/journal.zig
+++ b/src/vsr/journal.zig
@@ -97,7 +97,7 @@ pub const write_ahead_log_zone_size = headers_size + prepares_size;
 
 /// Limit on the number of repair reads.
 /// This keeps some reads available for commit path, so that an asymmetrically
-/// partitioned replica cannot starve the cluster with request_prepare messages.
+/// partitioned replica cannot starve the cluster with get_prepare messages.
 const reads_repair_count_max: u6 = constants.journal_iops_read_max - reads_commit_count_max;
 /// We need at most two reads on commit path: one for commit_journal, and one for
 /// primary_repair_pipeline_read.
@@ -280,7 +280,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
         faulty: BitSet,
 
         /// The checksum of the prepare in the corresponding slot.
-        /// This is used to respond to `request_prepare` messages even when the slot is faulty.
+        /// This is used to respond to `get_prepare` messages even when the slot is faulty.
         /// For example, the slot may be faulty because the redundant header is faulty.
         ///
         /// The checksum will missing (`prepare_checksums[i]=0`, `prepare_inhabited[i]=false`) when:
@@ -886,8 +886,8 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
                     // * The prepare was rewritten since the read began.
                     // * Misdirected read/write.
                     // * The combination of:
-                    //   * The primary is responding to a `request_prepare`.
-                    //   * The `request_prepare` did not include a checksum.
+                    //   * The primary is responding to a `get_prepare`.
+                    //   * The `get_prepare` did not include a checksum.
                     //   * The requested op's slot is faulty, but the prepare is valid. Since the
                     //     prepare is valid, WAL recovery set `prepare_checksums[slot]`. But on
                     //     reading this entry it turns out not to have the right op.
@@ -1229,7 +1229,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
         ///  eql  The header and prepare are identical; no repair necessary.
         ///  nil  Reserved; dirty/faulty are clear, no repair necessary.
         ///  fix  Repair header using local intact prepare.
-        ///  vsr  Repair with VSR `request_prepare`.
+        ///  vsr  Repair with VSR `get_prepare`.
         ///
         /// A "valid" header/prepare:
         /// 1. has a valid checksum
@@ -1264,7 +1264,7 @@ pub fn JournalType(comptime Replica: type, comptime Storage: type) type {
                     .op_checkpoint = replica.op_checkpoint(),
                 });
 
-                // `prepare_checksums` improves the availability of `request_prepare` by being more
+                // `prepare_checksums` improves the availability of `get_prepare` by being more
                 // flexible than `headers` regarding the prepares it references. It may hold a
                 // prepare whose redundant header is broken, as long as the prepare itself is valid.
                 if (prepare != null and prepare.?.operation != .reserved) {
@@ -2358,7 +2358,7 @@ const RecoveryDecision = enum {
     nil,
     /// Use intact prepare to repair redundant header. Dirty/faulty are clear.
     fix,
-    /// If replica_count>1  or  standby: Repair with VSR `request_prepare`. Mark dirty, mark faulty.
+    /// If replica_count>1  or  standby: Repair with VSR `get_prepare`. Mark dirty, mark faulty.
     /// If replica_count=1 and !standby: Fail; cannot recover safely.
     vsr,
     /// The prepare is from the next checkpoint. Truncate, set to reserved, clear dirty/faulty.

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -89,13 +89,13 @@ pub const Header = extern struct {
             .exit_view => ExitView,
             .join_view => JoinView,
             .view => View,
-            .request_view => RequestView,
-            .request_headers => RequestHeaders,
-            .request_prepare => RequestPrepare,
-            .request_reply => RequestReply,
+            .get_view => GetView,
+            .get_headers => GetHeaders,
+            .get_prepare => GetPrepare,
+            .get_reply => GetReply,
             .headers => Headers,
             .eviction => Eviction,
-            .request_blocks => RequestBlocks,
+            .get_blocks => GetBlocks,
             .block => Block,
             .deprecated_12 => Deprecated,
             .deprecated_21 => Deprecated,
@@ -221,13 +221,13 @@ pub const Header = extern struct {
             .exit_view,
             .join_view,
             .view,
-            .request_view,
-            .request_headers,
-            .request_prepare,
-            .request_reply,
+            .get_view,
+            .get_headers,
+            .get_prepare,
+            .get_reply,
             .headers,
             .eviction,
-            .request_blocks,
+            .get_blocks,
             => .{ .replica = self.replica },
 
             .deprecated_12,
@@ -1239,7 +1239,7 @@ pub const Header = extern struct {
         }
     };
 
-    pub const RequestView = extern struct {
+    pub const GetView = extern struct {
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -1270,7 +1270,7 @@ pub const Header = extern struct {
         pub const format = HeaderFunctionsType(@This()).format;
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
-            assert(self.command == .request_view);
+            assert(self.command == .get_view);
             if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
             if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
             if (self.release.value != 0) return "release != 0";
@@ -1280,7 +1280,7 @@ pub const Header = extern struct {
         }
     };
 
-    pub const RequestHeaders = extern struct {
+    pub const GetHeaders = extern struct {
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -1314,7 +1314,7 @@ pub const Header = extern struct {
         pub const format = HeaderFunctionsType(@This()).format;
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
-            assert(self.command == .request_headers);
+            assert(self.command == .get_headers);
             if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
             if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
             if (self.view != 0) return "view == 0";
@@ -1325,7 +1325,7 @@ pub const Header = extern struct {
         }
     };
 
-    pub const RequestPrepare = extern struct {
+    pub const GetPrepare = extern struct {
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -1358,7 +1358,7 @@ pub const Header = extern struct {
         pub const format = HeaderFunctionsType(@This()).format;
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
-            assert(self.command == .request_prepare);
+            assert(self.command == .get_prepare);
             if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
             if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
             if (self.view != 0 and self.prepare_checksum != 0) return "view != 0 and checksum != 0";
@@ -1369,7 +1369,7 @@ pub const Header = extern struct {
         }
     };
 
-    pub const RequestReply = extern struct {
+    pub const GetReply = extern struct {
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -1403,7 +1403,7 @@ pub const Header = extern struct {
         pub const format = HeaderFunctionsType(@This()).format;
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
-            assert(self.command == .request_reply);
+            assert(self.command == .get_reply);
             if (self.size != @sizeOf(Header)) return "size != @sizeOf(Header)";
             if (self.checksum_body != checksum_body_empty) return "checksum_body != expected";
             if (self.release.value != 0) return "release != 0";
@@ -1522,7 +1522,7 @@ pub const Header = extern struct {
         };
     };
 
-    pub const RequestBlocks = extern struct {
+    pub const GetBlocks = extern struct {
         checksum: u128 = 0,
         checksum_padding: u128 = 0,
         checksum_body: u128 = 0,
@@ -1552,7 +1552,7 @@ pub const Header = extern struct {
         pub const format = HeaderFunctionsType(@This()).format;
 
         fn invalid_header(self: *const @This()) ?[]const u8 {
-            assert(self.command == .request_blocks);
+            assert(self.command == .get_blocks);
             if (self.view != 0) return "view != 0";
             if (self.size == @sizeOf(Header)) return "size == @sizeOf(Header)";
             if ((self.size - @sizeOf(Header)) % @sizeOf(vsr.BlockRequest) != 0) {

--- a/src/vsr/repair_budget.zig
+++ b/src/vsr/repair_budget.zig
@@ -47,7 +47,7 @@ pub const RepairBudgetJournal = struct {
     // increasing the repair latency on expiry.
     duration_expiry_max: stdx.Duration = .ms(500),
 
-    // Maximum inflight `request_prepare` messages per remote replica, at any point of time.
+    // Maximum inflight `get_prepare` messages per remote replica, at any point of time.
     //
     // This is kept small to ensure that even if the budget to a remote replica is saturated
     // by multiple replicas, overflowing the egress `send_queue` (which leads to dropped messages)
@@ -281,7 +281,7 @@ pub const RepairBudgetGrid = struct {
     // remote replica is saturated by multiple replicas, overflowing
     // the egress `send_queue` (which leads to dropped messages, and
     // wasted network & storage IO) on the remote replica is unlikely.
-    // The +1 allows us to send a full `request_blocks` even when
+    // The +1 allows us to send a full `get_blocks` even when
     // all but one request has been responded to.
     const replica_blocks_requested_max = constants.grid_repair_request_max + 1;
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -1561,10 +1561,7 @@ pub fn ReplicaType(
                 .{ &self.exit_view_message_timeout, on_exit_view_message_timeout },
                 .{ &self.view_change_status_timeout, on_view_change_status_timeout },
                 .{ &self.join_view_message_timeout, on_join_view_message_timeout },
-                .{
-                    &self.get_view_message_timeout,
-                    on_get_view_message_timeout,
-                },
+                .{ &self.get_view_message_timeout, on_get_view_message_timeout },
                 .{ &self.journal_repair_timeout, on_journal_repair_timeout },
 
                 .{ &self.repair_sync_timeout, on_repair_sync_timeout },

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -480,7 +480,7 @@ pub fn ReplicaType(
 
         /// When "log_view < view": The JV headers.
         /// When "log_view = view": The View headers. (Just as a cache,
-        /// since they are regenerated for every request_view).
+        /// since they are regenerated for every get_view).
         ///
         /// Invariants:
         /// - view_headers.len     > 0
@@ -564,9 +564,9 @@ pub fn ReplicaType(
         /// (status=view-change)
         join_view_message_timeout: Timeout,
 
-        /// The number of ticks before resending a `request_view` message.
+        /// The number of ticks before resending a `get_view` message.
         /// (status=view-change backup)
-        request_view_message_timeout: Timeout,
+        get_view_message_timeout: Timeout,
 
         /// The number of ticks before repairing missing/disconnected headers, dirty/missing
         /// prepares, and replenishing the repair budget.
@@ -1402,8 +1402,8 @@ pub fn ReplicaType(
                     .id = replica_index,
                     .after = 500 / constants.tick_ms,
                 },
-                .request_view_message_timeout = Timeout{
-                    .name = "request_view_message_timeout",
+                .get_view_message_timeout = Timeout{
+                    .name = "get_view_message_timeout",
                     .id = replica_index,
                     .after = 1_000 / constants.tick_ms,
                 },
@@ -1562,8 +1562,8 @@ pub fn ReplicaType(
                 .{ &self.view_change_status_timeout, on_view_change_status_timeout },
                 .{ &self.join_view_message_timeout, on_join_view_message_timeout },
                 .{
-                    &self.request_view_message_timeout,
-                    on_request_view_message_timeout,
+                    &self.get_view_message_timeout,
+                    on_get_view_message_timeout,
                 },
                 .{ &self.journal_repair_timeout, on_journal_repair_timeout },
 
@@ -1810,12 +1810,12 @@ pub fn ReplicaType(
                 .exit_view => |m| self.on_exit_view(m),
                 .join_view => |m| self.on_join_view(m),
                 .view => |m| self.on_view(m),
-                .request_view => |m| self.on_request_view(m),
-                .request_prepare => |m| self.on_request_prepare(m),
-                .request_headers => |m| self.on_request_headers(m),
-                .request_reply => |m| self.on_request_reply(m),
+                .get_view => |m| self.on_get_view(m),
+                .get_prepare => |m| self.on_get_prepare(m),
+                .get_headers => |m| self.on_get_headers(m),
+                .get_reply => |m| self.on_get_reply(m),
                 .headers => |m| self.on_headers(m),
-                .request_blocks => |m| self.on_request_blocks(m),
+                .get_blocks => |m| self.on_get_blocks(m),
                 .block => |m| self.on_block(m),
                 // A replica should never handle misdirected messages intended for a client:
                 .pong_client, .eviction => {
@@ -2541,7 +2541,7 @@ pub fn ReplicaType(
                     self.commit_journal();
                 }
 
-                // Initiate repair so `repair_header`/`request_prepare` network messages can be
+                // Initiate repair so `repair_header`/`get_prepare` network messages can be
                 // sent concurrently while writing this prepare.
                 self.repair();
             }
@@ -3020,11 +3020,11 @@ pub fn ReplicaType(
             if (self.syncing == .idle) self.repair();
         }
 
-        fn on_request_view(
+        fn on_get_view(
             self: *Replica,
-            message: *const Message.RequestView,
+            message: *const Message.GetView,
         ) void {
-            assert(message.header.command == .request_view);
+            assert(message.header.command == .get_view);
             if (self.ignore_repair_message(message.base_const())) return;
 
             assert(self.status == .normal);
@@ -3054,8 +3054,8 @@ pub fn ReplicaType(
         /// to the cluster. The cluster sees the replica as an underwriter of a guaranteed
         /// prepare. If a guaranteed prepare is found to by faulty, the replica must repair it
         /// to restore durability.
-        fn on_request_prepare(self: *Replica, message: *const Message.RequestPrepare) void {
-            assert(message.header.command == .request_prepare);
+        fn on_get_prepare(self: *Replica, message: *const Message.GetPrepare) void {
+            assert(message.header.command == .get_prepare);
             if (self.ignore_repair_message(message.base_const())) return;
 
             assert(self.node_count > 1);
@@ -3071,7 +3071,7 @@ pub fn ReplicaType(
                 if (self.journal.header_with_op(message.header.prepare_op)) |header| {
                     break :blk header.checksum;
                 } else {
-                    log.debug("{}: on_request_prepare: op={} missing", .{
+                    log.debug("{}: on_get_prepare: op={} missing", .{
                         self.log_prefix(),
                         message.header.prepare_op,
                     });
@@ -3086,7 +3086,7 @@ pub fn ReplicaType(
                 message.header.prepare_op,
                 checksum,
             )) |prepare| {
-                log.debug("{}: on_request_prepare: op={} checksum={x:0>32} reply from pipeline", .{
+                log.debug("{}: on_get_prepare: op={} checksum={x:0>32} reply from pipeline", .{
                     self.log_prefix(),
                     message.header.prepare_op,
                     checksum,
@@ -3109,7 +3109,7 @@ pub fn ReplicaType(
                 // TODO Do not reissue the read if we are already reading in order to send to
                 // this particular destination replica.
                 self.journal.read_prepare_with_op_and_checksum(
-                    on_request_prepare_read,
+                    on_get_prepare_read,
                     .{
                         .op = message.header.prepare_op,
                         .checksum = checksum,
@@ -3117,7 +3117,7 @@ pub fn ReplicaType(
                     },
                 );
             } else {
-                log.debug("{}: on_request_prepare: op={} checksum={x:0>32} missing", .{
+                log.debug("{}: on_get_prepare: op={} checksum={x:0>32} missing", .{
                     self.log_prefix(),
                     message.header.prepare_op,
                     checksum,
@@ -3125,13 +3125,13 @@ pub fn ReplicaType(
             }
         }
 
-        fn on_request_prepare_read(
+        fn on_get_prepare_read(
             self: *Replica,
             prepare: ?*Message.Prepare,
             options: Journal.Read.Options,
         ) void {
             const message = prepare orelse {
-                log.debug("{}: on_request_prepare_read: " ++
+                log.debug("{}: on_get_prepare_read: " ++
                     "op={} checksum={x:0>32} prepare=null", .{
                     self.log_prefix(),
                     options.op,
@@ -3146,7 +3146,7 @@ pub fn ReplicaType(
             assert(options.op == message.header.op);
             assert(options.checksum == message.header.checksum);
 
-            log.debug("{}: on_request_prepare_read: " ++
+            log.debug("{}: on_get_prepare_read: " ++
                 "op={} checksum={x:0>32} sending to replica={}", .{
                 self.log_prefix(),
                 message.header.op,
@@ -3157,8 +3157,8 @@ pub fn ReplicaType(
             self.send_message_to_replica(destination_replica, message);
         }
 
-        fn on_request_headers(self: *Replica, message: *const Message.RequestHeaders) void {
-            assert(message.header.command == .request_headers);
+        fn on_get_headers(self: *Replica, message: *const Message.GetHeaders) void {
+            assert(message.header.command == .get_headers);
             if (self.ignore_repair_message(message.base_const())) return;
 
             maybe(self.status == .recovering_head);
@@ -3179,7 +3179,7 @@ pub fn ReplicaType(
             assert(op_max >= op_min);
 
             // We must add 1 because op_max and op_min are both inclusive:
-            const count_max: usize = @min(constants.request_headers_max, op_max - op_min + 1);
+            const count_max: usize = @min(constants.get_headers_max, op_max - op_min + 1);
             assert(count_max * @sizeOf(vsr.Header) <= constants.message_body_size_max);
 
             const count = self.journal.copy_latest_headers_between(
@@ -3193,7 +3193,7 @@ pub fn ReplicaType(
             assert(count <= count_max);
 
             if (count == 0) {
-                log.debug("{}: on_request_headers: ignoring (op={}..{}, no headers)", .{
+                log.debug("{}: on_get_headers: ignoring (op={}..{}, no headers)", .{
                     self.log_prefix(),
                     op_min,
                     op_max,
@@ -3211,15 +3211,15 @@ pub fn ReplicaType(
             self.send_message_to_replica(message.header.replica, response);
         }
 
-        fn on_request_reply(self: *Replica, message: *const Message.RequestReply) void {
-            assert(message.header.command == .request_reply);
+        fn on_get_reply(self: *Replica, message: *const Message.GetReply) void {
+            assert(message.header.command == .get_reply);
             assert(message.header.reply_client != 0);
 
             if (self.ignore_repair_message(message.base_const())) return;
             assert(message.header.replica != self.replica);
 
             const entry = self.client_sessions.get(message.header.reply_client) orelse {
-                log.debug("{}: on_request_reply: ignoring, client not in table", .{
+                log.debug("{}: on_get_reply: ignoring, client not in table", .{
                     self.log_prefix(),
                 });
                 return;
@@ -3227,7 +3227,7 @@ pub fn ReplicaType(
             assert(entry.header.client == message.header.reply_client);
 
             if (entry.header.checksum != message.header.reply_checksum) {
-                log.debug("{}: on_request_reply: ignoring, reply not in table " ++
+                log.debug("{}: on_get_reply: ignoring, reply not in table " ++
                     "(requested={x:0>32} stored={x:0>32})", .{
                     self.log_prefix(),
                     message.header.reply_checksum,
@@ -3240,7 +3240,7 @@ pub fn ReplicaType(
 
             const slot = self.client_sessions.get_slot_for_header(&entry.header).?;
             if (self.client_replies.read_reply_sync(slot, entry)) |reply| {
-                on_request_reply_read_callback(
+                on_get_reply_read_callback(
                     &self.client_replies,
                     &entry.header,
                     reply,
@@ -3250,11 +3250,11 @@ pub fn ReplicaType(
                 self.client_replies.read_reply(
                     slot,
                     entry,
-                    on_request_reply_read_callback,
+                    on_get_reply_read_callback,
                     message.header.replica,
                 ) catch |err| switch (err) {
                     error.Busy => {
-                        log.debug("{}: on_request_reply: ignoring, client_replies busy", .{
+                        log.debug("{}: on_get_reply: ignoring, client_replies busy", .{
                             self.log_prefix(),
                         });
                     },
@@ -3262,7 +3262,7 @@ pub fn ReplicaType(
             }
         }
 
-        fn on_request_reply_read_callback(
+        fn on_get_reply_read_callback(
             client_replies: *ClientReplies,
             reply_header: *const Header.Reply,
             reply_: ?*Message.Reply,
@@ -3270,7 +3270,7 @@ pub fn ReplicaType(
         ) void {
             const self: *Replica = @alignCast(@fieldParentPtr("client_replies", client_replies));
             const reply = reply_ orelse {
-                log.debug("{}: on_request_reply: reply not found for replica={} " ++
+                log.debug("{}: on_get_reply: reply not found for replica={} " ++
                     "(op={} checksum={x:0>32})", .{
                     self.log_prefix(),
                     destination_replica.?,
@@ -3287,7 +3287,7 @@ pub fn ReplicaType(
             assert(reply.header.command == .reply);
             assert(reply.header.checksum == reply_header.checksum);
 
-            log.debug("{}: on_request_reply: sending reply to replica={} " ++
+            log.debug("{}: on_get_reply: sending reply to replica={} " ++
                 "(op={} checksum={x:0>32})", .{
                 self.log_prefix(),
                 destination_replica.?,
@@ -3322,25 +3322,25 @@ pub fn ReplicaType(
             self.repair();
         }
 
-        fn on_request_blocks(self: *Replica, message: *const Message.RequestBlocks) void {
-            assert(message.header.command == .request_blocks);
+        fn on_get_blocks(self: *Replica, message: *const Message.GetBlocks) void {
+            assert(message.header.command == .get_blocks);
 
             if (message.header.replica == self.replica) {
-                log.warn("{}: on_request_blocks: ignoring; misdirected message (self)", .{
+                log.warn("{}: on_get_blocks: ignoring; misdirected message (self)", .{
                     self.log_prefix(),
                 });
                 return;
             }
 
             if (self.standby()) {
-                log.warn("{}: on_request_blocks: ignoring; misdirected message (standby)", .{
+                log.warn("{}: on_get_blocks: ignoring; misdirected message (standby)", .{
                     self.log_prefix(),
                 });
                 return;
             }
 
             if (self.grid.callback == .cancel) {
-                log.debug("{}: on_request_blocks: ignoring; canceling grid", .{self.log_prefix()});
+                log.debug("{}: on_get_blocks: ignoring; canceling grid", .{self.log_prefix()});
                 return;
             }
 
@@ -3358,7 +3358,7 @@ pub fn ReplicaType(
                         read.read.checksum == request.block_checksum and
                         read.destination == message.header.replica)
                     {
-                        log.debug("{}: on_request_blocks: ignoring block request;" ++
+                        log.debug("{}: on_get_blocks: ignoring block request;" ++
                             " already reading (destination={} address={} checksum={x:0>32})", .{
                             self.log_prefix(),
                             message.header.replica,
@@ -3370,7 +3370,7 @@ pub fn ReplicaType(
                 }
 
                 const read = self.grid_reads.acquire() orelse {
-                    log.debug("{}: on_request_blocks: ignoring remaining blocks; busy " ++
+                    log.debug("{}: on_get_blocks: ignoring remaining blocks; busy " ++
                         "(replica={} ignored={}/{})", .{
                         self.log_prefix(),
                         message.header.replica,
@@ -3380,7 +3380,7 @@ pub fn ReplicaType(
                     return;
                 };
 
-                log.debug("{}: on_request_blocks: reading block " ++
+                log.debug("{}: on_get_blocks: reading block " ++
                     "(replica={} address={} checksum={x:0>32})", .{
                     self.log_prefix(),
                     message.header.replica,
@@ -3399,7 +3399,7 @@ pub fn ReplicaType(
                 };
 
                 self.grid.read_block(
-                    .{ .from_local_storage = on_request_blocks_read_block },
+                    .{ .from_local_storage = on_get_blocks_read_block },
                     &read.read,
                     request.block_address,
                     request.block_checksum,
@@ -3408,7 +3408,7 @@ pub fn ReplicaType(
             }
         }
 
-        fn on_request_blocks_read_block(
+        fn on_get_blocks_read_block(
             grid_read: *Grid.Read,
             result: Grid.ReadBlockResult,
         ) void {
@@ -3422,7 +3422,7 @@ pub fn ReplicaType(
             assert(read.destination != self.replica);
 
             if (result != .valid) {
-                log.debug("{}: on_request_blocks: error: {s}: " ++
+                log.debug("{}: on_get_blocks: error: {s}: " ++
                     "(destination={} address={} checksum={x:0>32})", .{
                     self.log_prefix(),
                     @tagName(result),
@@ -3433,7 +3433,7 @@ pub fn ReplicaType(
                 return;
             }
 
-            log.debug("{}: on_request_blocks: success: " ++
+            log.debug("{}: on_get_blocks: success: " ++
                 "(destination={} address={} checksum={x:0>32})", .{
                 self.log_prefix(),
                 read.destination,
@@ -3534,7 +3534,7 @@ pub fn ReplicaType(
                 });
 
                 if (self.grid_repair_message_budget.next_destination(&self.prng)) |replica_index| {
-                    self.send_request_blocks(replica_index);
+                    self.send_get_blocks(replica_index);
                 }
             } else {
                 log.debug("{}: on_block: ignoring; block not needed " ++
@@ -3748,19 +3748,19 @@ pub fn ReplicaType(
             }
         }
 
-        fn on_request_view_message_timeout(self: *Replica) void {
+        fn on_get_view_message_timeout(self: *Replica) void {
             assert(self.status == .view_change);
             assert(self.primary_index(self.view) != self.replica);
-            self.request_view_message_timeout.reset();
+            self.get_view_message_timeout.reset();
 
-            log.debug("{}: on_request_view_message_timeout: view={}", .{
+            log.debug("{}: on_get_view_message_timeout: view={}", .{
                 self.log_prefix(),
                 self.view,
             });
             self.send_header_to_replica(
                 self.primary_index(self.view),
-                @bitCast(Header.RequestView{
-                    .command = .request_view,
+                @bitCast(Header.GetView{
+                    .command = .get_view,
                     .cluster = self.cluster,
                     .replica = self.replica,
                     .view = self.view,
@@ -3802,8 +3802,8 @@ pub fn ReplicaType(
                 });
                 self.send_header_to_replica(
                     self.primary_index(self.view),
-                    @bitCast(Header.RequestView{
-                        .command = .request_view,
+                    @bitCast(Header.GetView{
+                        .command = .get_view,
                         .cluster = self.cluster,
                         .replica = self.replica,
                         .view = self.view,
@@ -3822,7 +3822,7 @@ pub fn ReplicaType(
 
             if (self.grid.callback != .cancel) {
                 if (self.grid_repair_message_budget.next_destination(&self.prng)) |replica_index| {
-                    self.send_request_blocks(replica_index);
+                    self.send_get_blocks(replica_index);
                 }
             }
         }
@@ -5950,10 +5950,10 @@ pub fn ReplicaType(
                 header.view == self.view or
                     header.command == .pong_client or
                     header.command == .eviction or
-                    header.command == .request_view or
-                    header.command == .request_headers or
-                    header.command == .request_prepare or
-                    header.command == .request_reply or
+                    header.command == .get_view or
+                    header.command == .get_headers or
+                    header.command == .get_prepare or
+                    header.command == .get_reply or
                     header.command == .reply or
                     header.command == .ping or header.command == .pong,
             );
@@ -6087,10 +6087,10 @@ pub fn ReplicaType(
         }
 
         fn ignore_repair_message(self: *Replica, message: *const Message) bool {
-            assert(message.header.command == .request_view or
-                message.header.command == .request_headers or
-                message.header.command == .request_prepare or
-                message.header.command == .request_reply or
+            assert(message.header.command == .get_view or
+                message.header.command == .get_headers or
+                message.header.command == .get_prepare or
+                message.header.command == .get_reply or
                 message.header.command == .headers);
             switch (message.header.command) {
                 .headers => assert(message.header.replica < self.replica_count),
@@ -6099,9 +6099,9 @@ pub fn ReplicaType(
 
             const command: []const u8 = @tagName(message.header.command);
 
-            if (message.header.command == .request_headers or
-                message.header.command == .request_prepare or
-                message.header.command == .request_reply)
+            if (message.header.command == .get_headers or
+                message.header.command == .get_prepare or
+                message.header.command == .get_reply)
             {
                 // A recovering_head/syncing replica can still assist others with WAL/Reply-repair,
                 // but does not itself install headers, since its head is unknown.
@@ -6116,14 +6116,14 @@ pub fn ReplicaType(
                 }
             }
 
-            if (message.header.command == .request_headers or
-                message.header.command == .request_prepare or
-                message.header.command == .request_reply or
+            if (message.header.command == .get_headers or
+                message.header.command == .get_prepare or
+                message.header.command == .get_reply or
                 message.header.command == .headers)
             {
                 // A replica in a different view can assist WAL repair.
             } else {
-                assert(message.header.command == .request_view);
+                assert(message.header.command == .get_view);
 
                 if (message.header.view < self.view) {
                     log.debug("{}: on_{s}: ignoring (older view)", .{
@@ -6155,7 +6155,7 @@ pub fn ReplicaType(
             if (self.standby()) {
                 switch (message.header.command) {
                     .headers => {},
-                    .request_view, .request_headers, .request_prepare, .request_reply => {
+                    .get_view, .get_headers, .get_prepare, .get_reply => {
                         log.warn("{}: on_{s}: misdirected message (standby)", .{
                             self.log_prefix(),
                             command,
@@ -6169,14 +6169,14 @@ pub fn ReplicaType(
             if (self.primary_index(self.view) != self.replica) {
                 switch (message.header.command) {
                     // Only the primary may receive these messages:
-                    .request_view => {
+                    .get_view => {
                         log.warn("{}: on_{s}: misdirected message (backup)", .{
                             self.log_prefix(),
                             command,
                         });
                         return true;
                     },
-                    .request_prepare, .headers, .request_headers, .request_reply => {},
+                    .get_prepare, .headers, .get_headers, .get_reply => {},
                     else => unreachable,
                 }
             }
@@ -6189,7 +6189,7 @@ pub fn ReplicaType(
             const command: []const u8 = @tagName(message.header.command);
 
             switch (message.header.command) {
-                .request_view => {
+                .get_view => {
                     log.debug("{}: on_{s}: ignoring (view change)", .{
                         self.log_prefix(),
                         command,
@@ -6211,7 +6211,7 @@ pub fn ReplicaType(
                         return true;
                     }
                 },
-                .request_headers, .request_prepare, .request_reply => {
+                .get_headers, .get_prepare, .get_reply => {
                     // on_headers, on_prepare, and on_reply have the appropriate logic to handle
                     // incorrect headers, prepares, and replies.
                     return false;
@@ -6959,7 +6959,7 @@ pub fn ReplicaType(
         ///
         /// Note that for our purposes here, we only care about entries that were faulty during
         /// WAL recovery, not ones that were found to be faulty after the fact (e.g. due to
-        /// `request_prepare`).
+        /// `get_prepare`).
         ///
         /// Cases (`✓`: `replica.op_checkpoint`, `✗`: faulty, `o`: `replica.op`):
         /// * ` ✓ o ✗ `: View change is unsafe.
@@ -7531,7 +7531,7 @@ pub fn ReplicaType(
 
             if (self.grid.callback != .cancel) {
                 if (self.grid_repair_message_budget.next_destination(&self.prng)) |replica_index| {
-                    self.send_request_blocks(replica_index);
+                    self.send_get_blocks(replica_index);
                 }
             }
 
@@ -7575,8 +7575,8 @@ pub fn ReplicaType(
                 );
                 self.send_header_to_replica(
                     self.primary_index(self.view),
-                    @bitCast(Header.RequestView{
-                        .command = .request_view,
+                    @bitCast(Header.GetView{
+                        .command = .get_view,
                         .cluster = self.cluster,
                         .replica = self.replica,
                         .view = self.view,
@@ -7645,8 +7645,8 @@ pub fn ReplicaType(
                     );
                     self.send_header_to_replica(
                         self.choose_any_other_replica(),
-                        @bitCast(Header.RequestHeaders{
-                            .command = .request_headers,
+                        @bitCast(Header.GetHeaders{
+                            .command = .get_headers,
                             .cluster = self.cluster,
                             .replica = self.replica,
                             // Pessimistically request extra headers. Requesting/sending extra
@@ -7693,8 +7693,8 @@ pub fn ReplicaType(
 
                 self.send_header_to_replica(
                     self.choose_any_other_replica(),
-                    @bitCast(Header.RequestReply{
-                        .command = .request_reply,
+                    @bitCast(Header.GetReply{
+                        .command = .get_reply,
                         .cluster = self.cluster,
                         .replica = self.replica,
                         .reply_client = entry.header.client,
@@ -8215,7 +8215,7 @@ pub fn ReplicaType(
             for (op_min..op_max + 1) |op| {
                 const slot_with_op_maybe = self.journal.slot_with_op(op);
                 if (slot_with_op_maybe == null or self.journal.dirty.bit(slot_with_op_maybe.?)) {
-                    // Rebroadcast outstanding `request_prepare` every `repair_timeout` tick.
+                    // Rebroadcast outstanding `get_prepare` every `repair_timeout` tick.
                     // Continue to request prepares until our budget is depleted.
                     if (self.repair_prepare(op)) {
                         io_budget -= 1;
@@ -8253,7 +8253,7 @@ pub fn ReplicaType(
                 {
                     // In-bounds — handled by the repair_prepares_between invocations
                     // before this function is invoked. The slot is either already
-                    // repaired, or we sent a request_prepare and are waiting for a reply.
+                    // repaired, or we sent a get_prepare and are waiting for a reply.
                 } else {
                     // This op must be either:
                     // - less-than-or-equal-to `op_checkpoint` — we committed before
@@ -8325,7 +8325,7 @@ pub fn ReplicaType(
                 // - the journal already had another running write to the same slot, or
                 // - the journal had no IOPs available.
                 //
-                // Using the pipeline to repair is faster than a `request_prepare`.
+                // Using the pipeline to repair is faster than a `get_prepare`.
                 // Also, messages in the pipeline are never corrupt.
                 if (self.pipeline_prepare_by_op_and_checksum(op, checksum)) |prepare| {
                     assert(prepare.header.op == op);
@@ -8364,8 +8364,8 @@ pub fn ReplicaType(
                 &self.prng,
             )) |replica_index| {
                 assert(replica_index != self.replica);
-                const request_prepare = Header.RequestPrepare{
-                    .command = .request_prepare,
+                const get_prepare = Header.GetPrepare{
+                    .command = .get_prepare,
                     .cluster = self.cluster,
                     .replica = self.replica,
                     .view = if (slot_with_op_maybe == null) self.view else 0,
@@ -8403,11 +8403,11 @@ pub fn ReplicaType(
                 if (self.status == .view_change) {
                     // Only the primary is allowed to do repairs in a view change.
                     assert(self.primary_index(self.view) == self.replica);
-                    self.send_header_to_other_replicas(@bitCast(request_prepare));
+                    self.send_header_to_other_replicas(@bitCast(get_prepare));
                 } else {
                     self.send_header_to_replica(
                         replica_index,
-                        @bitCast(request_prepare),
+                        @bitCast(get_prepare),
                     );
                 }
 
@@ -8815,7 +8815,7 @@ pub fn ReplicaType(
                     }
 
                     // Presence bit: the prepare is on disk, is being written to disk, or is cached
-                    // in memory. These conditions mirror logic in `on_request_prepare` and imply
+                    // in memory. These conditions mirror logic in `on_get_prepare` and imply
                     // that we can help the new primary to repair this prepare.
                     if ((self.journal.prepare_inhabited[slot.index] and
                         self.journal.prepare_checksums[slot.index] == header.checksum) or
@@ -9041,11 +9041,11 @@ pub fn ReplicaType(
                 .pong,
                 .ping_client,
                 .commit,
-                .request_view,
-                .request_headers,
-                .request_prepare,
-                .request_reply,
-                .request_blocks,
+                .get_view,
+                .get_headers,
+                .get_prepare,
+                .get_reply,
+                .get_blocks,
                 .block,
                 => unreachable,
             }
@@ -9256,7 +9256,7 @@ pub fn ReplicaType(
                     assert(header.replica != replica);
                     assert(header.release.value == vsr.Release.zero.value);
                 },
-                .request_view => |header| {
+                .get_view => |header| {
                     maybe(self.standby());
                     assert(header.view >= self.view);
                     assert(header.replica == self.replica);
@@ -9264,24 +9264,24 @@ pub fn ReplicaType(
                     assert(self.primary_index(message.header.view) == replica);
                     assert(header.release.value == vsr.Release.zero.value);
                 },
-                .request_headers => |header| {
+                .get_headers => |header| {
                     maybe(self.standby());
                     assert(header.replica == self.replica);
                     assert(header.replica != replica);
                     assert(header.release.value == vsr.Release.zero.value);
                 },
-                .request_prepare => |header| {
+                .get_prepare => |header| {
                     maybe(self.standby());
                     assert(header.replica == self.replica);
                     assert(header.replica != replica);
                     assert(header.release.value == vsr.Release.zero.value);
                 },
-                .request_reply => |header| {
+                .get_reply => |header| {
                     assert(header.replica == self.replica);
                     assert(header.replica != replica);
                     assert(header.release.value == vsr.Release.zero.value);
                 },
-                .request_blocks => |header| {
+                .get_blocks => |header| {
                     maybe(self.standby());
                     assert(header.replica == self.replica);
                     assert(header.replica != replica);
@@ -9298,7 +9298,7 @@ pub fn ReplicaType(
             // See view_durable()/log_view_durable().
             if (replica != self.replica and message.header.replica == self.replica) {
                 if (message.header.view > self.view_durable() and
-                    message.header.command != .request_view)
+                    message.header.command != .get_view)
                 {
                     // Pings are used for syncing time, so they must not be
                     // blocked on persisting view.
@@ -9497,7 +9497,7 @@ pub fn ReplicaType(
             assert(self.replica == self.primary_index(self.view));
             assert(self.primary_journal_headers_repaired());
 
-            // Only replies to `request_view` need a nonce,
+            // Only replies to `get_view` need a nonce,
             // to guarantee freshness of the message.
             const nonce = 0;
 
@@ -9891,7 +9891,7 @@ pub fn ReplicaType(
             assert(!self.commit_message_timeout.ticking);
             assert(!self.view_change_status_timeout.ticking);
             assert(!self.join_view_message_timeout.ticking);
-            assert(!self.request_view_message_timeout.ticking);
+            assert(!self.get_view_message_timeout.ticking);
             assert(!self.repair_sync_timeout.ticking);
             assert(!self.journal_repair_timeout.ticking);
             assert(!self.pulse_timeout.ticking);
@@ -9932,7 +9932,7 @@ pub fn ReplicaType(
             assert(!self.commit_message_timeout.ticking);
             assert(!self.view_change_status_timeout.ticking);
             assert(!self.join_view_message_timeout.ticking);
-            assert(!self.request_view_message_timeout.ticking);
+            assert(!self.get_view_message_timeout.ticking);
             assert(!self.repair_sync_timeout.ticking);
             assert(!self.journal_repair_timeout.ticking);
             assert(!self.pulse_timeout.ticking);
@@ -10020,7 +10020,7 @@ pub fn ReplicaType(
             assert(!self.commit_message_timeout.ticking);
             assert(!self.view_change_status_timeout.ticking);
             assert(!self.join_view_message_timeout.ticking);
-            assert(!self.request_view_message_timeout.ticking);
+            assert(!self.get_view_message_timeout.ticking);
             assert(!self.repair_sync_timeout.ticking);
             assert(!self.pulse_timeout.ticking);
             assert(!self.upgrade_timeout.ticking);
@@ -10073,7 +10073,7 @@ pub fn ReplicaType(
                 self.exit_view_message_timeout.start();
                 self.view_change_status_timeout.stop();
                 self.join_view_message_timeout.stop();
-                self.request_view_message_timeout.stop();
+                self.get_view_message_timeout.stop();
                 if (!self.aof_recovery) self.pulse_timeout.start();
                 self.upgrade_timeout.start();
 
@@ -10093,7 +10093,7 @@ pub fn ReplicaType(
                 assert(!self.primary_abdicate_timeout.ticking);
                 assert(!self.repair_sync_timeout.ticking);
                 assert(!self.upgrade_timeout.ticking);
-                assert(self.request_view_message_timeout.ticking);
+                assert(self.get_view_message_timeout.ticking);
                 assert(self.pipeline == .cache);
 
                 if (self.log_view == view_new and self.view == view_new) {
@@ -10111,7 +10111,7 @@ pub fn ReplicaType(
                 self.exit_view_message_timeout.start();
                 self.view_change_status_timeout.stop();
                 self.join_view_message_timeout.stop();
-                self.request_view_message_timeout.stop();
+                self.get_view_message_timeout.stop();
                 self.repair_sync_timeout.start();
             }
 
@@ -10211,9 +10211,9 @@ pub fn ReplicaType(
             self.journal_repair_timeout.stop();
 
             if (self.primary_index(self.view) == self.replica) {
-                self.request_view_message_timeout.stop();
+                self.get_view_message_timeout.stop();
             } else {
-                self.request_view_message_timeout.start();
+                self.get_view_message_timeout.start();
             }
 
             // Do not reset quorum counters only on entering a view, assuming that the view will be
@@ -10559,9 +10559,9 @@ pub fn ReplicaType(
             // checkpoint header and the Journal.
             assert(self.op >= self.op_checkpoint());
 
-            // We just replaced our superblock, so many outstanding request_prepares/request_blocks
-            // are probably not useful, and we are likely to need to repair soon (and quickly) in
-            // order to start committing again.
+            // We just replaced our superblock, so many outstanding get_prepares/get_blocks are
+            // probably not useful, and we are likely to need to repair soon (and quickly) in order
+            // to start committing again.
             self.journal_repair_message_budget.refill();
             if (self.journal_repair_timeout.ticking) {
                 self.journal_repair_timeout.reset_with_jitter(&self.prng);
@@ -11108,14 +11108,14 @@ pub fn ReplicaType(
                     }
 
                     // TODO Debounce and decouple this from `on_message()` by moving into `tick()`:
-                    // (Using request_view_message_timeout).
+                    // (Using get_view_message_timeout).
                     log.debug("{}: jump_view: requesting View message", .{
                         self.log_prefix(),
                     });
                     self.send_header_to_replica(
                         self.primary_index(header.view),
-                        @bitCast(Header.RequestView{
-                            .command = .request_view,
+                        @bitCast(Header.GetView{
+                            .command = .get_view,
                             .cluster = self.cluster,
                             .replica = self.replica,
                             .view = header.view,
@@ -11206,7 +11206,7 @@ pub fn ReplicaType(
             self.flush_loopback_queue();
         }
 
-        fn send_request_blocks(self: *Replica, destination_replica_index: u8) void {
+        fn send_get_blocks(self: *Replica, destination_replica_index: u8) void {
             assert(self.grid_repair_timeout.ticking);
             assert(self.grid.callback != .cancel);
             maybe(self.state_machine_opened);
@@ -11221,7 +11221,7 @@ pub fn ReplicaType(
             if (self.grid.blocks_missing.faulty_blocks.count() == 0 and
                 self.grid.read_global_queue.count() == 0) return;
 
-            var message = self.message_bus.get_message(.request_blocks);
+            var message = self.message_bus.get_message(.get_blocks);
             defer self.message_bus.unref(message);
 
             const requests_buffer = std.mem.bytesAsSlice(
@@ -11300,7 +11300,7 @@ pub fn ReplicaType(
             for (requests_buffer[0..requests_count]) |*request| {
                 assert(!self.grid.free_set.is_free(request.block_address));
 
-                log.debug("{}: send_request_blocks: request address={} checksum={x:0>32}", .{
+                log.debug("{}: send_get_blocks: request address={} checksum={x:0>32}", .{
                     self.log_prefix(),
                     request.block_address,
                     request.block_checksum,
@@ -11308,7 +11308,7 @@ pub fn ReplicaType(
             }
 
             message.header.* = .{
-                .command = .request_blocks,
+                .command = .get_blocks,
                 .cluster = self.cluster,
                 .replica = self.replica,
                 .size = @sizeOf(Header) + requests_count * @sizeOf(vsr.BlockRequest),

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1054,7 +1054,7 @@ test "Cluster: view-change: primary with dirty log" {
 
     // B2 tries to become primary. (Don't let B1 become primary – it would not realize its
     // checkpoint entry is corrupt, which would defeat the purpose of this test).
-    // B2 tries to repair (request_prepare) this corrupt op, even though it is before its
+    // B2 tries to repair (get_prepare) this corrupt op, even though it is before its
     // checkpoint. B1 discovers that this op is corrupt, and marks it as faulty.
     b1.corrupt(.{ .wal_prepare = checkpoint_2 % slot_count });
     t.run();
@@ -1325,8 +1325,8 @@ test "Cluster: sync: using View from durable checkpoint" {
     try c.request(checkpoint_1_prepare_max - 1, checkpoint_1_prepare_max - 1);
 
     // Ensure b2 can't repair its WAL, commit & transition to checkpoint_1.
-    a0.drop(.R_, .incoming, .request_prepare);
-    b1.drop(.R_, .incoming, .request_prepare);
+    a0.drop(.R_, .incoming, .get_prepare);
+    b1.drop(.R_, .incoming, .get_prepare);
 
     try b2.open();
 
@@ -2021,7 +2021,7 @@ test "Cluster: broken hash chain within the same view does not stall commit via 
             return header.op == constants.pipeline_prepare_queue_max + 1;
         }
     }.drop_message);
-    b2.drop(.R_, .outgoing, .request_headers);
+    b2.drop(.R_, .outgoing, .get_headers);
     b2.drop(.R_, .incoming, .view);
 
     var c = t.clients(.{});


### PR DESCRIPTION
Remove the `request_` prefix from repair commands to avoid confusion between the `reply` command, a reply to a request, and the `request_reply` command, which requests a reply for repair.