### PR TITLE
CFO: Fix lagging canary

### DIFF
--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -1189,6 +1189,7 @@ const SeedRecord = struct {
     }
 
     fn order_by_seed_timestamp_start(a: SeedRecord, b: SeedRecord) ?std.math.Order {
+        assert(std.mem.eql(u8, a.fuzzer, b.fuzzer));
         // For canaries, prefer newer seeds to show that the canary is alive.
         // For other fuzzers, prefer older seeds to keep them stable.
         return if (std.mem.eql(u8, a.fuzzer, "canary"))
@@ -1199,6 +1200,7 @@ const SeedRecord = struct {
 
     fn order_by_seed_duration(a: SeedRecord, b: SeedRecord) ?std.math.Order {
         assert(a.ok == b.ok);
+        assert(std.mem.eql(u8, a.fuzzer, b.fuzzer));
 
         // Duration is irrelevant for canaries, and it can obscure timestamp_start.
         if (std.mem.eql(u8, a.fuzzer, "canary")) return null;

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -1199,6 +1199,10 @@ const SeedRecord = struct {
 
     fn order_by_seed_duration(a: SeedRecord, b: SeedRecord) ?std.math.Order {
         assert(a.ok == b.ok);
+
+        // Duration is irrelevant for canaries, and it can obscure timestamp_start.
+        if (std.mem.eql(u8, a.fuzzer, "canary")) return null;
+
         if (a.ok) {
             // Passing seeds: prefer long durations -- near-timeouts might be interesting, and it
             // gives us a p100 for the fuzzer's runtime.


### PR DESCRIPTION
CFO prioritizes which seeds to keep or discard based on:

1. ...
2. duration: Shorter seed wins. The idea here is that if we have two failures, the shorter one will be easier to debug.
3. age: Newer seed wins.
4. ...

However, this breaks down for the canary. For canary we care about age, and duration is irrelevant.

Due to how CFO measures fuzz duration, it tends to overestimate, since cfo is synchronous and doesn't necessarily check whether the fuzzer is finished immediately if it is busy. So we are currently discarding some useful canary seeds. And this causes the canary in devhub to be bumped less frequently than it should be.