### PR TITLE
trace: fix TypeInfo int field access

### DIFF
--- a/src/trace/statsd.zig
+++ b/src/trace/statsd.zig
@@ -436,7 +436,7 @@ fn struct_size_max(StructOrVoid: type) StructOrVoid {
     for (std.meta.fields(Struct)) |field| {
         const type_info = @typeInfo(field.type);
         assert(type_info == .int or type_info == .@"enum");
-        assert(type_info != .int or type_info.Int.signedness == .unsigned);
+        assert(type_info != .int or type_info.int.signedness == .unsigned);
         switch (type_info) {
             .int => @field(output, field.name) = std.math.maxInt(field.type),
             .@"enum" => @field(output, field.name) =


### PR DESCRIPTION
Another one encountered while debugging: `@typeInfo()`'s integer payload is accessed as `.int` with the current Zig API.