### PR TITLE
Client fixes

### DIFF
--- a/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
+++ b/src/clients/dotnet/TigerBeetle.Tests/IntegrationTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -125,6 +126,24 @@ public class IntegrationTests
         // No using here, we want to test the finalizer
         var client = new Client(1, new string[] { "3000" });
         Assert.IsTrue(client.ClusterID == 1);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(OverflowException))]
+    public void CreateAccountBatchSizeOverflow()
+    {
+        var batch = new DummyMemory<Account>(int.MaxValue);
+        _ = client.CreateAccounts(batch.Memory.Span);
+        Assert.Fail();
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(OverflowException))]
+    public async Task CreateAccountBatchSizeOverflowAsync()
+    {
+        var batch = new DummyMemory<Account>(int.MaxValue);
+        _ = await client.CreateAccountsAsync(batch.Memory);
+        Assert.Fail();
     }
 
     [TestMethod]
@@ -2362,5 +2381,45 @@ internal class TBServer : IDisposable
         process.WaitForExit();
         process.Dispose();
         File.Delete($"./{dataFile}");
+    }
+}
+
+/// <summary>
+/// Dummy allocator capable of creating memory regions
+/// and spans for testing purposes.
+/// The contents cannot be dereferenced.
+/// </summary>
+sealed class DummyMemory<T> : MemoryManager<T>
+    where T : unmanaged
+{
+    private readonly int length;
+
+    public DummyMemory(int length)
+    {
+        this.length = length;
+    }
+
+    public override Memory<T> Memory => base.CreateMemory(length);
+
+    public override Span<T> GetSpan()
+    {
+        unsafe
+        {
+            return new Span<T>(null, length);
+        }
+    }
+
+    public override MemoryHandle Pin(int elementIndex = 0)
+    {
+        return new MemoryHandle();
+    }
+
+    public override void Unpin()
+    {
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        _ = disposing;
     }
 }

--- a/src/clients/dotnet/TigerBeetle/Request.cs
+++ b/src/clients/dotnet/TigerBeetle/Request.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,8 +31,9 @@ internal abstract class NativeRequest
         {
             nativeClient.Submit((TBPacket*)packetHandle.Value.AddrOfPinnedObject());
         }
-        catch (ObjectDisposedException)
+        catch
         {
+            requestHandle.Free();
             packetHandle.Value.Free();
             throw;
         }
@@ -76,7 +76,7 @@ internal abstract class Request<TResult, TBody> : NativeRequest
 
     public unsafe void Submit(NativeClient nativeClient, void* body, int bodyCount)
     {
-        this.Submit(nativeClient, this.operation, body, bodyCount * sizeof(TBody));
+        this.Submit(nativeClient, this.operation, body, checked(bodyCount * sizeof(TBody)));
     }
 
     public override void Complete(PacketStatus status, byte operation, ReadOnlySpan<byte> result)

--- a/src/clients/java/src/client.zig
+++ b/src/clients/java/src/client.zig
@@ -122,8 +122,12 @@ const NativeClient = struct {
             .status = undefined,
         };
 
-        client.submit(packet) catch |err| switch (err) {
-            error.ClientInvalid => ReflectionHelper.client_closed_exception_throw(env),
+        client.submit(packet) catch |err| {
+            env.delete_global_ref(global_ref);
+            global_allocator.destroy(packet);
+            switch (err) {
+                error.ClientInvalid => ReflectionHelper.client_closed_exception_throw(env),
+            }
         };
     }
 

--- a/src/clients/java/src/main/java/com/tigerbeetle/Batch.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/Batch.java
@@ -78,6 +78,8 @@ public abstract class Batch {
         assertTrue(ELEMENT_SIZE > 0, "Element size cannot be zero or negative");
 
         if (capacity < 0) throw new IllegalArgumentException("Buffer capacity cannot be negative");
+        if ((long)capacity * (long)ELEMENT_SIZE > Integer.MAX_VALUE)
+            throw new IllegalArgumentException("Buffer capacity overflows");
 
         this.ELEMENT_SIZE = ELEMENT_SIZE;
 

--- a/src/clients/java/src/test/java/com/tigerbeetle/BatchTest.java
+++ b/src/clients/java/src/test/java/com/tigerbeetle/BatchTest.java
@@ -10,7 +10,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.math.BigInteger;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -50,6 +49,11 @@ public class BatchTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorWithNegativeCapacity() {
         new AccountBatch(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorOverflows() {
+        new AccountBatch(Integer.MAX_VALUE);
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
Fixes the .NET and Java clients:

- Prevent unchecked overflow from truncating huge batches.
- Fix GC handle leaks.

Closes #3755
Closes #3756 
Closes #3757 
Closes #3758