### PR TITLE
stdx: parse_int

### DIFF
--- a/src/build_multiversion.zig
+++ b/src/build_multiversion.zig
@@ -792,10 +792,9 @@ fn git_sha_to_binary(commit: []const u8) ![20]u8 {
     assert(commit.len == 40);
 
     var commit_bytes: [20]u8 = std.mem.zeroes([20]u8);
-    for (0..@divExact(commit.len, 2)) |i| {
-        const byte = try std.fmt.parseInt(u8, commit[i * 2 ..][0..2], 16);
-        commit_bytes[i] = byte;
-    }
+    const commit_int =
+        try stdx.parse_int(u160, commit, .{ .base = 16, .allow_leading_zero = true });
+    std.mem.writeInt(u160, &commit_bytes, commit_int, .big);
 
     var commit_roundtrip: [40]u8 = undefined;
     assert(std.mem.eql(u8, try std.fmt.bufPrint(

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -307,7 +307,6 @@ pub fn ContextType(
                 error.AddressHasTrailingComma,
                 error.AddressInvalid,
                 error.PortInvalid,
-                error.PortOverflow,
                 => error.AddressInvalid,
             };
             assert(addresses_parsed.len > 0);

--- a/src/clients/java/src/jni_tests.zig
+++ b/src/clients/java/src/jni_tests.zig
@@ -1164,7 +1164,11 @@ test "JNI: CallStatic<Type>Method" {
         try testing.expect(class != null);
         defer env.delete_local_ref(class);
 
-        const method_id = env.get_static_method_id(class, "parseInt", "(Ljava/lang/String;)I");
+        const method_id = env.get_static_method_id(
+            class,
+            "parse" ++ "Int", // dodge tidy
+            "(Ljava/lang/String;)I",
+        );
         try testing.expect(method_id != null);
 
         const ret = env.call_static_int_method(

--- a/src/copyhound.zig
+++ b/src/copyhound.zig
@@ -165,7 +165,7 @@ fn extract_memcpy_size(memcpy_call: []const u8) ?u32 {
     // Runtime-known memcpy size, assume that's OK.
     if (std.mem.startsWith(u8, size_value, "%")) return 0;
 
-    return std.fmt.parseInt(u32, size_value, 10) catch null;
+    return stdx.parse_int(u32, size_value, .{}) catch null;
 }
 
 test "extract_memcpy_size" {

--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -317,10 +317,10 @@ test "benchmark/inspect smoke" {
         .{ .tigerbeetle = tigerbeetle, .path = data_file },
     );
 
-    const offset = try std.fmt.parseInt(
+    const offset = try stdx.parse_int(
         u64,
         stdx.cut(tables_output, "O=").?[1],
-        10,
+        .{},
     );
 
     {

--- a/src/multiversion.zig
+++ b/src/multiversion.zig
@@ -259,9 +259,9 @@ pub const ReleaseTriple = extern struct {
         const patch = parts.next() orelse return error.InvalidRelease;
         if (parts.next() != null) return error.InvalidRelease;
         return .{
-            .major = std.fmt.parseUnsigned(u16, major, 10) catch return error.InvalidRelease,
-            .minor = std.fmt.parseUnsigned(u8, minor, 10) catch return error.InvalidRelease,
-            .patch = std.fmt.parseUnsigned(u8, patch, 10) catch return error.InvalidRelease,
+            .major = stdx.parse_int(u16, major, .{}) catch return error.InvalidRelease,
+            .minor = stdx.parse_int(u8, minor, .{}) catch return error.InvalidRelease,
+            .patch = stdx.parse_int(u8, patch, .{}) catch return error.InvalidRelease,
         };
     }
 };

--- a/src/repl/parser.zig
+++ b/src/repl/parser.zig
@@ -1,3 +1,4 @@
+const stdx = @import("stdx");
 const std = @import("std");
 const assert = std.debug.assert;
 
@@ -248,13 +249,11 @@ pub const Parser = struct {
         }
     }
 
+    // Allows 0b/0o/0x prefixes for UUIDs.
+    // Allows -N as a shorthand for INT_MAX - N.
     fn parse_int(comptime T: type, input: []const u8) !T {
         const info = @typeInfo(T);
         comptime assert(info == .int);
-
-        // When base is zero the string prefix is examined to detect the true base:
-        // "0b", "0o" or "0x", otherwise base=10 is assumed.
-        const base_unknown = 0;
 
         assert(input.len > 0);
         const input_negative = input[0] == '-';
@@ -263,10 +262,10 @@ pub const Parser = struct {
             // Negative input means `maxInt - input`.
             // Useful for representing sentinels such as `AMOUNT_MAX`, as `-0`.
             const max = std.math.maxInt(T);
-            return max - try std.fmt.parseUnsigned(T, input[1..], base_unknown);
+            return max - try stdx.parse_int_with_base(T, input[1..]);
         }
 
-        return try std.fmt.parseUnsigned(T, input, base_unknown);
+        return try stdx.parse_int_with_base(T, input);
     }
 
     fn parse_arguments(

--- a/src/repl/terminal.zig
+++ b/src/repl/terminal.zig
@@ -1,3 +1,4 @@
+const stdx = @import("stdx");
 const std = @import("std");
 const assert = std.debug.assert;
 const posix = std.posix;
@@ -254,7 +255,8 @@ pub const Terminal = struct {
                     else => return err,
                 }
             };
-            const row = std.fmt.parseInt(usize, buffer_in.getWritten(), 10) catch continue;
+            const row = stdx.parse_int(usize, buffer_in.getWritten(), .{}) catch
+                continue;
 
             buffer_in.reset();
             stdin.streamUntilDelimiter(
@@ -267,7 +269,8 @@ pub const Terminal = struct {
                     else => return err,
                 }
             };
-            const column = std.fmt.parseInt(usize, buffer_in.getWritten(), 10) catch continue;
+            const column = stdx.parse_int(usize, buffer_in.getWritten(), .{}) catch
+                continue;
 
             return .{
                 .row = row,

--- a/src/scripts/amqp.zig
+++ b/src/scripts/amqp.zig
@@ -947,7 +947,7 @@ const TmpRabbitMQ = struct {
                 _, const host = stdx.cut(line, " -> ") orelse continue;
                 // Last index of `:`, because ipv6 can be `[::]:port`.
                 const index = std.mem.lastIndexOfScalar(u8, host, ':') orelse continue;
-                const port = try std.fmt.parseUnsigned(u16, host[index + 1 ..], 10);
+                const port = try stdx.parse_int(u16, host[index + 1 ..], .{});
                 break :host try std.net.Address.parseIp4("127.0.0.1", port);
             }
             try testing.expect(false);

--- a/src/scripts/cfo.zig
+++ b/src/scripts/cfo.zig
@@ -1154,7 +1154,8 @@ const SeedRecord = struct {
                 if (std.mem.eql(u8, string, release_url)) return .release;
                 assert(std.mem.startsWith(u8, string, pull_url_prefix));
                 const pull_number_string = string[pull_url_prefix.len..];
-                const pull_number = std.fmt.parseInt(u32, pull_number_string, 10) catch unreachable;
+                const pull_number = stdx.parse_int(u32, pull_number_string, .{}) catch
+                    unreachable;
                 return .{ .pull = pull_number };
             }
         };

--- a/src/scripts/changelog.zig
+++ b/src/scripts/changelog.zig
@@ -141,7 +141,7 @@ fn format_changelog_cut_single_merge(merges_left: *[]const u8) !?struct {
 
     const pr_string, merges_left.* = stdx.cut(merges_left.*, " from ") orelse
         return error.ParseMergeLog;
-    const pr = try std.fmt.parseInt(u16, pr_string, 10);
+    const pr = try stdx.parse_int(u16, pr_string, .{});
 
     _, merges_left.* = stdx.cut(merges_left.*, "\n    \n    ") orelse return error.ParseMergeLog;
 

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -100,7 +100,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
 
     const commit_timestamp_str =
         try shell.exec_stdout("git show -s --format=%ct {sha}", .{ .sha = cli_args.sha });
-    const commit_timestamp = try std.fmt.parseInt(u64, commit_timestamp_str, 10);
+    const commit_timestamp = try stdx.parse_int(u64, commit_timestamp_str, .{});
 
     // Only build the TigerBeetle binary to test build speed and build size. Throw it away once
     // done, and use a release build from `zig-out/dist/` to run the benchmark.
@@ -227,7 +227,7 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
             // timing: compact_mutable_suffix(tree)=136
             if (line.len != 0) {
                 _, const value_string = stdx.cut(line, "=").?;
-                stats_count += try std.fmt.parseInt(u32, value_string, 10);
+                stats_count += try stdx.parse_int(u32, value_string, .{});
             }
         }
         break :blk stats_count;
@@ -252,9 +252,11 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
             _ = process.wait() catch {};
         }
 
-        var port_buffer: [std.fmt.count("{}\n", .{std.math.maxInt(u16)})]u8 = undefined;
-        const port_buffer_len = try process.stdout.?.readAll(&port_buffer);
-        const port = try std.fmt.parseInt(u16, port_buffer[0 .. port_buffer_len - 1], 10);
+        const port: u16 = b: {
+            var buffer: [std.fmt.count("{}\n", .{std.math.maxInt(u16)})]u8 = undefined;
+            const size = try process.stdout.?.readAll(&buffer);
+            break :b try stdx.parse_int(u16, buffer[0 .. size - 1], .{});
+        };
 
         // TODO: This sends a ping manually; once register connection speed has been fixed, this can
         // use the benchmark or repl via CLI.
@@ -393,7 +395,7 @@ fn get_measurement(
         return error.BadMeasurement;
     const value_string, _ = stdx.cut(rest, " " ++ unit) orelse return error.BadMeasurement;
 
-    return try std.fmt.parseInt(u64, value_string, 10);
+    return try stdx.parse_int(u64, value_string, .{});
 }
 
 fn upload_run(shell: *Shell, batch: *const MetricBatch) !void {

--- a/src/stdx/flags.zig
+++ b/src/stdx/flags.zig
@@ -443,7 +443,7 @@ fn parse_value_int(comptime T: type, flag: []const u8, value: [:0]const u8) T {
 
     // Support only unsigned integers, as a conservative choice.
     comptime assert(@typeInfo(T).int.signedness == .unsigned);
-    return std.fmt.parseUnsigned(T, value, 10) catch |err| {
+    return stdx.parse_int(T, value, .{ .allow_separators = true }) catch |err| {
         switch (err) {
             error.Overflow => fatal(
                 "{s}: value exceeds {d}-bit {s} integer: '{s}'",
@@ -451,6 +451,10 @@ fn parse_value_int(comptime T: type, flag: []const u8, value: [:0]const u8) T {
             ),
             error.InvalidCharacter => fatal(
                 "{s}: expected an integer value, but found '{s}' (invalid digit)",
+                .{ flag, value },
+            ),
+            error.LeadingZero => fatal(
+                "{s}: leading zero disallowed: '{s}'",
                 .{ flag, value },
             ),
         }
@@ -1203,6 +1207,13 @@ test "flags" {
         \\status: 1
         \\stderr:
         \\error: --int: expected an integer value, but found '-92' (invalid digit)
+        \\
+    ));
+
+    try t.check(&.{ "values", "--int=092" }, snap(@src(),
+        \\status: 1
+        \\stderr:
+        \\error: --int: leading zero disallowed: '092'
         \\
     ));
 

--- a/src/stdx/huge_page_allocator.zig
+++ b/src/stdx/huge_page_allocator.zig
@@ -72,8 +72,8 @@ fn verify_address_is_huge_page(ptr: [*]const u8) !bool {
 fn parse_mapping_range(line: []const u8) ?struct { min: u64, max: u64 } {
     const addr_range, _ = stdx.cut(line, " ") orelse return null;
     const addr_hex_min, const addr_hex_max = stdx.cut(addr_range, "-") orelse return null;
-    const addr_min = std.fmt.parseUnsigned(u64, addr_hex_min, 16) catch return null;
-    const addr_max = std.fmt.parseUnsigned(u64, addr_hex_max, 16) catch return null;
+    const addr_min = stdx.parse_int(u64, addr_hex_min, .{ .base = 16 }) catch return null;
+    const addr_max = stdx.parse_int(u64, addr_hex_max, .{ .base = 16 }) catch return null;
     return .{ .min = addr_min, .max = addr_max };
 }
 

--- a/src/stdx/prng.zig
+++ b/src/stdx/prng.zig
@@ -62,11 +62,17 @@ pub const Ratio = struct {
             return error.InvalidFlagValue;
         };
 
-        const numerator = std.fmt.parseInt(u64, string_numerator, 10) catch {
+        const numerator = stdx.parse_int(u64, string_numerator, .{
+            .base = 10,
+            .allow_separators = true,
+        }) catch {
             static_diagnostic.* = "invalid numerator:";
             return error.InvalidFlagValue;
         };
-        const denominator = std.fmt.parseInt(u64, string_denominator, 10) catch {
+        const denominator = stdx.parse_int(u64, string_denominator, .{
+            .base = 10,
+            .allow_separators = true,
+        }) catch {
             static_diagnostic.* = "invalid denominator:";
             return error.InvalidFlagValue;
         };

--- a/src/stdx/shell.zig
+++ b/src/stdx/shell.zig
@@ -702,7 +702,7 @@ pub fn git_commit_timestamp(shell: *Shell, sha: []const u8) !stdx.InstantUnix {
 
     const timestamp_s = try shell.exec_stdout("git show -s --format=%ct {sha}", .{ .sha = sha });
     return stdx.InstantUnix.from_timestamp_s(
-        try std.fmt.parseInt(u64, timestamp_s, 10),
+        try stdx.parse_int(u64, timestamp_s, .{}),
     );
 }
 
@@ -1053,10 +1053,10 @@ fn http_request(
 
 /// Converts an ISO8601 timestamp into seconds from the epoch by shelling out to the `date` util.
 pub fn iso8601_to_timestamp_seconds(shell: *Shell, datetime_iso8601: []const u8) !u64 {
-    return try std.fmt.parseInt(u64, try shell.exec_stdout(
+    return try stdx.parse_int(u64, try shell.exec_stdout(
         "date -d {datetime_iso8601} +%s",
         .{ .datetime_iso8601 = datetime_iso8601 },
-    ), 10);
+    ), .{});
 }
 
 pub fn unzip_executable(

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -898,6 +898,54 @@ test fmt_int_size_bin_exact {
     });
 }
 
+// Dodge tidy:
+const std_parse_int = @field(std.fmt, "parse" ++ "Int");
+const std_parse_unsigned = @field(std.fmt, "parse" ++ "Unsigned");
+
+/// Strict by default integer parsing.
+pub fn parse_int(T: type, text: []const u8, comptime options: struct {
+    base: u8 = 10,
+    allow_leading_zero: bool = false,
+    allow_separators: bool = false,
+}) !T {
+    comptime assert((options.base == 10) or (options.base == 16));
+    if (!options.allow_leading_zero) {
+        if (text.len > 1 and text[0] == '0') return error.LeadingZero;
+    }
+    for (text) |c| switch (c) {
+        '0'...'9', 'a'...'f', 'A'...'F' => {},
+        '_' => if (!options.allow_separators) return error.InvalidCharacter,
+        '-' => if (@typeInfo(T).int.signedness == .unsigned) return error.InvalidCharacter,
+        else => return error.InvalidCharacter,
+    };
+    return std_parse_int(T, text, options.base);
+}
+
+test parse_int {
+    const T = struct {
+        fn check(text: []const u8) !void {
+            _ = try std_parse_int(u8, text, 10);
+            _ = parse_int(u8, text, .{}) catch return;
+            return error.TestExpectedError;
+        }
+    };
+
+    // Examples that parse with std, but should be rejected by default.
+    try T.check("0_0");
+    try T.check("000");
+    try T.check("-0");
+}
+
+// Allows `0b`, `0o`, `0x` prefixes to select the base, matches the syntax of Zig literals.
+pub fn parse_int_with_base(T: type, text: []const u8) !T {
+    comptime assert(@typeInfo(T).int.signedness == .unsigned);
+    return std_parse_unsigned(T, text, 0);
+}
+
+test parse_int_with_base {
+    try std.testing.expectEqual(0xBEE71E, try parse_int_with_base(u32, "0xBE_E71E"));
+}
+
 /// Like std.fmt.bufPrint, but checks, at compile time, that the buffer is sufficiently large.
 pub fn array_print(
     comptime n: usize,
@@ -983,16 +1031,21 @@ pub const ByteSize = struct {
         maybe(string_amount.len == 0);
         maybe(string_unit.len == 0);
 
-        const amount = std.fmt.parseUnsigned(u64, string_amount, 10) catch |err| switch (err) {
-            error.Overflow => {
-                static_diagnostic.* = "value exceeds 64-bit unsigned integer:";
-                return error.InvalidFlagValue;
-            },
-            error.InvalidCharacter => {
-                static_diagnostic.* = "expected a size, but found:";
-                return error.InvalidFlagValue;
-            },
-        };
+        const amount = parse_int(u64, string_amount, .{ .allow_separators = true }) catch |err|
+            switch (err) {
+                error.Overflow => {
+                    static_diagnostic.* = "value exceeds 64-bit unsigned integer:";
+                    return error.InvalidFlagValue;
+                },
+                error.InvalidCharacter => {
+                    static_diagnostic.* = "expected a size, but found:";
+                    return error.InvalidFlagValue;
+                },
+                error.LeadingZero => {
+                    static_diagnostic.* = "leading zero disallowed:";
+                    return error.InvalidFlagValue;
+                },
+            };
 
         const unit = if (string_unit.len == 0)
             .bytes
@@ -1055,6 +1108,7 @@ test "ByteSize.parse_flag_value" {
             .{ "10bananas", "invalid unit in size, needed KiB, MiB, GiB or TiB" },
             .{ "10GB", "invalid unit in size" },
             .{ "18446744073709551GiB", "size in bytes exceeds 64-bit unsigned integer" },
+            .{ "0009GiB", "leading zero disallowed" },
         },
     });
 }

--- a/src/stdx/time_units.zig
+++ b/src/stdx/time_units.zig
@@ -128,9 +128,16 @@ pub const Duration = struct {
         assert(string_amount.len > 0);
         assert(string_remaining.len > 0);
 
-        const amount = std.fmt.parseInt(u64, string_amount, 10) catch |err| switch (err) {
+        const amount = stdx.parse_int(u64, string_amount, .{
+            .base = 10,
+            .allow_separators = true,
+        }) catch |err| switch (err) {
             error.Overflow => {
                 static_diagnostic.* = "integer overflow:";
+                return error.InvalidFlagValue;
+            },
+            error.LeadingZero => {
+                static_diagnostic.* = "leading zero disallowed:";
                 return error.InvalidFlagValue;
             },
             error.InvalidCharacter => unreachable,
@@ -191,6 +198,7 @@ test "Duration.parse_flag_value" {
             .{ "1h 2m", "missing value" },
             .{ "18446744073709551616ns", "integer overflow" },
             .{ "1844674407370955161s", "duration too large" },
+            .{ "0024h", "leading zero disallowed" },
         },
     });
 }

--- a/src/testing/fuzz.zig
+++ b/src/testing/fuzz.zig
@@ -94,17 +94,16 @@ pub fn parse_seed(bytes: []const u8) u64 {
         // current commit hash as a seed --- that way, we run simulator on CI, we run it with
         // different, "random" seeds, but the failures remain reproducible just from the commit
         // hash!
-        const commit_hash = std.fmt.parseUnsigned(u160, bytes, 16) catch |err| switch (err) {
-            error.Overflow => unreachable,
-            error.InvalidCharacter => @panic("commit hash seed contains an invalid character"),
-        };
+        const commit_hash = stdx.parse_int(u160, bytes, .{
+            .base = 16,
+            .allow_leading_zero = true,
+        }) catch
+            @panic("commit hash seed invalid");
         return @truncate(commit_hash);
     }
 
-    return std.fmt.parseUnsigned(u64, bytes, 10) catch |err| switch (err) {
-        error.Overflow => @panic("seed exceeds a 64-bit unsigned integer"),
-        error.InvalidCharacter => @panic("seed contains an invalid character"),
-    };
+    return stdx.parse_int(u64, bytes, .{}) catch
+        @panic("seed invalid");
 }
 
 // Like `std.meta.DeclEnum`, but allows excluding specific things. Feed the result into

--- a/src/testing/table.zig
+++ b/src/testing/table.zig
@@ -45,9 +45,10 @@ fn parse_data(comptime Data: type, tokens: *std.mem.TokenIterator(u8, .scalar)) 
             const offset: usize = if (std.ascii.isAlphabetic(token[0])) 1 else 0;
             // Negative unsigned values are computed relative to the maxInt.
             if (info.signedness == .unsigned and token[offset] == '-') {
-                return max - (std.fmt.parseInt(Data, token[offset + 1 ..], 10) catch unreachable);
+                const negative = stdx.parse_int(Data, token[offset + 1 ..], .{}) catch unreachable;
+                return max - negative;
             }
-            return std.fmt.parseInt(Data, token[offset..], 10) catch unreachable;
+            return stdx.parse_int(Data, token[offset..], .{}) catch unreachable;
         },
         .@"struct" => {
             var data: Data = undefined;

--- a/src/testing/tmp_tigerbeetle.zig
+++ b/src/testing/tmp_tigerbeetle.zig
@@ -122,7 +122,7 @@ pub fn init(
             return error.NoPort;
         }
 
-        break :port try std.fmt.parseInt(u16, port_buf[0 .. port_buf_len - 1], 10);
+        break :port try stdx.parse_int(u16, port_buf[0 .. port_buf_len - 1], .{});
     };
 
     const port_str = try std.fmt.allocPrint(gpa, "{d}", .{port});

--- a/src/tidy.zig
+++ b/src/tidy.zig
@@ -319,6 +319,8 @@ fn tidy_banned(file: SourceFile, errors: *Errors) void {
         .{ "intRangeLessThan", "stdx.PRNG" },
         .{ "intRangeAtMost", "stdx.PRNG" },
         .{ "intRangeAtMostBiased", "stdx.PRNG" },
+        .{ "parseInt", "stdx.parse_int" },
+        .{ "parseUnsigned", "stdx.parse_int" },
 
         // Library footguns:
         .{ "unexpectedErrno", "stdx.unexpected_errno" },
@@ -1313,7 +1315,7 @@ test "tidy no large blobs" {
         const blob = stdx.cut_prefix(line, "blob ") orelse continue;
 
         const size_string, const path = stdx.cut(blob, " ").?;
-        const size = try std.fmt.parseInt(u64, size_string, 10);
+        const size = try stdx.parse_int(u64, size_string, .{});
 
         if (std.mem.eql(u8, path, "src/vsr/replica.zig")) continue; // :-)
         if (std.mem.eql(u8, path, "src/state_machine.zig")) continue; // :-|

--- a/src/tigerbeetle/benchmark_driver.zig
+++ b/src/tigerbeetle/benchmark_driver.zig
@@ -17,6 +17,7 @@ const Allocator = std.mem.Allocator;
 const ChildProcess = std.process.Child;
 
 const vsr = @import("vsr");
+const stdx = vsr.stdx;
 const cli = @import("./cli.zig");
 const benchmark_load = @import("./benchmark_load.zig");
 
@@ -218,7 +219,7 @@ fn start(allocator: std.mem.Allocator, options: struct {
         errdefer log.err("failed to read port number from tigerbeetle process", .{});
         var port_buf: [std.fmt.count("{}\n", .{std.math.maxInt(u16)})]u8 = undefined;
         const port_buf_len = try child.stdout.?.readAll(&port_buf);
-        break :port try std.fmt.parseInt(u16, port_buf[0 .. port_buf_len - 1], 10);
+        break :port try stdx.parse_int(u16, port_buf[0 .. port_buf_len - 1], .{});
     };
 
     const address = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, port);

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -1398,7 +1398,6 @@ fn parse_addresses(
         error.AddressHasMoreThanOneColon => {
             vsr.fatal(.cli, flag ++ ": invalid address with more than one colon", .{});
         },
-        error.PortOverflow => vsr.fatal(.cli, flag ++ ": port exceeds 65535", .{}),
         error.PortInvalid => vsr.fatal(.cli, flag ++ ": invalid port", .{}),
         error.AddressInvalid => vsr.fatal(.cli, flag ++ ": invalid IPv4 or IPv6 address", .{}),
     };
@@ -1422,7 +1421,6 @@ fn parse_address_and_port(
         error.AddressHasMoreThanOneColon => {
             vsr.fatal(.cli, flag ++ ": invalid address with more than one colon", .{});
         },
-        error.PortOverflow => vsr.fatal(.cli, flag ++ ": port exceeds 65535", .{}),
         error.PortInvalid => vsr.fatal(.cli, flag ++ ": invalid port", .{}),
         error.AddressInvalid => vsr.fatal(.cli, flag ++ ": invalid IPv4 or IPv6 address", .{}),
     };

--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -1442,7 +1442,7 @@ fn format_tree_id(tree_id: u16) []const u8 {
 }
 
 fn parse_tree_id(tree_label: []const u8) ?u16 {
-    const tree_label_integer = std.fmt.parseInt(u16, tree_label, 10) catch null;
+    const tree_label_integer = stdx.parse_int(u16, tree_label, .{}) catch null;
     inline for (StateMachine.Forest.tree_infos) |tree_info| {
         if (std.mem.eql(u8, tree_info.tree_name, tree_label)) {
             return tree_info.tree_id;

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -920,12 +920,10 @@ pub fn parse_addresses(
     return out_buffer[0..address_count];
 }
 
-pub fn parse_address_and_port(
-    options: struct {
-        string: []const u8,
-        port_default: u16,
-    },
-) !std.net.Address {
+pub fn parse_address_and_port(options: struct {
+    string: []const u8,
+    port_default: u16,
+}) !std.net.Address {
     assert(options.string.len > 0);
     assert(options.port_default > 0);
 
@@ -933,14 +931,8 @@ pub fn parse_address_and_port(
         if (options.string[split] == ':') {
             return parse_address(
                 options.string[0..split],
-                std.fmt.parseUnsigned(
-                    u16,
-                    options.string[split + 1 ..],
-                    10,
-                ) catch |err| switch (err) {
-                    error.Overflow => return error.PortOverflow,
-                    error.InvalidCharacter => return error.PortInvalid,
-                },
+                stdx.parse_int(u16, options.string[split + 1 ..], .{}) catch
+                    return error.PortInvalid,
             );
         } else {
             return parse_address(options.string, options.port_default);
@@ -948,10 +940,8 @@ pub fn parse_address_and_port(
     } else {
         return std.net.Address.parseIp4(
             constants.address,
-            std.fmt.parseUnsigned(u16, options.string, 10) catch |err| switch (err) {
-                error.Overflow => return error.PortOverflow,
-                error.InvalidCharacter => return error.AddressInvalid,
-            },
+            stdx.parse_int(u16, options.string, .{}) catch
+                return error.PortInvalid,
         ) catch unreachable;
     }
 }
@@ -961,9 +951,8 @@ fn parse_address(string: []const u8, port: u16) !std.net.Address {
     if (string[string.len - 1] == ':') return error.AddressHasMoreThanOneColon;
 
     if (string[0] == '[' and string[string.len - 1] == ']') {
-        return std.net.Address.parseIp6(string[1 .. string.len - 1], port) catch {
+        return std.net.Address.parseIp6(string[1 .. string.len - 1], port) catch
             return error.AddressInvalid;
-        };
     } else {
         return std.net.Address.parseIp4(string, port) catch return error.AddressInvalid;
     }
@@ -1064,13 +1053,13 @@ test parse_addresses {
         .{ .raw = "1.2.3.4:5,2.3.4.5:6,4.5.6.7:8", .err = error.AddressLimitExceeded },
         .{ .raw = "1.2.3.4:7777,", .err = error.AddressHasTrailingComma },
         .{ .raw = "1.2.3.4:7777,2.3.4.5::8888", .err = error.AddressHasMoreThanOneColon },
-        .{ .raw = "1.2.3.4:5,A", .err = error.AddressInvalid }, // default port
+        .{ .raw = "1.2.3.4:5,A", .err = error.PortInvalid }, // default port
         .{ .raw = "1.2.3.4:5,2.a.4.5", .err = error.AddressInvalid }, // default port
         .{ .raw = "1.2.3.4:5,2.a.4.5:6", .err = error.AddressInvalid }, // specified port
         .{ .raw = "1.2.3.4:5,2.3.4.5:", .err = error.PortInvalid },
         .{ .raw = "1.2.3.4:5,2.3.4.5:A", .err = error.PortInvalid },
-        .{ .raw = "1.2.3.4:5,65536", .err = error.PortOverflow }, // default address
-        .{ .raw = "1.2.3.4:5,2.3.4.5:65536", .err = error.PortOverflow },
+        .{ .raw = "1.2.3.4:5,65536", .err = error.PortInvalid }, // default address
+        .{ .raw = "1.2.3.4:5,2.3.4.5:65536", .err = error.PortInvalid },
     };
 
     var buffer: [3]std.net.Address = undefined;


### PR DESCRIPTION
std versions are premissive: they allow leading zeros, underscores, and
even `-0` when parsing unsinged number with `parseInt`. This is good
for interactive use-cases, but when dealing with protocols, we should
be more restrictive.

The leading zeros is also ambiguous, as it sometimes means octal.