### PR TITLE
vsr: various changes related to ping_client

### DIFF
--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -268,6 +268,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
             .release = Release.minimum,
             .client = 1,
             .ping_timestamp_monotonic = 0,
+            .session = 0,
         };
         ping.set_checksum_body(&[0]u8{});
         ping.set_checksum();

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -644,6 +644,7 @@ pub fn ClientType(
                 .release = self.release,
                 .client = self.id,
                 .ping_timestamp_monotonic = self.time.monotonic().ns,
+                .session = self.session,
             };
 
             self.send_header_to_replicas(ping.frame_const());

--- a/src/vsr/client.zig
+++ b/src/vsr/client.zig
@@ -315,6 +315,10 @@ pub fn ClientType(
                 .callback = .{ .register = callback },
             };
             self.send_request_for_the_first_time(message);
+
+            // Proactively send ping to replicas so they can identify this peer
+            // (see `recv_update_peer` in MessageBus).
+            self.on_ping_timeout();
         }
 
         /// Sends a request message with the operation and events payload to the replica.

--- a/src/vsr/message_header.zig
+++ b/src/vsr/message_header.zig
@@ -491,7 +491,9 @@ pub const Header = extern struct {
 
         client: u128,
         ping_timestamp_monotonic: u64,
-        reserved: [104]u8 = @splat(0),
+        // NB: Introduced in 0.17.6, and was implicitly 0 before that.
+        session: u64,
+        reserved: [96]u8 = @splat(0),
 
         pub const frame = HeaderFunctionsType(@This()).frame;
         pub const frame_const = HeaderFunctionsType(@This()).frame_const;

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6007,6 +6007,22 @@ pub fn ReplicaType(
                 return true;
             }
 
+            // NB: Introduced in 0.17.6, `session` was implicitly 0 before that.
+            if (self.client_sessions.get(message.header.client) == null and
+                message.header.session != 0)
+            {
+                if (self.status == .normal and self.primary() and
+                    self.commit_min >= message.header.session)
+                {
+                    log.mark.warn("{}: on_ping_client: no session (client={})", .{
+                        self.log_prefix(),
+                        message.header.client,
+                    });
+                    self.send_eviction_message_to_client(message.header.client, .no_session);
+                    return true;
+                }
+            }
+
             if (message.header.release.value < self.release_client_min.value) {
                 log.warn("{}: on_ping_client: ignoring unsupported client version; too low" ++
                     " (client={} version={}<{})", .{
@@ -6015,7 +6031,7 @@ pub fn ReplicaType(
                     message.header.release,
                     self.release_client_min,
                 });
-                if (self.primary()) {
+                if (self.status == .normal and self.primary()) {
                     self.send_eviction_message_to_client(
                         message.header.client,
                         .client_release_too_low,
@@ -6033,7 +6049,7 @@ pub fn ReplicaType(
                     message.header.release,
                     self.release,
                 });
-                if (self.primary()) {
+                if (self.status == .normal and self.primary()) {
                     self.send_eviction_message_to_client(
                         message.header.client,
                         .client_release_too_high,
@@ -6598,7 +6614,10 @@ pub fn ReplicaType(
                     // primary) if we are partitioned and don't yet know about a session. We solve
                     // this by having clients include the view number and rejecting messages from
                     // clients with newer views.
-                    log.warn("{}: on_request: no session", .{self.log_prefix()});
+                    log.mark.warn("{}: on_request: no session (client={})", .{
+                        self.log_prefix(),
+                        message.header.client,
+                    });
                     self.send_eviction_message_to_client(message.header.client, .no_session);
                     return true;
                 }

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1678,7 +1678,7 @@ test "Cluster: client: empty command=request operation=register body" {
     try run_test(releases[0].release_client_min, .invalid_request_body_size);
 }
 
-test "Cluster: eviction: no_session" {
+test "Cluster: eviction: no_session via request" {
     const t = try TestContext.init(.{
         .replica_count = 3,
         .client_count = constants.clients_max + 1,
@@ -1688,6 +1688,10 @@ test "Cluster: eviction: no_session" {
     var c0 = t.clients(.{ .index = 0, .count = 1 });
     var c = t.clients(.{ .index = 1, .count = constants.clients_max });
 
+    const mark = marks.check("on_request: no session");
+
+    // Drop ping_client to prevent eviction message being sent via that path.
+    t.replica(.R_).drop(.__, .incoming, .ping_client);
     // Register a single client.
     try c0.request(1, 1);
     // Register clients_max other clients.
@@ -1696,6 +1700,30 @@ test "Cluster: eviction: no_session" {
 
     // Try to send one last request -- which fails, since this client has been evicted.
     try c0.request(2, 1);
+
+    try mark.expect_hit();
+    try expectEqual(c0.eviction_reason(), .no_session);
+    try expectEqual(c.eviction_reason(), null);
+}
+
+test "Cluster: eviction: no_session via ping" {
+    const t = try TestContext.init(.{
+        .replica_count = 3,
+        .client_count = constants.clients_max + 1,
+    });
+    defer t.deinit();
+
+    var c0 = t.clients(.{ .index = 0, .count = 1 });
+    var c = t.clients(.{ .index = 1, .count = constants.clients_max });
+
+    const mark = marks.check("on_ping_client: no session");
+    // Register a single client.
+    try c0.request(1, 1);
+    // Register clients_max other clients.
+    // This evicts the "extra" client, though the eviction message has not been sent yet.
+    try c.request(constants.clients_max, constants.clients_max);
+
+    try mark.expect_hit();
     try expectEqual(c0.eviction_reason(), .no_session);
     try expectEqual(c.eviction_reason(), null);
 }
@@ -1736,6 +1764,9 @@ test "Cluster: eviction: session_too_low" {
 
     t.replica(.R_).record(.C0, .incoming, .request);
     try c0.request(1, 1);
+
+    // Drop ping_client to prevent eviction message being sent via that path.
+    t.replica(.R_).drop(.__, .incoming, .ping_client);
 
     // Evict C0. (C0 doesn't know this yet, though).
     try c.request(constants.clients_max, constants.clients_max);


### PR DESCRIPTION
This PR takes up the following two changes:
1. Replica sending an eviction messages when a ping_client
    message is received from an evicted client. We already do this
    for clients with incompatible release (client_release_too_low/
    client_release_too_high), but not for this particular case
    which seems more plausible in practice, where an idle client
    that has been evicted just lingers around holding a connection 
    slot at the replicas, without sending any requests to the cluster.
2. Client broadcasting a ping_client message when it is registering
    to the cluster. Currently,  we only send the `ping_client` message
    every _30 seconds_,  which means the client connection is identified
   as `client_likely` at replicas up till then. This would cause issues
   if the cluster & the client are started together, since in that case
   we may consider a replica connection as a client (if it forwards a
   request from the client → primary)!