### PR TITLE
inspect: fix metrics with multiple tag fields

### DIFF
--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -290,7 +290,7 @@ fn inspect_metrics(output: std.io.AnyWriter) !void {
         try output.print("gauge: {s}(", .{field.name});
         if (field.type != void) {
             inline for (std.meta.fields(field.type), 0..) |data_field, i| {
-                if (i != 0) try output.print(", ");
+                if (i != 0) try output.print(", ", .{});
                 try output.print("{s}", .{data_field.name});
             }
         }
@@ -303,7 +303,7 @@ fn inspect_metrics(output: std.io.AnyWriter) !void {
         try output.print("timing: {s}(", .{field.name});
         if (field.type != void) {
             inline for (std.meta.fields(field.type), 0..) |data_field, i| {
-                if (i != 0) try output.print(", ");
+                if (i != 0) try output.print(", ", .{});
                 try output.print("{s}", .{data_field.name});
             }
         }


### PR DESCRIPTION
While debugging something I noticed that `inspect_metrics` hits a latent bug in an assertion when called with an `EventMetrics` or `EventTiming` variant whose payload type is not `void`, and whose struct has at least two fields.

The Zig `Writer.print` signature is:

```zig
output.print(comptime format: []const u8, args: anytype)
```

so the calls should be:

```zig
output.print(", ", .{})
```