### PR TITLE
ci: update release workflow comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # Remove once this is the default (June 2nd, 2026).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # Remove once this is the default (June 16th, 2026).
 
 jobs:
   release:


### PR DESCRIPTION
I noticed the comment about removing `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` while working on the Ruby client release. I originally wanted to remove it, but while double-checking the date, I noticed that it was pushed by two weeks:

>  Editor’s note (May 19, 2026): Updated the migration date to June 16th, 2026.

Source: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Let's fix the comment for now so others don't spend time on it, and revisit it in two weeks.