### PR TITLE
CI: Don't overlap release and release-validate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ permissions: {}
 on:
   workflow_dispatch:
 
+# Don't run release and release_validate simultaneously, to avoid races.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # Remove once this is the default (June 16th, 2026).
 

--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -13,6 +13,11 @@ on:
     # in systems we do not control.
     - cron: 0 */6 * * *
 
+# Don't run release and release_validate simultaneously, to avoid races.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # Remove once this is the default (June 2nd, 2026).
 


### PR DESCRIPTION
To prevent race conditions, don't run release and release-validate jobs simultaneously. The `cancel-in-progress: false` means they should queue up behind each other if needed.

Example flake: https://github.com/tigerbeetle/tigerbeetle/actions/runs/27140355010/job/80103575131