### PR TITLE
vsr: reject empty register via client version

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -6334,30 +6334,6 @@ pub fn ReplicaType(
                 }
             }
 
-            // For compatibility with clients <= 0.15.3, `Request.invalid_header()`
-            // considers a `.register` without body as valid, evicting the client with
-            // `client_release_too_low` instead of silently dropping the invalid request.
-            //
-            // This code is a safeguard against **malformed** requests that have the
-            // expected release number but lack a `RegisterRequest`.
-            // TODO: Remove this code once `invalid_header()` starts rejecting the request.
-            if (message.header.operation == .register and
-                message.header.size != @sizeOf(Header) + @sizeOf(vsr.RegisterRequest))
-            {
-                log.warn("{}: on_request: ignoring register without body" ++
-                    " (client={} version={}<{})", .{
-                    self.log_prefix(),
-                    message.header.client,
-                    message.header.release,
-                    self.release_client_min,
-                });
-                self.send_eviction_message_to_client(
-                    message.header.client,
-                    .invalid_request_body_size,
-                );
-                return true;
-            }
-
             if (self.view_durable_updating()) {
                 log.debug("{}: on_request: ignoring (still persisting view)", .{
                     self.log_prefix(),

--- a/src/vsr/replica_test.zig
+++ b/src/vsr/replica_test.zig
@@ -1632,7 +1632,6 @@ test "Cluster: scrub: background scrubber, fully corrupt grid" {
     try TestReplicas.expect_equal_grid(b1, b2);
 }
 
-// Compat(v0.15.3)
 test "Cluster: client: empty command=request operation=register body" {
     const run_test = struct {
         fn run_test(
@@ -1675,7 +1674,6 @@ test "Cluster: client: empty command=request operation=register body" {
     }.run_test;
 
     try run_test(vsr.Release.minimum, .client_release_too_low);
-    try run_test(releases[0].release_client_min, .invalid_request_body_size);
 }
 
 test "Cluster: eviction: no_session" {


### PR DESCRIPTION
The minimum client version we support right now is 0.16.4. In 0.15.4 we added a body to the request command, which made it necessary to allow a request without a body to pass through the `fn invalid_header` check but be ignored in `fn ignore_request_message`. Remove this code path.