### PR TITLE
stdx: add FuzzIterations abstraction

### DIFF
--- a/src/stdx/flags.zig
+++ b/src/stdx/flags.zig
@@ -546,7 +546,6 @@ pub fn parse_flag_value_fuzz(
 ) !void {
     comptime assert(T.parse_flag_value == parse_flag_value);
 
-    const test_count = 50_000;
     const string_size_max = 32;
 
     const gpa = std.testing.allocator;
@@ -599,7 +598,9 @@ pub fn parse_flag_value_fuzz(
     const alphabet = stdx.unique(corpus.items);
 
     var string_buffer: [string_size_max]u8 = @splat(0);
-    for (0..test_count) |_| {
+
+    var iterations: stdx.PRNG.FuzzIterations = .{};
+    while (iterations.more()) {
         const string_size = prng.range_inclusive(usize, 1, string_size_max);
         const string = string_buffer[0..string_size];
         assert(string.len > 0);

--- a/src/stdx/prng.zig
+++ b/src/stdx/prng.zig
@@ -14,6 +14,7 @@
 //! - simplify and extend the API
 //! - remove dynamic-dispatch indirection (a minor bonus).
 
+const builtin = @import("builtin");
 const std = @import("std");
 const stdx = @import("stdx.zig");
 const assert = std.debug.assert;
@@ -681,3 +682,29 @@ test "no floating point please" {
     assert(std.mem.indexOf(u8, file_text, "f" ++ "32") == null);
     assert(std.mem.indexOf(u8, file_text, "f" ++ "64") == null);
 }
+
+// Automatically determine a reasonable amount of iterations for a unit fuzz-test, based on time.
+pub const FuzzIterations = struct {
+    // Don't inject time for test-only code.
+    timer: ?std.time.Timer = null,
+    iteration: u32 = 0,
+
+    iterations_min: u32 = 10,
+    duration_max: stdx.Duration = .ms(100),
+
+    pub fn more(clock: *FuzzIterations) bool {
+        comptime assert(builtin.is_test);
+        if (clock.timer == null) {
+            clock.timer = std.time.Timer.start() catch @panic("timer failed");
+        }
+
+        if (clock.iteration > clock.iterations_min and
+            clock.timer.?.read() > clock.duration_max.ns)
+        {
+            return false;
+        }
+
+        clock.iteration += 1;
+        return true;
+    }
+};


### PR DESCRIPTION
Ever wondered just how long should you spin your fuzzer? Never more, just use FuzzIterations to get the answer!

I still don't know _what_ the answer should be though, but 100ms per test seems like a good default, and the neat thing is that we can always fix this later!