### PR TITLE
Fixes `u128` wrap-around conversion for the Java and Go clients.

### DIFF
--- a/src/clients/go/uint128.go
+++ b/src/clients/go/uint128.go
@@ -94,18 +94,13 @@ func BigIntToUint128(value *big.Int) Uint128 {
 		panic("cannot convert negative big.Int to Uint128")
 	}
 
+	// FillBytes can panic if the value does not fit in 16 bytes.
+	bytes := value.FillBytes(make([]byte, 16))
+
 	// big.Int bytes are big-endian so convert them to little-endian for Uint128 bytes.
-	bytes := value.Bytes()
 	swapEndian(bytes[:])
 
-	// Only cast slice to bytes when there's enough.
-	if len(bytes) >= 16 {
-		return BytesToUint128(*(*[16]byte)(bytes))
-	}
-
-	var zeroPadded [16]byte
-	copy(zeroPadded[:], bytes)
-	return BytesToUint128(zeroPadded)
+	return BytesToUint128(*(*[16]byte)(bytes))
 }
 
 // ToUint128 converts a integer to a Uint128.

--- a/src/clients/go/uint128_test.go
+++ b/src/clients/go/uint128_test.go
@@ -101,6 +101,22 @@ func Test_BigIntToUint128_Negative(t *testing.T) {
 	t.Errorf("Expected panic, but execution continued")
 }
 
