### PR TITLE
vsr: switch to stdx.SocketAddress 

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -338,7 +338,7 @@ pub fn AOFType(comptime IO: type) type {
                 allocator: std.mem.Allocator,
                 time: vsr.time.Time,
                 cluster: u128,
-                addresses: []std.net.Address,
+                addresses: []stdx.SocketAddress,
             ) !ReplayClient {
                 assert(addresses.len > 0);
                 assert(addresses.len <= constants.replicas_max);
@@ -957,7 +957,7 @@ pub fn main() !void {
             var it = try AOFIterator.init(&io, command.path);
             defer it.close();
 
-            var addresses_buffer: [constants.replicas_max]std.net.Address = undefined;
+            var addresses_buffer: [constants.replicas_max]stdx.SocketAddress = undefined;
             const addresses_parsed = try vsr.parse_addresses(command.addresses, &addresses_buffer);
             var replay =
                 try AOFReplayClient.init(&io, gpa, time, command.cluster, addresses_parsed);

--- a/src/cdc/amqp.zig
+++ b/src/cdc/amqp.zig
@@ -216,7 +216,7 @@ pub const Client = struct {
         } };
 
         self.fd = try self.io.open_socket_tcp(
-            options.host.any.family,
+            options.host.ip.family(),
             .{
                 // Keeping the default value.
                 // Large buffers can cause latency issues.

--- a/src/cdc/amqp/types.zig
+++ b/src/cdc/amqp/types.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const stdx = @import("stdx");
 const builtin = @import("builtin");
 const vsr = @import("../../vsr.zig");
 const protocol = @import("protocol.zig");
@@ -6,7 +7,7 @@ const Encoder = protocol.Encoder;
 const Decoder = protocol.Decoder;
 
 pub const ConnectOptions = struct {
-    host: std.net.Address,
+    host: stdx.SocketAddress,
     user_name: []const u8,
     password: []const u8,
     vhost: []const u8,

--- a/src/cdc/runner.zig
+++ b/src/cdc/runner.zig
@@ -116,9 +116,9 @@ pub const Runner = struct {
             /// TigerBeetle cluster ID.
             cluster_id: u128,
             /// TigerBeetle cluster addresses.
-            addresses: []const std.net.Address,
+            addresses: []const stdx.SocketAddress,
             /// AMQP host address.
-            host: std.net.Address,
+            host: stdx.SocketAddress,
             /// AMQP User name for PLAIN authentication.
             user: []const u8,
             /// AMQP Password for PLAIN authentication.

--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -211,7 +211,7 @@ pub fn ContextType(
         cluster_id: u128,
         addresses_owned: []const u8,
 
-        addresses: stdx.BoundedArrayType(std.net.Address, constants.replicas_max) = .{},
+        addresses: stdx.BoundedArrayType(stdx.SocketAddress, constants.replicas_max) = .{},
         io: IO,
         message_pool: MessagePool,
         client: Client,

--- a/src/io/common.zig
+++ b/src/io/common.zig
@@ -31,20 +31,30 @@ pub const NextTickSource = enum { lsm, vsr };
 
 pub fn listen(
     fd: posix.socket_t,
-    address: std.net.Address,
+    address: stdx.SocketAddress,
     options: ListenOptions,
-) !std.net.Address {
+) !stdx.SocketAddress {
+    const address_std = address.to_std();
     try setsockopt(fd, posix.SOL.SOCKET, posix.SO.REUSEADDR, 1);
-    try posix.bind(fd, &address.any, address.getOsSockLen());
+    try posix.bind(fd, &address_std.any, address_std.getOsSockLen());
 
     // Resolve port 0 to an actual port picked by the OS.
-    var address_resolved: std.net.Address = .{ .any = undefined };
+    var address_resolved_std: std.net.Address = .{ .any = undefined };
     var addrlen: posix.socklen_t = @sizeOf(std.net.Address);
-    try posix.getsockname(fd, &address_resolved.any, &addrlen);
-    assert(address_resolved.getOsSockLen() == addrlen);
-    assert(address_resolved.any.family == address.any.family);
+    try posix.getsockname(fd, &address_resolved_std.any, &addrlen);
+    assert(address_resolved_std.getOsSockLen() == addrlen);
+    assert(address_resolved_std.any.family == address_std.any.family);
 
     try posix.listen(fd, options.backlog);
+
+    const address_resolved = stdx.SocketAddress.from_std(address_resolved_std) catch |err|
+        switch (err) {
+            error.UnsupportedFamily => unreachable,
+        };
+
+    assert(address.ip.family() == address_resolved.ip.family());
+    assert(std.meta.eql(address.ip, address_resolved.ip));
+    if (address.port != address_resolved.port) assert(address.port == 0);
 
     return address_resolved;
 }

--- a/src/io/darwin.zig
+++ b/src/io/darwin.zig
@@ -427,7 +427,7 @@ pub const IO = struct {
         ) void,
         completion: *Completion,
         socket: socket_t,
-        address: std.net.Address,
+        address: stdx.SocketAddress,
     ) void {
         self.submit(
             context,
@@ -436,7 +436,7 @@ pub const IO = struct {
             .connect,
             .{
                 .socket = socket,
-                .address = address,
+                .address = address.to_std(),
                 .initiated = false,
             },
             struct {
@@ -911,9 +911,13 @@ pub const IO = struct {
     pub const socket_t = posix.socket_t;
 
     /// Creates a TCP socket that can be used for async operations with the IO instance.
-    pub fn open_socket_tcp(self: *IO, family: u32, options: TCPOptions) !socket_t {
+    pub fn open_socket_tcp(
+        self: *IO,
+        family: stdx.IPAddress.Family,
+        options: TCPOptions,
+    ) !socket_t {
         const fd = try self.open_socket(
-            family,
+            family.to_std(),
             posix.SOCK.STREAM | posix.SOCK.NONBLOCK,
             posix.IPPROTO.TCP,
         );
@@ -924,9 +928,9 @@ pub const IO = struct {
     }
 
     /// Creates a UDP socket that can be used for async operations with the IO instance.
-    pub fn open_socket_udp(self: *IO, family: u32) !socket_t {
+    pub fn open_socket_udp(self: *IO, family: stdx.IPAddress.Family) !socket_t {
         return try self.open_socket(
-            family,
+            family.to_std(),
             posix.SOCK.DGRAM | posix.SOCK.NONBLOCK,
             posix.IPPROTO.UDP,
         );
@@ -960,10 +964,10 @@ pub const IO = struct {
     pub fn listen(
         _: *IO,
         fd: socket_t,
-        address: std.net.Address,
+        address: stdx.SocketAddress,
         options: ListenOptions,
-    ) !std.net.Address {
-        return common.listen(fd, address, options);
+    ) !stdx.SocketAddress {
+        return try common.listen(fd, address, options);
     }
 
     pub fn shutdown(_: *IO, socket: socket_t, how: posix.ShutdownHow) posix.ShutdownError!void {

--- a/src/io/linux.zig
+++ b/src/io/linux.zig
@@ -930,7 +930,7 @@ pub const IO = struct {
         ) void,
         completion: *Completion,
         socket: socket_t,
-        address: std.net.Address,
+        address: stdx.SocketAddress,
     ) void {
         completion.* = .{
             .io = self,
@@ -939,7 +939,7 @@ pub const IO = struct {
             .operation = .{
                 .connect = .{
                     .socket = socket,
-                    .address = address,
+                    .address = address.to_std(),
                 },
             },
         };
@@ -1346,9 +1346,13 @@ pub const IO = struct {
     pub const socket_t = posix.socket_t;
 
     /// Creates a TCP socket that can be used for async operations with the IO instance.
-    pub fn open_socket_tcp(self: *IO, family: u32, options: TCPOptions) !socket_t {
+    pub fn open_socket_tcp(
+        self: *IO,
+        family: stdx.IPAddress.Family,
+        options: TCPOptions,
+    ) !socket_t {
         const fd = try posix.socket(
-            family,
+            family.to_std(),
             posix.SOCK.STREAM | posix.SOCK.CLOEXEC,
             posix.IPPROTO.TCP,
         );
@@ -1359,10 +1363,10 @@ pub const IO = struct {
     }
 
     /// Creates a UDP socket that can be used for async operations with the IO instance.
-    pub fn open_socket_udp(self: *IO, family: u32) !socket_t {
+    pub fn open_socket_udp(self: *IO, family: stdx.IPAddress.Family) !socket_t {
         _ = self;
         return try posix.socket(
-            family,
+            family.to_std(),
             std.posix.SOCK.DGRAM | posix.SOCK.CLOEXEC,
             posix.IPPROTO.UDP,
         );
@@ -1380,9 +1384,9 @@ pub const IO = struct {
     pub fn listen(
         _: *IO,
         fd: socket_t,
-        address: std.net.Address,
+        address: stdx.SocketAddress,
         options: ListenOptions,
-    ) !std.net.Address {
+    ) !stdx.SocketAddress {
         return common.listen(fd, address, options);
     }
 

--- a/src/io/test.zig
+++ b/src/io/test.zig
@@ -175,13 +175,13 @@ test "accept/connect/send/receive" {
             var io = try IO.init(32, 0);
             defer io.deinit();
 
-            const address = try std.net.Address.parseIp4("127.0.0.1", 0);
+            const address: stdx.SocketAddress = .{ .ip = .@"127.0.0.1", .port = 0 };
             const kernel_backlog = 1;
 
-            const server = try io.open_socket_tcp(address.any.family, tcp_options);
+            const server = try io.open_socket_tcp(address.ip.family(), tcp_options);
             defer io.close_socket(server);
 
-            const client = try io.open_socket_tcp(address.any.family, tcp_options);
+            const client = try io.open_socket_tcp(address.ip.family(), tcp_options);
             defer io.close_socket(client);
 
             try posix.setsockopt(
@@ -190,12 +190,14 @@ test "accept/connect/send/receive" {
                 posix.SO.REUSEADDR,
                 &std.mem.toBytes(@as(c_int, 1)),
             );
-            try posix.bind(server, &address.any, address.getOsSockLen());
+            const address_std = address.to_std();
+            try posix.bind(server, &address_std.any, address_std.getOsSockLen());
             try posix.listen(server, kernel_backlog);
 
-            var client_address = std.net.Address.initIp4(undefined, undefined);
-            var client_address_len = client_address.getOsSockLen();
-            try posix.getsockname(server, &client_address.any, &client_address_len);
+            var client_address_std = std.net.Address.initIp4(undefined, undefined);
+            var client_address_std_len = client_address_std.getOsSockLen();
+            try posix.getsockname(server, &client_address_std.any, &client_address_std_len);
+            const client_address = try stdx.SocketAddress.from_std(client_address_std);
 
             var self: Context = .{
                 .io = &io,
@@ -474,10 +476,10 @@ test "tick to wait" {
             var self: Context = .{ .io = try IO.init(1, 0) };
             defer self.io.deinit();
 
-            const address = try std.net.Address.parseIp4("127.0.0.1", 0);
+            const address: stdx.SocketAddress = .{ .ip = .@"127.0.0.1", .port = 0 };
             const kernel_backlog = 1;
 
-            const server = try self.io.open_socket_tcp(address.any.family, tcp_options);
+            const server = try self.io.open_socket_tcp(address.ip.family(), tcp_options);
             defer self.io.close_socket(server);
 
             try posix.setsockopt(
@@ -486,14 +488,16 @@ test "tick to wait" {
                 posix.SO.REUSEADDR,
                 &std.mem.toBytes(@as(c_int, 1)),
             );
-            try posix.bind(server, &address.any, address.getOsSockLen());
+            const address_std = address.to_std();
+            try posix.bind(server, &address_std.any, address_std.getOsSockLen());
             try posix.listen(server, kernel_backlog);
 
-            var client_address = std.net.Address.initIp4(undefined, undefined);
-            var client_address_len = client_address.getOsSockLen();
-            try posix.getsockname(server, &client_address.any, &client_address_len);
+            var client_address_std = std.net.Address.initIp4(undefined, undefined);
+            var client_address_std_len = client_address_std.getOsSockLen();
+            try posix.getsockname(server, &client_address_std.any, &client_address_std_len);
+            const client_address = try stdx.SocketAddress.from_std(client_address_std);
 
-            const client = try self.io.open_socket_tcp(client_address.any.family, tcp_options);
+            const client = try self.io.open_socket_tcp(client_address.ip.family(), tcp_options);
             defer self.io.close_socket(client);
 
             // Start the accept.
@@ -636,10 +640,10 @@ test "pipe data over socket" {
             };
             defer self.io.deinit();
 
-            self.server.fd = try self.io.open_socket_tcp(posix.AF.INET, tcp_options);
+            self.server.fd = try self.io.open_socket_tcp(.IPv4, tcp_options);
             defer self.io.close_socket(self.server.fd.?);
 
-            const address = try std.net.Address.parseIp4("127.0.0.1", 0);
+            const address: stdx.SocketAddress = .{ .ip = .@"127.0.0.1", .port = 0 };
             try posix.setsockopt(
                 self.server.fd.?,
                 posix.SOL.SOCKET,
@@ -647,12 +651,18 @@ test "pipe data over socket" {
                 &std.mem.toBytes(@as(c_int, 1)),
             );
 
-            try posix.bind(self.server.fd.?, &address.any, address.getOsSockLen());
+            const address_std = address.to_std();
+            try posix.bind(self.server.fd.?, &address_std.any, address_std.getOsSockLen());
             try posix.listen(self.server.fd.?, 1);
 
-            var client_address = std.net.Address.initIp4(undefined, undefined);
-            var client_address_len = client_address.getOsSockLen();
-            try posix.getsockname(self.server.fd.?, &client_address.any, &client_address_len);
+            var client_address_std = std.net.Address.initIp4(undefined, undefined);
+            var client_address_std_len = client_address_std.getOsSockLen();
+            try posix.getsockname(
+                self.server.fd.?,
+                &client_address_std.any,
+                &client_address_std_len,
+            );
+            const client_address = try stdx.SocketAddress.from_std(client_address_std);
 
             self.io.accept(
                 *Context,
@@ -662,7 +672,7 @@ test "pipe data over socket" {
                 self.server.fd.?,
             );
 
-            self.tx.socket.fd = try self.io.open_socket_tcp(posix.AF.INET, tcp_options);
+            self.tx.socket.fd = try self.io.open_socket_tcp(.IPv4, tcp_options);
             defer self.io.close_socket(self.tx.socket.fd.?);
 
             self.io.connect(

--- a/src/io/windows.zig
+++ b/src/io/windows.zig
@@ -463,7 +463,7 @@ pub const IO = struct {
         ) void,
         completion: *Completion,
         socket: socket_t,
-        address: std.net.Address,
+        address: stdx.SocketAddress,
     ) void {
         self.submit(
             context,
@@ -472,7 +472,7 @@ pub const IO = struct {
             .connect,
             .{
                 .socket = socket,
-                .address = address,
+                .address = address.to_std(),
                 .overlapped = undefined,
                 .pending = false,
             },
@@ -1144,9 +1144,13 @@ pub const IO = struct {
     pub const socket_t = posix.socket_t;
 
     /// Creates a TCP socket that can be used for async operations with the IO instance.
-    pub fn open_socket_tcp(self: *IO, family: u32, options: TCPOptions) !socket_t {
+    pub fn open_socket_tcp(
+        self: *IO,
+        family: stdx.IPAddress.Family,
+        options: TCPOptions,
+    ) !socket_t {
         const socket = try self.open_socket(
-            @bitCast(family),
+            family.to_std(),
             posix.SOCK.STREAM,
             posix.IPPROTO.TCP,
         );
@@ -1157,9 +1161,9 @@ pub const IO = struct {
     }
 
     /// Creates a UDP socket that can be used for async operations with the IO instance.
-    pub fn open_socket_udp(self: *IO, family: u32) !socket_t {
+    pub fn open_socket_udp(self: *IO, family: stdx.IPAddress.Family) !socket_t {
         return try self.open_socket(
-            @bitCast(family),
+            family.to_std(),
             posix.SOCK.DGRAM,
             posix.IPPROTO.UDP,
         );
@@ -1210,10 +1214,10 @@ pub const IO = struct {
     pub fn listen(
         _: *IO,
         fd: socket_t,
-        address: std.net.Address,
+        address: stdx.SocketAddress,
         options: ListenOptions,
-    ) !std.net.Address {
-        return common.listen(fd, address, options);
+    ) !stdx.SocketAddress {
+        return try common.listen(fd, address, options);
     }
 
     pub fn shutdown(_: *IO, socket: socket_t, how: posix.ShutdownHow) posix.ShutdownError!void {

--- a/src/message_bus.zig
+++ b/src/message_bus.zig
@@ -87,13 +87,13 @@ pub fn MessageBusType(comptime IO: type) type {
         }
 
         pub const Options = struct {
-            configuration: []const Address,
+            configuration: []const stdx.SocketAddress,
             io: *IO,
             trace: ?*Tracer,
             clients_limit: ?u32 = null,
             time: Time,
         };
-        const Address = std.net.Address;
+        const Address = stdx.SocketAddress;
         const MessageBus = @This();
 
         /// Initialize the MessageBus for the given configuration and replica/client process.
@@ -258,7 +258,7 @@ pub fn MessageBusType(comptime IO: type) type {
             bus.* = undefined;
         }
 
-        fn init_tcp(io: *IO, process: vsr.ProcessType, family: u32) !IO.socket_t {
+        fn init_tcp(io: *IO, process: vsr.ProcessType, family: stdx.IPAddress.Family) !IO.socket_t {
             return try io.open_socket_tcp(family, .{
                 .rcvbuf = constants.tcp_rcvbuf,
                 .sndbuf = switch (process) {
@@ -281,7 +281,7 @@ pub fn MessageBusType(comptime IO: type) type {
             assert(bus.accept_address == null);
 
             const address = bus.replicas_addresses[bus.process.replica];
-            const fd = try init_tcp(bus.io, .replica, address.any.family);
+            const fd = try init_tcp(bus.io, .replica, address.ip.family());
             errdefer bus.io.close_socket(fd);
 
             const accept_address = try bus.io.listen(fd, address, .{
@@ -510,7 +510,7 @@ pub fn MessageBusType(comptime IO: type) type {
             assert(connection.state == .free);
             assert(connection.fd == null);
 
-            const family = bus.replicas_addresses[replica].any.family;
+            const family = bus.replicas_addresses[replica].ip.family();
             connection.fd = init_tcp(bus.io, bus.process, family) catch |err| {
                 log.err("{}: connect_to_replica: init_tcp error={s}", .{
                     bus.id,

--- a/src/message_bus_fuzz.zig
+++ b/src/message_bus_fuzz.zig
@@ -48,10 +48,10 @@ pub fn main(gpa: std.mem.Allocator, args: fuzz.FuzzArgs) !void {
     // Note that this probability is conditional on sending a ping.
     const message_bus_ping_misdirect_probability = ratio(prng.range_inclusive(u64, 0, 3), 10);
 
-    const configuration = &.{
-        try std.net.Address.parseIp4("127.0.0.1", 3000),
-        try std.net.Address.parseIp4("127.0.0.1", 3001),
-        try std.net.Address.parseIp4("127.0.0.1", 3002),
+    const configuration: []const stdx.SocketAddress = &.{
+        .{ .ip = .@"127.0.0.1", .port = 3000 },
+        .{ .ip = .@"127.0.0.1", .port = 3001 },
+        .{ .ip = .@"127.0.0.1", .port = 3002 },
     };
 
     const command_weights = weights: {
@@ -445,7 +445,7 @@ const IO = struct {
     };
 
     const SocketServer = struct {
-        address: std.net.Address,
+        address: stdx.SocketAddress,
         /// Invariant: completion.operation == .connect
         backlog: std.ArrayListUnmanaged(*Completion) = .empty,
     };
@@ -475,7 +475,7 @@ const IO = struct {
     const Operation = union(enum) {
         accept: struct { socket: socket_t },
         close: struct { fd: fd_t },
-        connect: struct { socket: socket_t, address: std.net.Address },
+        connect: struct { socket: socket_t, address: stdx.SocketAddress },
         recv: struct { socket: socket_t, buffer: []u8 },
         send: struct { socket: socket_t, buffer: []const u8 },
         timeout,
@@ -606,7 +606,7 @@ const IO = struct {
                 }
 
                 for (io.servers.values()) |*server| {
-                    if (server.address.eql(operation.address)) {
+                    if (std.meta.eql(server.address, operation.address)) {
                         try server.backlog.append(gpa, completion);
                         break;
                     }
@@ -743,7 +743,7 @@ const IO = struct {
         return .done;
     }
 
-    pub fn open_socket_tcp(io: *IO, _: u32, _: RealIO.TCPOptions) !socket_t {
+    pub fn open_socket_tcp(io: *IO, _: stdx.IPAddress.Family, _: RealIO.TCPOptions) !socket_t {
         const socket = io.fd_next;
         io.fd_next += 1;
         io.fds_open += 1;
@@ -753,9 +753,9 @@ const IO = struct {
     pub fn listen(
         io: *IO,
         fd: socket_t,
-        address: std.net.Address,
+        address: stdx.SocketAddress,
         _: RealIO.ListenOptions,
-    ) !std.net.Address {
+    ) !stdx.SocketAddress {
         io.servers.putNoClobber(io.gpa, fd, .{ .address = address }) catch @panic("OOM");
         return address;
     }
@@ -841,7 +841,7 @@ const IO = struct {
         comptime callback: fn (Context, *Completion, ConnectError!void) void,
         completion: *Completion,
         socket: socket_t,
-        address: std.net.Address,
+        address: stdx.SocketAddress,
     ) void {
         completion.* = .{
             .context = context,

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -621,7 +621,7 @@ pub fn ReplType(comptime MessageBus: type) type {
             io: *IO,
             time: Time,
             options: struct {
-                addresses: []const std.net.Address,
+                addresses: []const stdx.SocketAddress,
                 cluster_id: u128,
                 verbose: bool,
             },

--- a/src/scripts/amqp.zig
+++ b/src/scripts/amqp.zig
@@ -59,7 +59,7 @@ pub fn main(_: *Shell, gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
     }
 }
 
-fn run_protocol_test(gpa: std.mem.Allocator, options: struct { host: std.net.Address }) !void {
+fn run_protocol_test(gpa: std.mem.Allocator, options: struct { host: stdx.SocketAddress }) !void {
     var context: AmqpContext = undefined;
     try context.init(gpa);
     defer context.deinit(gpa);
@@ -269,7 +269,7 @@ fn run_protocol_test(gpa: std.mem.Allocator, options: struct { host: std.net.Add
 
 fn run_serialization_test(
     gpa: std.mem.Allocator,
-    options: struct { host: std.net.Address },
+    options: struct { host: stdx.SocketAddress },
 ) !void {
     var context: AmqpContext = undefined;
     try context.init(gpa);
@@ -372,7 +372,7 @@ fn run_cdc_test(
     gpa: std.mem.Allocator,
     options: struct {
         transfer_count: u32,
-        host: std.net.Address,
+        host: stdx.SocketAddress,
     },
 ) !void {
     var amqp_context: AmqpContext = undefined;
@@ -417,7 +417,7 @@ fn run_cdc_test(
         .{
             .tigerbeetle = tmp_beetle.tigerbeetle_exe,
             .addresses = tmp_beetle.port_str,
-            .port = options.host.getPort(),
+            .port = options.host.port,
             .queue = queue,
             .idle_interval_ms = 1,
         },
@@ -538,7 +538,7 @@ fn run_cdc_test(
 fn run_timeout_test(
     gpa: std.mem.Allocator,
     options: struct {
-        host: std.net.Address,
+        host: stdx.SocketAddress,
     },
 ) !void {
     var amqp_context: AmqpContext = undefined;
@@ -584,7 +584,7 @@ fn run_timeout_test(
         .{
             .tigerbeetle = tmp_beetle.tigerbeetle_exe,
             .addresses = tmp_beetle.port_str,
-            .port = options.host.getPort(),
+            .port = options.host.port,
             .queue = queue,
             .idle_interval_ms = 1,
             .tigerbeetle_timeout_seconds = 1,
@@ -648,7 +648,7 @@ const AmqpContext = struct {
         self.io.deinit();
     }
 
-    pub fn connect(self: *AmqpContext, host: std.net.Address) !void {
+    pub fn connect(self: *AmqpContext, host: stdx.SocketAddress) !void {
         assert(!self.busy);
         self.busy = true;
         try self.client.connect(&callback, .{
@@ -788,7 +788,7 @@ const VSRContext = struct {
         self.message_pool = try MessagePool.init(gpa, .client);
         errdefer self.message_pool.deinit(gpa);
 
-        const address = try std.net.Address.parseIp4("127.0.0.1", port);
+        const address: stdx.SocketAddress = .{ .ip = .@"127.0.0.1", .port = port };
         self.client = try Client.init(
             gpa,
             time,
@@ -910,7 +910,7 @@ const TmpRabbitMQ = struct {
     const rabbitmq4 = "rabbitmq:4";
 
     id: u128,
-    host: std.net.Address,
+    host: stdx.SocketAddress,
     process: std.process.Child,
 
     pub fn init(
@@ -937,7 +937,7 @@ const TmpRabbitMQ = struct {
         );
         errdefer _ = process.kill() catch unreachable;
 
-        const host: std.net.Address = host: {
+        const host: stdx.SocketAddress = host: {
             const stdout = try try_execute(shell, "docker port {id}", .{ .id = id });
             // The command `docker port` outputs multiple lines:
             // 5672/tcp -> 0.0.0.0:32773
@@ -948,7 +948,7 @@ const TmpRabbitMQ = struct {
                 // Last index of `:`, because ipv6 can be `[::]:port`.
                 const index = std.mem.lastIndexOfScalar(u8, host, ':') orelse continue;
                 const port = try stdx.parse_int(u16, host[index + 1 ..], .{});
-                break :host try std.net.Address.parseIp4("127.0.0.1", port);
+                break :host .{ .ip = .@"127.0.0.1", .port = port };
             }
             try testing.expect(false);
             unreachable;

--- a/src/stdx/net.zig
+++ b/src/stdx/net.zig
@@ -24,11 +24,23 @@ pub const IPAddress = extern struct {
     // - Natural alignment to allow re-interpreting as u128.
     big: [16]u8 align(16),
 
-    const Family = enum { IPv4, IPv6 };
+    pub const Family = enum {
+        IPv4,
+        IPv6,
+
+        pub fn to_std(f: Family) u32 {
+            return switch (f) {
+                .IPv4 => std.posix.AF.INET,
+                .IPv6 => std.posix.AF.INET6,
+            };
+        }
+    };
 
     const IPv4_prefix: u128 = 0x0000_0000_0000_0000_0000_FFFF_0000_0000;
     const IPv4_prefix_octets: [12]u8 =
         @as([16]u8, @bitCast(std.mem.nativeToBig(u128, IPv4_prefix)))[0..12].*;
+
+    pub const @"127.0.0.1" = parse("127.0.0.1") catch unreachable;
 
     comptime {
         // The code is endianness-clean, aspirationally. Audit before running on your PowerPC!

--- a/src/stdx/net.zig
+++ b/src/stdx/net.zig
@@ -287,8 +287,15 @@ test IPAddress {
             const address = SocketAddress.to_std(.{ .ip = ip, .port = 0 });
             const address_std = try parse_std(text);
             if (!address.eql(address_std)) {
-                std.log.err("{} != {}", .{ address, address_std });
-                return error.TestUnexpectedResult;
+                if (address.any.family == std.posix.AF.INET and
+                    address_std.any.family == std.posix.AF.INET6 and
+                    std.mem.eql(u8, &IPAddress.IPv4_prefix_octets, address_std.in6.sa.addr[0..12]))
+                {
+                    // Std doesn't canonicalize IPv6-mapped IPv4 addresses.
+                } else {
+                    std.log.err("{} != {}", .{ address, address_std });
+                    return error.TestUnexpectedResult;
+                }
             }
 
             var buffer: [64]u8 = undefined;
@@ -396,6 +403,7 @@ test IPAddress {
             "0:0:0:0:0:0:0:1",
             "0:0:0:0:0:0:0:0",
             "Ff01::101",
+            "::ffff:c0a8:64e4",
         },
         .err = &.{
             "::d3:",

--- a/src/testing/vortex/faulty_network.zig
+++ b/src/testing/vortex/faulty_network.zig
@@ -269,7 +269,7 @@ const Connection = struct {
     origin_to_remote_pipe: Pipe,
     remote_to_origin_pipe: Pipe,
 
-    remote_address: ?std.net.Address = null,
+    remote_address: ?stdx.SocketAddress = null,
 
     accept_completion: IO.Completion = undefined,
     connect_completion: IO.Completion = undefined,
@@ -296,7 +296,7 @@ const Connection = struct {
         connection.origin_fd = fd;
 
         const remote_fd = connection.io.open_socket_tcp(
-            connection.remote_address.?.any.family,
+            connection.remote_address.?.ip.family(),
             tcp_options,
         ) catch |err| {
             log.warn("couldn't open socket for remote ({d},{d}): {}", .{
@@ -452,8 +452,8 @@ const Connection = struct {
 const Proxy = struct {
     io: *IO,
     accept_fd: std.posix.socket_t,
-    origin_address: std.net.Address, // The proxy's address.
-    remote_address: std.net.Address, // The replica's address.
+    origin_address: stdx.SocketAddress, // The proxy's address.
+    remote_address: stdx.SocketAddress, // The replica's address.
     connections: [constants.vortex.connections_count_max]Connection,
 
     fn deinit(proxy: *Proxy) void {
@@ -502,10 +502,12 @@ pub const Network = struct {
         // /proc/sys/net/ipv4/ip_local_port_range) by listening on port=0.
         // We assume that replicas' ports are from outside of that range and cannot conflict.
         for (proxies, replica_ports, 0..) |*proxy, replica_port, replica_index| {
-            const Address = std.net.Address;
-            const replica_address = Address.parseIp("127.0.0.1", replica_port) catch unreachable;
-            const listen_address = Address.parseIp("127.0.0.1", 0) catch unreachable;
-            const listen_fd = try io.open_socket_tcp(std.posix.AF.INET, tcp_options);
+            const replica_address: stdx.SocketAddress = .{
+                .ip = .@"127.0.0.1",
+                .port = replica_port,
+            };
+            const listen_address: stdx.SocketAddress = .{ .ip = .@"127.0.0.1", .port = 0 };
+            const listen_fd = try io.open_socket_tcp(.IPv4, tcp_options);
             errdefer io.close_socket(listen_fd);
 
             const origin_address = try io.listen(listen_fd, listen_address, .{ .backlog = 64 });

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -191,9 +191,9 @@ pub const Supervisor = struct {
             var replica_ports: [constants.vsr.replicas_max]u16 = undefined;
             for (replica_ports[0..options.replica_count], 0..) |*replica_port, i| {
                 if (replica_index == i) {
-                    replica_port.* = network.proxies[i].remote_address.getPort();
+                    replica_port.* = network.proxies[i].remote_address.port;
                 } else {
-                    replica_port.* = network.proxies[i].origin_address.getPort();
+                    replica_port.* = network.proxies[i].origin_address.port;
                 }
             }
 
@@ -656,7 +656,7 @@ pub const Supervisor = struct {
 
         var proxy_ports_all: [constants.vsr.replicas_max]u16 = undefined;
         for (proxy_ports_all[0..supervisor.options.replica_count], 0..) |*port, i| {
-            port.* = supervisor.network.proxies[i].origin_address.getPort();
+            port.* = supervisor.network.proxies[i].origin_address.port;
         }
         const proxy_ports = proxy_ports_all[0..supervisor.options.replica_count];
 

--- a/src/tigerbeetle/benchmark_driver.zig
+++ b/src/tigerbeetle/benchmark_driver.zig
@@ -86,7 +86,7 @@ pub fn command_benchmark(
     }
 
     const addresses = if (args.addresses) |*addresses|
-        addresses.const_slice()
+        addresses.slice()
     else
         &.{tigerbeetle_process.?.address};
     try benchmark_load.main(allocator, io, time, addresses, args);
@@ -140,7 +140,7 @@ fn format(allocator: std.mem.Allocator, options: struct {
 
 const TigerBeetleProcess = struct {
     child: std.process.Child,
-    address: std.net.Address,
+    address: stdx.SocketAddress,
 
     fn deinit(self: *TigerBeetleProcess) std.process.Child.ResourceUsageStatistics {
         // Although we could just kill the child here, let's exercise the "normal" termination logic
@@ -222,7 +222,10 @@ fn start(allocator: std.mem.Allocator, options: struct {
         break :port try stdx.parse_int(u16, port_buf[0 .. port_buf_len - 1], .{});
     };
 
-    const address = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, port);
+    const address: stdx.SocketAddress = .{
+        .ip = .@"127.0.0.1",
+        .port = port,
+    };
 
     return .{ .child = child, .address = address };
 }

--- a/src/tigerbeetle/benchmark_load.zig
+++ b/src/tigerbeetle/benchmark_load.zig
@@ -39,7 +39,7 @@ pub fn main(
     allocator: std.mem.Allocator,
     io: *IO,
     time: Time,
-    addresses: []const std.net.Address,
+    addresses: []const stdx.SocketAddress,
     cli_args: *const cli.Command.Benchmark,
 ) !void {
     if (builtin.mode != .ReleaseSafe and builtin.mode != .ReleaseFast) {

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -1358,39 +1358,6 @@ fn parse_args_amqp(amqp: CLIArgs.AMQP) Command.AMQP {
     };
 }
 
-/// Parse and allocate the addresses returning a slice into that array.
-fn parse_addresses(
-    raw_addresses: []const u8,
-    comptime flag: []const u8,
-    comptime BoundedArray: type,
-) BoundedArray {
-    comptime assert(std.mem.startsWith(u8, flag, "--"));
-    var result: BoundedArray = .{};
-
-    const addresses_parsed = vsr.parse_addresses(
-        raw_addresses,
-        result.unused_capacity_slice(),
-    ) catch |err| switch (err) {
-        error.AddressHasTrailingComma => {
-            vsr.fatal(.cli, flag ++ ": invalid trailing comma", .{});
-        },
-        error.AddressLimitExceeded => {
-            vsr.fatal(.cli, flag ++ ": too many addresses, at most {d} are allowed", .{
-                result.capacity(),
-            });
-        },
-        error.AddressHasMoreThanOneColon => {
-            vsr.fatal(.cli, flag ++ ": invalid address with more than one colon", .{});
-        },
-        error.PortInvalid => vsr.fatal(.cli, flag ++ ": invalid port", .{}),
-        error.AddressInvalid => vsr.fatal(.cli, flag ++ ": invalid IPv4 or IPv6 address", .{}),
-    };
-    assert(addresses_parsed.len > 0);
-    assert(addresses_parsed.len <= result.capacity());
-    result.resize(addresses_parsed.len) catch unreachable;
-    return result;
-}
-
 fn parse_address_and_port(
     raw_address: []const u8,
     comptime flag: []const u8,
@@ -1398,7 +1365,7 @@ fn parse_address_and_port(
 ) stdx.SocketAddress {
     comptime assert(std.mem.startsWith(u8, flag, "--"));
 
-    const address = vsr.parse_address_and_port(.{
+    return vsr.parse_address_and_port(.{
         .string = raw_address,
         .port_default = port_default,
     }) catch |err| switch (err) {
@@ -1407,11 +1374,6 @@ fn parse_address_and_port(
         },
         error.PortInvalid => vsr.fatal(.cli, flag ++ ": invalid port", .{}),
         error.AddressInvalid => vsr.fatal(.cli, flag ++ ": invalid IPv4 or IPv6 address", .{}),
-    };
-    return stdx.SocketAddress.from_std(address) catch |err| switch (err) {
-        error.UnsupportedFamily => {
-            vsr.fatal(.cli, flag ++ ": invalid IPv4 or IPv6 address", .{});
-        },
     };
 }
 

--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -14,7 +14,6 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const fmt = std.fmt;
-const net = std.net;
 
 const vsr = @import("vsr");
 const stdx = vsr.stdx;
@@ -52,7 +51,7 @@ const CLIArgs = union(enum) {
 
     const Recover = struct {
         cluster: u128,
-        addresses: []const u8,
+        addresses: vsr.ClusterAddress,
         replica: u8,
         replica_count: u8,
         development: bool = false,
@@ -64,7 +63,7 @@ const CLIArgs = union(enum) {
 
     const Start = struct {
         // Stable CLI arguments.
-        addresses: []const u8,
+        addresses: vsr.ClusterAddress,
         cache_grid: ?ByteSize = null,
         development: bool = false,
 
@@ -121,7 +120,7 @@ const CLIArgs = union(enum) {
     };
 
     const Repl = struct {
-        addresses: []const u8,
+        addresses: vsr.ClusterAddress,
         cluster: u128,
         verbose: bool = false,
         command: []const u8 = "",
@@ -162,7 +161,7 @@ const CLIArgs = union(enum) {
         trace: ?[]const u8 = null,
         /// When set, don't delete the data file when the benchmark completes.
         file: ?[]const u8 = null,
-        addresses: ?[]const u8 = null,
+        addresses: ?vsr.ClusterAddress = null,
         seed: ?[]const u8 = null,
     };
 
@@ -314,7 +313,7 @@ const CLIArgs = union(enum) {
 
     // CDC connector for AMQP targets.
     const AMQP = struct {
-        addresses: []const u8,
+        addresses: vsr.ClusterAddress,
         cluster: u128,
         host: []const u8,
         user: []const u8,
@@ -503,7 +502,6 @@ const lsm_compaction_block_memory_min = lsm_compaction_block_count_min * constan
 /// While CLIArgs store raw arguments as passed on the command line, Command ensures that arguments
 /// are properly validated and desugared (e.g, sizes converted to counts where appropriate).
 pub const Command = union(enum) {
-    const Addresses = stdx.BoundedArrayType(std.net.Address, constants.members_max);
     const Path = stdx.BoundedArrayType(u8, std.fs.max_path_bytes);
 
     pub const Format = struct {
@@ -517,7 +515,7 @@ pub const Command = union(enum) {
 
     pub const Recover = struct {
         cluster: u128,
-        addresses: Addresses,
+        addresses: vsr.ClusterAddress,
         replica: u8,
         replica_count: u8,
         development: bool,
@@ -526,11 +524,7 @@ pub const Command = union(enum) {
     };
 
     pub const Start = struct {
-        addresses: Addresses,
-        // true when the value of `--addresses` is exactly `0`. Used to enable "magic zero" mode for
-        // testing. We check the raw string rather then the parsed address to prevent triggering
-        // this logic by accident.
-        addresses_zero: bool,
+        addresses: vsr.ClusterAddress,
         cache_accounts: u32,
         cache_transfers: u32,
         cache_transfers_pending: u32,
@@ -555,7 +549,7 @@ pub const Command = union(enum) {
         path: []const u8,
         log_debug: bool,
         log_trace: bool,
-        statsd: ?std.net.Address,
+        statsd: ?stdx.SocketAddress,
     };
 
     pub const Version = struct {
@@ -563,7 +557,7 @@ pub const Command = union(enum) {
     };
 
     pub const Repl = struct {
-        addresses: Addresses,
+        addresses: vsr.ClusterAddress,
         cluster: u128,
         verbose: bool,
         statements: []const u8,
@@ -619,7 +613,7 @@ pub const Command = union(enum) {
         statsd: ?[]const u8,
         trace: ?[]const u8,
         file: ?[]const u8,
-        addresses: ?Addresses,
+        addresses: ?vsr.ClusterAddress,
         seed: ?[]const u8,
     };
 
@@ -673,9 +667,9 @@ pub const Command = union(enum) {
     };
 
     pub const AMQP = struct {
-        addresses: Addresses,
+        addresses: vsr.ClusterAddress,
         cluster: u128,
-        host: std.net.Address,
+        host: stdx.SocketAddress,
         user: []const u8,
         password: []const u8,
         vhost: []const u8,
@@ -814,7 +808,7 @@ fn parse_args_recover(recover: CLIArgs.Recover) Command.Recover {
 
     return .{
         .cluster = recover.cluster,
-        .addresses = parse_addresses(recover.addresses, "--addresses", Command.Addresses),
+        .addresses = recover.addresses,
         .replica = replica,
         .replica_count = recover.replica_count,
         .development = recover.development,
@@ -868,7 +862,6 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
     const TransfersValuesCache = groove_config.transfers.ObjectsCache.Cache;
     const TransfersPendingValuesCache = groove_config.transfers_pending.ObjectsCache.Cache;
 
-    const addresses = parse_addresses(start.addresses, "--addresses", Command.Addresses);
     const defaults =
         if (start.development) start_defaults_development else start_defaults_production;
 
@@ -1050,8 +1043,7 @@ fn parse_args_start(start: CLIArgs.Start) Command.Start {
     }
 
     return .{
-        .addresses = addresses,
-        .addresses_zero = std.mem.eql(u8, start.addresses, "0"),
+        .addresses = start.addresses,
         .storage_size_limit = storage_size_limit,
         .pipeline_requests_limit = pipeline_limit,
         .request_size_limit = @intCast(request_size_limit.bytes()),
@@ -1116,10 +1108,8 @@ fn parse_args_version(version: CLIArgs.Version) Command.Version {
 }
 
 fn parse_args_repl(repl: CLIArgs.Repl) Command.Repl {
-    const addresses = parse_addresses(repl.addresses, "--addresses", Command.Addresses);
-
     return .{
-        .addresses = addresses,
+        .addresses = repl.addresses,
         .cluster = repl.cluster,
         .verbose = repl.verbose,
         .statements = repl.command,
@@ -1138,11 +1128,6 @@ const transfer_batch_count_max = @divExact(
 );
 
 fn parse_args_benchmark(benchmark: CLIArgs.Benchmark) Command.Benchmark {
-    const addresses = if (benchmark.addresses) |addresses|
-        parse_addresses(addresses, "--addresses", Command.Addresses)
-    else
-        null;
-
     if (benchmark.addresses != null and benchmark.file != null) {
         vsr.fatal(.cli, "--file: --addresses and --file are mutually exclusive", .{});
     }
@@ -1198,7 +1183,7 @@ fn parse_args_benchmark(benchmark: CLIArgs.Benchmark) Command.Benchmark {
         .statsd = benchmark.statsd,
         .trace = benchmark.trace,
         .file = benchmark.file,
-        .addresses = addresses,
+        .addresses = benchmark.addresses,
         .seed = benchmark.seed,
     };
 }
@@ -1300,7 +1285,6 @@ fn parse_args_multiversion(multiversion: CLIArgs.Multiversion) Command.Multivers
 }
 
 fn parse_args_amqp(amqp: CLIArgs.AMQP) Command.AMQP {
-    const addresses = parse_addresses(amqp.addresses, "--addresses", Command.Addresses);
     const host = parse_address_and_port(
         amqp.host,
         "--host",
@@ -1356,7 +1340,7 @@ fn parse_args_amqp(amqp: CLIArgs.AMQP) Command.AMQP {
     }
 
     return .{
-        .addresses = addresses,
+        .addresses = amqp.addresses,
         .cluster = amqp.cluster,
         .host = host,
         .user = amqp.user,
@@ -1411,7 +1395,7 @@ fn parse_address_and_port(
     raw_address: []const u8,
     comptime flag: []const u8,
     port_default: u16,
-) std.net.Address {
+) stdx.SocketAddress {
     comptime assert(std.mem.startsWith(u8, flag, "--"));
 
     const address = vsr.parse_address_and_port(.{
@@ -1424,7 +1408,11 @@ fn parse_address_and_port(
         error.PortInvalid => vsr.fatal(.cli, flag ++ ": invalid port", .{}),
         error.AddressInvalid => vsr.fatal(.cli, flag ++ ": invalid IPv4 or IPv6 address", .{}),
     };
-    return address;
+    return stdx.SocketAddress.from_std(address) catch |err| switch (err) {
+        error.UnsupportedFamily => {
+            vsr.fatal(.cli, flag ++ ": invalid IPv4 or IPv6 address", .{});
+        },
+    };
 }
 
 /// Given a limit like `10GiB`, a SetAssociativeCache and T return the largest `value_count_max`

--- a/src/tigerbeetle/main.zig
+++ b/src/tigerbeetle/main.zig
@@ -109,7 +109,7 @@ pub fn main() !void {
     var trace_file: ?std.fs.File = null;
     defer if (trace_file) |file| file.close();
 
-    var statsd_address: ?std.net.Address = null;
+    var statsd_address: ?stdx.SocketAddress = null;
     var log_trace = true;
 
     switch (command) {
@@ -263,7 +263,7 @@ fn command_start(
     // (Here or in Replica.open()?).
 
     var message_pool = try MessagePool.init(gpa, .{ .replica = .{
-        .members_count = args.addresses.count_as(u8),
+        .members_count = args.addresses.members_count(),
         .pipeline_requests_limit = args.pipeline_requests_limit,
         .message_bus = .tcp,
     } });
@@ -322,7 +322,7 @@ fn command_start(
             break :blk .single_release(constants.config.process.release);
         }
 
-        if (args.addresses_zero) {
+        if (args.addresses.zero) {
             log.info("multiversioning: upgrades disabled due to --addresses=0", .{});
             break :blk .single_release(constants.config.process.release);
         }
@@ -355,7 +355,7 @@ fn command_start(
         storage,
         &message_pool,
         .{
-            .node_count = args.addresses.count_as(u8),
+            .node_count = args.addresses.members_count(),
             .release = config.process.release,
             .release_client_min = config.process.release_client_min,
             .multiversion = multiversion,
@@ -381,7 +381,7 @@ fn command_start(
                 .aof_recovery = args.aof_recovery,
             },
             .message_bus_options = .{
-                .configuration = args.addresses.const_slice(),
+                .configuration = args.addresses.slice(),
                 .io = io,
                 .trace = tracer,
                 .time = time,
@@ -465,8 +465,8 @@ fn command_start(
     // - The port, and only the port, is printed to the stdout, so that the parent process
     //   can learn it.
     // - tigerbeetle process exits when its stdin gets closed.
-    if (args.addresses_zero) {
-        const port_actual = replica.message_bus.accept_address.?.getPort();
+    if (args.addresses.zero) {
+        const port_actual = replica.message_bus.accept_address.?.port;
         const stdout = std.io.getStdOut();
         try stdout.writer().print("{}\n", .{port_actual});
         stdout.close();
@@ -546,7 +546,7 @@ fn command_reformat(
             .aof_recovery = false,
 
             .message_bus_options = .{
-                .configuration = args.addresses.const_slice(),
+                .configuration = args.addresses.slice(),
                 .io = io,
                 .trace = null,
                 .time = time,
@@ -597,7 +597,7 @@ fn command_repl(
 
     var repl_instance = try Repl.init(gpa, io, time, .{
         .cluster_id = args.cluster,
-        .addresses = args.addresses.const_slice(),
+        .addresses = args.addresses.slice(),
         .verbose = args.verbose,
     });
     defer repl_instance.deinit(gpa);
@@ -612,7 +612,7 @@ fn command_amqp(gpa: mem.Allocator, time: Time, args: *const cli.Command.AMQP) !
         time,
         .{
             .cluster_id = args.cluster,
-            .addresses = args.addresses.const_slice(),
+            .addresses = args.addresses.slice(),
             .host = args.host,
             .user = args.user,
             .password = args.password,

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -167,7 +167,7 @@ pub const Options = struct {
         log,
         udp: struct {
             io: *IO,
-            address: std.net.Address,
+            address: stdx.SocketAddress,
         },
     } = .log,
     log_trace: bool = true,

--- a/src/trace/statsd.zig
+++ b/src/trace/statsd.zig
@@ -132,16 +132,17 @@ pub const StatsD = struct {
         allocator: std.mem.Allocator,
         process_id: ProcessID,
         io: *IO,
-        address: std.net.Address,
+        address: stdx.SocketAddress,
     ) !StatsD {
-        const socket = try io.open_socket_udp(address.any.family);
+        const socket = try io.open_socket_udp(address.ip.family());
         errdefer io.close_socket(socket);
 
         const send_buffer = try allocator.create([packet_count_max * packet_size_max]u8);
         errdefer allocator.destroy(send_buffer);
 
+        const address_std = address.to_std();
         // 'Connect' the UDP socket, so we can just send() to it normally.
-        try std.posix.connect(socket, &address.any, address.getOsSockLen());
+        try std.posix.connect(socket, &address_std.any, address_std.getOsSockLen());
 
         log.info("{}: sending statsd metrics to {}", .{ process_id, address });
 

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -996,11 +996,11 @@ fn parse_address(string: []const u8) !stdx.IPAddress {
     if (string[string.len - 1] == ':') return error.AddressHasMoreThanOneColon;
 
     const expect_v6 = string[0] == '[' and string[string.len - 1] == ']';
+    if (expect_v6 != (std.mem.indexOfScalar(u8, string, ':') != null)) return error.AddressInvalid;
     const ip = if (expect_v6)
         stdx.IPAddress.parse(string[1 .. string.len - 1]) catch return error.AddressInvalid
     else
         stdx.IPAddress.parse(string) catch return error.AddressInvalid;
-    if ((ip.family() == .IPv6) != expect_v6) return error.AddressInvalid;
     return ip;
 }
 
@@ -1084,6 +1084,13 @@ test parse_addresses {
                     0,
                     0,
                 ),
+            },
+        },
+        .{
+            // Test IPv6-mapped IPv4 address.
+            .raw = "[::ffff:7f00:1]:1234",
+            .addresses = &[_]std.net.Address{
+                std.net.Address.initIp4([_]u8{ 127, 0, 0, 1 }, 1234),
             },
         },
     };

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -956,13 +956,10 @@ pub fn parse_addresses(
     while (comma_iterator.next()) |raw_address| : (index += 1) {
         assert(index < out_buffer.len);
         if (raw_address.len == 0) return error.AddressHasTrailingComma;
-        const address_std = try parse_address_and_port(.{
+        out_buffer[index] = try parse_address_and_port(.{
             .string = raw_address,
             .port_default = constants.port,
         });
-        out_buffer[index] = stdx.SocketAddress.from_std(address_std) catch |err| switch (err) {
-            error.UnsupportedFamily => return error.AddressInvalid,
-        };
     }
     assert(index == address_count);
 
@@ -972,39 +969,39 @@ pub fn parse_addresses(
 pub fn parse_address_and_port(options: struct {
     string: []const u8,
     port_default: u16,
-}) !std.net.Address {
+}) !stdx.SocketAddress {
     assert(options.string.len > 0);
     assert(options.port_default > 0);
 
     if (std.mem.lastIndexOfAny(u8, options.string, ":.]")) |split| {
         if (options.string[split] == ':') {
-            return parse_address(
-                options.string[0..split],
-                stdx.parse_int(u16, options.string[split + 1 ..], .{}) catch
-                    return error.PortInvalid,
-            );
+            const port = stdx.parse_int(u16, options.string[split + 1 ..], .{}) catch
+                return error.PortInvalid;
+            const ip = try parse_address(options.string[0..split]);
+            return .{ .ip = ip, .port = port };
         } else {
-            return parse_address(options.string, options.port_default);
+            const ip = try parse_address(options.string);
+            return .{ .ip = ip, .port = options.port_default };
         }
     } else {
-        return std.net.Address.parseIp4(
-            constants.address,
-            stdx.parse_int(u16, options.string, .{}) catch
-                return error.PortInvalid,
-        ) catch unreachable;
+        const ip = comptime stdx.IPAddress.parse(constants.address) catch unreachable;
+        const port = stdx.parse_int(u16, options.string, .{}) catch return error.PortInvalid;
+        return .{ .ip = ip, .port = port };
     }
 }
 
-fn parse_address(string: []const u8, port: u16) !std.net.Address {
+// A variation of stdx.IPAddress.parse that requires `[]` around IPv6 addresses.
+fn parse_address(string: []const u8) !stdx.IPAddress {
     if (string.len == 0) return error.AddressInvalid;
     if (string[string.len - 1] == ':') return error.AddressHasMoreThanOneColon;
 
-    if (string[0] == '[' and string[string.len - 1] == ']') {
-        return std.net.Address.parseIp6(string[1 .. string.len - 1], port) catch
-            return error.AddressInvalid;
-    } else {
-        return std.net.Address.parseIp4(string, port) catch return error.AddressInvalid;
-    }
+    const expect_v6 = string[0] == '[' and string[string.len - 1] == ']';
+    const ip = if (expect_v6)
+        stdx.IPAddress.parse(string[1 .. string.len - 1]) catch return error.AddressInvalid
+    else
+        stdx.IPAddress.parse(string) catch return error.AddressInvalid;
+    if ((ip.family() == .IPv6) != expect_v6) return error.AddressInvalid;
+    return ip;
 }
 
 test parse_addresses {
@@ -1099,6 +1096,8 @@ test parse_addresses {
         .{ .raw = ".", .err = error.AddressInvalid },
         .{ .raw = ":", .err = error.PortInvalid },
         .{ .raw = ":92", .err = error.AddressInvalid },
+        .{ .raw = "[127.0.0.1]", .err = error.AddressInvalid },
+        .{ .raw = "[127.0.0.1]:3001", .err = error.AddressInvalid },
         .{ .raw = "::ff:92", .err = error.AddressInvalid },
         .{ .raw = "1.2.3.4:5,2.3.4.5:6,4.5.6.7:8", .err = error.AddressLimitExceeded },
         .{ .raw = "1.2.3.4:7777,", .err = error.AddressHasTrailingComma },
@@ -1125,6 +1124,7 @@ test parse_addresses {
     }
 
     for (vectors_negative) |vector| {
+        errdefer log.err("raw = '{s}', err = {any}", .{ vector.raw, vector.err });
         try std.testing.expectEqual(
             vector.err,
             parse_addresses(vector.raw, buffer[0..2]),

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -997,11 +997,9 @@ fn parse_address(string: []const u8) !stdx.IPAddress {
 
     const expect_v6 = string[0] == '[' and string[string.len - 1] == ']';
     if (expect_v6 != (std.mem.indexOfScalar(u8, string, ':') != null)) return error.AddressInvalid;
-    const ip = if (expect_v6)
-        stdx.IPAddress.parse(string[1 .. string.len - 1]) catch return error.AddressInvalid
-    else
-        stdx.IPAddress.parse(string) catch return error.AddressInvalid;
-    return ip;
+
+    const string_inner = if (expect_v6) string[1 .. string.len - 1] else string;
+    return stdx.IPAddress.parse(string_inner) catch error.AddressInvalid;
 }
 
 test parse_addresses {

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -891,6 +891,52 @@ test "exponential_backoff_with_jitter" {
     }
 }
 
+pub const ClusterAddress = struct {
+    array: stdx.BoundedArrayType(stdx.SocketAddress, constants.members_max),
+    // true when the value of `--addresses` is exactly `0`. Used to enable "magic zero" mode for
+    // testing. We check the raw string rather than the parsed address to prevent triggering
+    // this logic by accident.
+    zero: bool,
+
+    pub fn slice(address: *const ClusterAddress) []const stdx.SocketAddress {
+        return address.array.const_slice();
+    }
+
+    pub fn members_count(address: *const ClusterAddress) u8 {
+        return address.array.count_as(u8);
+    }
+
+    pub fn parse_flag_value(
+        text: []const u8,
+        static_diagnostic: *?[]const u8,
+    ) error{InvalidFlagValue}!ClusterAddress {
+        var result: ClusterAddress = .{
+            .array = .{},
+            .zero = std.mem.eql(u8, text, "0"),
+        };
+        const parsed = parse_addresses(text, result.array.unused_capacity_slice()) catch |err| {
+            static_diagnostic.* = switch (err) {
+                error.AddressHasTrailingComma => "invalid trailing comma:",
+                error.AddressLimitExceeded => std.fmt.comptimePrint(
+                    "too many addresses, at most {d} are allowed:",
+                    .{constants.members_max},
+                ),
+                error.AddressHasMoreThanOneColon => "invalid address with more than one colon:",
+                error.PortInvalid => "invalid port:",
+                error.AddressInvalid => "invalid IPv4 or IPv6 address:",
+            };
+            return error.InvalidFlagValue;
+        };
+        result.array.resize(parsed.len) catch |err| switch (err) {
+            error.Overflow => unreachable,
+        };
+        assert(result.array.slice().len == parsed.len);
+        assert(result.array.count() > 0);
+        assert(result.array.count() <= constants.members_max);
+        return result;
+    }
+};
+
 /// Returns An array containing the remote or local addresses of each of the 2f + 1 replicas:
 /// Unlike the VRR paper, we do not sort the array but leave the order explicitly to the user.
 /// There are several advantages to this:
@@ -900,8 +946,8 @@ test "exponential_backoff_with_jitter" {
 /// The caller owns the memory of the returned slice of addresses.
 pub fn parse_addresses(
     raw: []const u8,
-    out_buffer: []std.net.Address,
-) ![]std.net.Address {
+    out_buffer: []stdx.SocketAddress,
+) ![]stdx.SocketAddress {
     const address_count = std.mem.count(u8, raw, ",") + 1;
     if (address_count > out_buffer.len) return error.AddressLimitExceeded;
 
@@ -910,10 +956,13 @@ pub fn parse_addresses(
     while (comma_iterator.next()) |raw_address| : (index += 1) {
         assert(index < out_buffer.len);
         if (raw_address.len == 0) return error.AddressHasTrailingComma;
-        out_buffer[index] = try parse_address_and_port(.{
+        const address_std = try parse_address_and_port(.{
             .string = raw_address,
             .port_default = constants.port,
         });
+        out_buffer[index] = stdx.SocketAddress.from_std(address_std) catch |err| switch (err) {
+            error.UnsupportedFamily => return error.AddressInvalid,
+        };
     }
     assert(index == address_count);
 
@@ -1044,7 +1093,7 @@ test parse_addresses {
 
     const vectors_negative = &[_]struct {
         raw: []const u8,
-        err: anyerror![]std.net.Address,
+        err: anyerror![]stdx.SocketAddress,
     }{
         .{ .raw = "", .err = error.AddressHasTrailingComma },
         .{ .raw = ".", .err = error.AddressInvalid },
@@ -1063,17 +1112,15 @@ test parse_addresses {
         .{ .raw = "1.2.3.4:5,2.3.4.5:65536", .err = error.PortInvalid },
     };
 
-    var buffer: [3]std.net.Address = undefined;
+    var buffer: [3]stdx.SocketAddress = undefined;
     for (vectors_positive) |vector| {
         const addresses_actual = try parse_addresses(vector.raw, &buffer);
 
         try std.testing.expectEqual(addresses_actual.len, vector.addresses.len);
-        for (vector.addresses, 0..) |address_expect, i| {
+        for (vector.addresses, 0..) |address_expect_std, i| {
             const address_actual = addresses_actual[i];
-            try std.testing.expectEqual(address_expect.in.sa.family, address_actual.in.sa.family);
-            try std.testing.expectEqual(address_expect.in.sa.port, address_actual.in.sa.port);
-            try std.testing.expectEqual(address_expect.in.sa.addr, address_actual.in.sa.addr);
-            try std.testing.expectEqual(address_expect.in.sa.zero, address_actual.in.sa.zero);
+            const address_expect = try stdx.SocketAddress.from_std(address_expect_std);
+            try std.testing.expectEqual(address_expect, address_actual);
         }
     }
 
@@ -1093,7 +1140,7 @@ test "parse_addresses: fuzz" {
     var prng = stdx.PRNG.from_seed_testing();
 
     var input_buffer: [input_size_max]u8 = @splat(0);
-    var buffer: [3]std.net.Address = undefined;
+    var buffer: [3]stdx.SocketAddress = undefined;
     for (0..test_count) |_| {
         const input_size = prng.int_inclusive(usize, input_size_max);
         const input = input_buffer[0..input_size];


### PR DESCRIPTION
std.net.Address is physical, what we use to talk to OS. stdx.SocketAddress is logical, what we use to talk with other processes (and humans on the CLI). 

The rule is that you should use `stdx.SocketAddress` pretty much everywhere, except when doing a syscall, and the only place doing syscalls should ideally be our IO. Note that at the IO _interface_ we use `SocketAddress`