### PR TITLE
vsr: tweak stall logic.

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -4783,7 +4783,8 @@ pub fn ReplicaType(
                 for (
                     self.commit_mins[0..self.replica_count],
                     self.head_ops[0..self.replica_count],
-                ) |commit_min, op| {
+                ) |commit_min, op_head| {
+                    const op = @min(op_head, self.commit_min);
                     // Don't stall on account of replicas that are more than
                     // three checkpoints behind, they may be down/partitioned.
                     // Default to three checkpoints as in that case we are


### PR DESCRIPTION
We observed a performance regression when increasing the number of clients from 7 to 8. The root cause was that our mechanism for detecting lagging replicas did not fully account for  the fact that prepares that are not "expected" to be committed.