### PR TITLE
Release: Validate release from correct cwd

### DIFF
--- a/src/clients/dotnet/ci.zig
+++ b/src/clients/dotnet/ci.zig
@@ -121,6 +121,14 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     errdefer tmp_beetle.log_stderr();
 
     try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const base_dir = shell.cwd;
+    try shell.pushd_dir(tmp_dir.dir);
+    defer shell.popd();
+
     try shell.exec("dotnet new console", .{});
 
     // NuGet may take a few minutes to make the new package available for download.
@@ -141,7 +149,7 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     }
 
     try Shell.copy_path(
-        shell.project_root,
+        base_dir,
         "src/clients/dotnet/samples/basic/Program.cs",
         shell.cwd,
         "Program.cs",

--- a/src/clients/go/ci.zig
+++ b/src/clients/go/ci.zig
@@ -77,7 +77,7 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     });
 
     try Shell.copy_path(
-        shell.project_root,
+        shell.cwd,
         "src/clients/go/samples/basic/main.go",
         shell.cwd,
         "main.go",

--- a/src/clients/java/ci.zig
+++ b/src/clients/java/ci.zig
@@ -101,7 +101,7 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     , .{options.version}) });
 
     try Shell.copy_path(
-        shell.project_root,
+        shell.cwd,
         "src/clients/java/samples/basic/src/main/java/Main.java",
         shell.cwd,
         "src/main/java/Main.java",

--- a/src/clients/node/ci.zig
+++ b/src/clients/node/ci.zig
@@ -91,7 +91,7 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     });
 
     try Shell.copy_path(
-        shell.project_root,
+        shell.cwd,
         "src/clients/node/samples/basic/main.js",
         shell.cwd,
         "main.js",

--- a/src/clients/ruby/ci.zig
+++ b/src/clients/ruby/ci.zig
@@ -93,7 +93,7 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
 
     try Shell.copy_path(
-        shell.project_root,
+        shell.cwd,
         "src/clients/ruby/samples/basic/main.rb",
         shell.cwd,
         "main.rb",

--- a/src/clients/rust/ci.zig
+++ b/src/clients/rust/ci.zig
@@ -37,6 +37,7 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     const tmp_dir = try shell.create_tmp_dir();
     defer shell.cwd.deleteTree(tmp_dir) catch {};
 
+    const base_dir = shell.cwd;
     try shell.pushd(tmp_dir);
     defer shell.popd();
 
@@ -74,7 +75,7 @@ pub fn validate_release(shell: *Shell, gpa: std.mem.Allocator, options: struct {
     try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
 
     try Shell.copy_path(
-        shell.project_root,
+        base_dir,
         "src/clients/rust/samples/basic/src/main.rs",
         shell.cwd,
         "src/main.rs",

--- a/src/scripts/ci.zig
+++ b/src/scripts/ci.zig
@@ -143,6 +143,9 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
         "./zig/zig build scripts -- release --build --sha={git_sha} --language=zig",
         .{ .git_sha = git_sha },
     );
+    // Delete this as we will soon unzip a tigerbeetle binary to the same location.
+    try shell.cwd.deleteFile("tigerbeetle");
+
     for (artifacts) |artifact| {
         // Zig only guarantees release builds to be deterministic.
         if (std.mem.indexOf(u8, artifact, "-debug.zip") != null) continue;
@@ -179,7 +182,6 @@ fn validate_release(shell: *Shell, gpa: std.mem.Allocator, language_requested: ?
         },
         else => std.debug.panic("unsupported os {}", .{builtin.os.tag}),
     };
-    try shell.cwd.deleteFile("tigerbeetle");
     try shell.unzip_executable(artifact_host, "tigerbeetle");
 
     const version = try shell.exec_stdout("./tigerbeetle version --verbose", .{});


### PR DESCRIPTION
Now that release validation is run against a different checkout, we must be more careful about distinguishing `cwd` and `project_root`.