### PR TITLE
CFO: Debug vortex build network flake

### DIFF
--- a/src/build/fetch.zig
+++ b/src/build/fetch.zig
@@ -77,14 +77,29 @@ fn fetch(arena: Allocator, options: struct {
         try std.fs.cwd().makePath(tmp_dir);
 
         const curl_output = path_join(arena, &.{ tmp_dir, url_file_name });
-        _ = try stdb.exec(arena, &(.{
-            "curl",             "--retry-all-errors",
-            "--retry",          "5",
-            "--retry-max-time", "120",
-            "--retry-delay",    "30",
-            "--location",       options.url,
-            "--output",         curl_output,
-        }));
+        // TODO Go back to using stdb.exec once this curl/zip issue is debugged.
+        const curl_result = std.process.Child.run(.{
+            .allocator = arena,
+            .argv = &(.{
+                "curl",             "--retry-all-errors",
+                "--retry",          "5",
+                "--retry-max-time", "120",
+                "--retry-delay",    "30",
+                "--location",       options.url,
+                "--output",         curl_output,
+                "--verbose",
+            }),
+            .max_output_bytes = 1024 * 1024,
+        }) catch |err| {
+            log.err("curl error: {}", .{err});
+            return err;
+        };
+        errdefer log.err("curl stderr: {s}\n\ncurl stderr end", .{curl_result.stderr});
+
+        if (!(curl_result.term == .Exited and curl_result.term.Exited == 0)) {
+            log.err("curl error: {}", .{curl_result.term});
+            return error.Exec;
+        }
         return try stdb.exec(arena, &.{ options.zig, "fetch", curl_output });
     }
     log.debug("download: zig fetch", .{});


### PR DESCRIPTION
CFO occasionally fails to build vortex due to some sort of network flake while it is downloading one of the Vortex dependencies.

From looking at the logs + code I am not seeing how this particular flake is possible, unless GitHub releases http server is seriously misbehaving. (e.g. returning the wrong/truncated data while reporting success)

- It fails during build on the `zig fetch` with `ZipNoEndRecord` -- so presumably the zip file was truncated somehow.
- But we are using `curl` to download + write the file. If curl was reporting an error it wouldn't `zig fetch` at all, so `curl` must be reporting success.
- The flake tends to occur in bursts of ~10 minutes. (I originally guessed this was related to build caching, but have ruled that out.)

To troubleshoot, add `--verbose` to `curl` and log that stderr on any error. This will be quite noisy when it happens, but adding this temporarily will help shed some light on this flake.