+func Test_BigIntToUint128_ExceedU128(t *testing.T) {
+	tooBig := new(big.Int).Lsh(big.NewInt(1), 128)
+	testFunc := func() {
+		BigIntToUint128(tooBig)
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic")
+		}
+	}()
+
+	testFunc()
+	t.Errorf("Expected panic, but execution continued")
+}
+
 func Test_ID(t *testing.T) {
 	verifier := func() {
 		idA := ID()

--- a/src/clients/java/java_bindings.zig
+++ b/src/clients/java/java_bindings.zig
@@ -107,7 +107,7 @@ const type_mappings = .{
             .readonly_fields = &.{},
             .docs_link = "reference/transfer#",
             .constants =
-            \\    public static final BigInteger AMOUNT_MAX = UInt128.asBigInteger(-1L, -1L);
+            \\    public static final BigInteger AMOUNT_MAX = UInt128.INT_MAX;
             \\
             ,
         },

--- a/src/clients/java/src/main/java/com/tigerbeetle/TransferBatch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/TransferBatch.java
@@ -10,7 +10,7 @@ import java.math.BigInteger;
 
 public final class TransferBatch extends Batch {
 
-    public static final BigInteger AMOUNT_MAX = UInt128.asBigInteger(-1L, -1L);
+    public static final BigInteger AMOUNT_MAX = UInt128.INT_MAX;
 
     interface Struct {
         int SIZE = 128;

--- a/src/clients/java/src/main/java/com/tigerbeetle/UInt128.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/UInt128.java
@@ -17,6 +17,9 @@ public enum UInt128 {
     private static final BigInteger MOST_SIGNIFICANT_MASK = BigInteger.ONE.shiftLeft(64);
     private static final BigInteger LEAST_SIGNIFICANT_MASK = BigInteger.valueOf(Long.MAX_VALUE);
 
+    // Maximum unsigned 128-bit integer: 2^128 - 1.
+    static final BigInteger INT_MAX = BigInteger.ONE.shiftLeft(128).add(BigInteger.ONE.negate());
+
     /**
      * Gets the partial 64-bit representation of a 128-bit unsigned integer.
      *
@@ -157,12 +160,15 @@ public enum UInt128 {
         if (value.signum() < 0)
             throw new IllegalArgumentException("Value cannot be negative");
 
+        if (value.compareTo(INT_MAX) > 0)
+            throw new IllegalArgumentException("Value larger than a 128-bit integer");
+
         if (BigInteger.ZERO.equals(value))
             return new byte[SIZE];
 
         final var parts = value.divideAndRemainder(MOST_SIGNIFICANT_MASK);
-        var bigintMsb = parts[0];
-        var bigintLsb = parts[1];
+        BigInteger bigintMsb = parts[0];
+        BigInteger bigintLsb = parts[1];
 
         if (LEAST_SIGNIFICANT_MASK.compareTo(bigintMsb) < 0) {
             bigintMsb = bigintMsb.subtract(MOST_SIGNIFICANT_MASK);

--- a/src/clients/java/src/test/java/com/tigerbeetle/UInt128Test.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/UInt128Test.java
@@ -30,6 +30,7 @@ public class UInt128Test {
                 (byte) 0xe2, (byte) 0xe1, (byte) 0xd2, (byte) 0xd1, (byte) 0xc2, (byte) 0xc1,
                 (byte) 0xb2, (byte) 0xb1, (byte) 0xa4, (byte) 0xa3, (byte) 0xa2, (byte) 0xa1};
         final var bytes = UInt128.asBytes(lower, upper);
+        assertArrayEquals(bytes, UInt128.asBytes(u128));
         assertArrayEquals(binary, bytes);
 
         // UUID representation:
@@ -84,6 +85,63 @@ public class UInt128Test {
     }
 
     @Test
+    public void testAsBytesBigInteger() {
+        {
+            final var expected = UInt128.asBytes(0);
+            final var actual = UInt128.asBytes(BigInteger.ZERO);
+            assertArrayEquals(expected, actual);
+        }
+
+        {
+            final var expected = UInt128.asBytes(1);
+            final var actual = UInt128.asBytes(BigInteger.ONE);
+            assertArrayEquals(expected, actual);
+        }
+
+        {
+            final var expected = UInt128.asBytes(2);
+            final var actual = UInt128.asBytes(BigInteger.TWO);
+            assertArrayEquals(expected, actual);
+        }
+
+        {
+            final var expected = UInt128.asBytes(10);
+            final var actual = UInt128.asBytes(BigInteger.TEN);
+            assertArrayEquals(expected, actual);
+        }
+
+        {
+            final var expected = UInt128.asBytes(-1L, -1L);
+            final var actual = UInt128.asBytes(UInt128.INT_MAX);
+            assertArrayEquals(expected, actual);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAsBytesBigIntegerNegative() {
+        BigInteger bigint = BigInteger.valueOf(-1);
+        @SuppressWarnings("unused")
+        var nop = UInt128.asBytes(bigint);
+        fail();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAsBytesBigIntegerExceedU128() {
+        final var bigint = new BigInteger("9999999999999999999999999999999999999999", 10);
+        @SuppressWarnings("unused")
+        var nop = UInt128.asBytes(bigint);
+        fail();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testAsBytesBigIntegerNull() {
+        BigInteger bigint = null;
+        @SuppressWarnings("unused")
+        var nop = UInt128.asBytes(bigint);
+        fail();
+    }
+
+    @Test
     public void testAsBytesZero() {
 
         byte[] reverse = UInt128.asBytes(0, 0);
@@ -126,23 +184,6 @@ public class UInt128Test {
         byte[] bytes = new byte[] {1, 2, 3, 4, 5, 6};
         @SuppressWarnings("unused")
         var nop = UInt128.asUUID(bytes);
-        fail();
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testAsBytesBigIntegerNull() {
-
-        BigInteger bigint = null;
-        @SuppressWarnings("unused")
-        var nop = UInt128.asBytes(bigint);
-        fail();
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testAsBytesBigIntegerNegative() {
-        BigInteger bigint = BigInteger.valueOf(-1);
-        @SuppressWarnings("unused")
-        var nop = UInt128.asBytes(bigint);
         fail();
     }
 

--- a/src/clients/node/src/test.ts
+++ b/src/clients/node/src/test.ts
@@ -77,6 +77,55 @@ test.skip = (name: string, fn: () => Promise<void>) => {
   console.log(name + ': SKIPPED')
 }
 
+test('Serialization: BigInt exceeds U128', async (): Promise<void> => {
+  const transfer: Transfer = {
+      id: 9999999999999999999999999999999999999999n,
+      debit_account_id: 0n,
+      credit_account_id: 0n,
+      amount: 0n,
+      user_data_128: 0n,
+      user_data_64: 0n,
+      user_data_32: 0,
+      pending_id: 0n,
+      timeout: 0,
+      ledger: 0,
+      code: 0,
+      flags: 0,
+      timestamp: 0n,
+  };
+
+  assert.rejects(async() => await client.createTransfers([transfer]), (err) => {
+    assert.ok(err instanceof Error)
+    assert.strictEqual(err.message, "id must fit in 128 bits")
+    return true
+  })
+})
+
+test('Serialization: BigInt negative', async (): Promise<void> => {
+  const transfer: Transfer = {
+      id: -1n,
+      debit_account_id: 0n,
+      credit_account_id: 0n,
+      amount: 0n,
+      user_data_128: 0n,
+      user_data_64: 0n,
+      user_data_32: 0,
+      pending_id: 0n,
+      timeout: 0,
+      ledger: 0,
+      code: 0,
+      flags: 0,
+      timestamp: 0n,
+  };
+
+  assert.rejects(async() => await client.createTransfers([transfer]), (err) => {
+    assert.ok(err instanceof Error)
+    assert.strictEqual(err.message, "id must be positive")
+    return true
+  })
+})
+
+
 test('id() monotonically increasing', async (): Promise<void> => {
   let idA = id();
   for (let i = 0; i < 10_000_000; i++) {

--- a/src/clients/python/tests/test_basic.py
+++ b/src/clients/python/tests/test_basic.py
@@ -51,6 +51,22 @@ account_b = tb.Account(
     timestamp=0
 )
 
+def test_range_check_u128_cannot_exceed(client):
+    account = tb.Account(**{ **asdict(account_a), "id": 9999999999999999999999999999999999999999 })
+
+    try:
+        error = client.create_accounts([account])
+    except tb.IntegerOverflowError:
+        pass
+
+def test_range_check_u128_cannot_be_negative(client):
+    account = tb.Account(**{ **asdict(account_a), "id": -1 })
+
+    try:
+        error = client.create_accounts([account])
+    except tb.IntegerOverflowError:
+        pass
+
 def test_range_check_code_on_account_to_be_u16(client):
     account = tb.Account(**{ **asdict(account_a), "id": 0, "code": 65535 + 1 })
 


### PR DESCRIPTION
Fixes `u128` wrap-around conversion for the Java and Go clients.

Closes #3759