### PR TITLE
Revert unique keys.

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -36,7 +36,6 @@ const FuzzOpAction = union(enum) {
     remove: u128,
     get_by_id: UniqueKey,
     get_by_timestamp: UniqueKey,
-    get_by_pending_id: UniqueKey,
     scan: ScanParams,
 };
 const FuzzOpActionTag = std.meta.Tag(FuzzOpAction);
@@ -554,7 +553,6 @@ const Environment = struct {
                     .timestamp => |timestamp| ObjectTable.key_from_value(
                         &entry.transfer,
                     ) == timestamp,
-                    .pending_id => |id| id != 0 and entry.transfer.pending_id == id,
                 }) {
                     if (ObjectTable.tombstone(&entry.transfer)) return .tombstone;
                     return .{ .found = entry.transfer };
@@ -579,21 +577,12 @@ const Environment = struct {
                     assert(model.checkpointed.unique_keys.remove(.{
                         .timestamp = ObjectTable.key_from_value(&entry.transfer),
                     }));
-                    if (entry.transfer.pending_id != 0) {
-                        assert(model.checkpointed.unique_keys.remove(.{
-                            .pending_id = entry.transfer.pending_id,
-                        }));
-                    }
                     continue;
                 }
 
                 try model.checkpointed.objects.put(entry.transfer.id, entry.transfer);
                 try model.checkpointed.unique_keys.put(
                     .{ .timestamp = entry.transfer.timestamp },
-                    entry.transfer.id,
-                );
-                if (entry.transfer.pending_id != 0) try model.checkpointed.unique_keys.put(
-                    .{ .pending_id = entry.transfer.pending_id },
                     entry.transfer.id,
                 );
             }
@@ -768,7 +757,6 @@ const Environment = struct {
             },
             inline .get_by_id,
             .get_by_timestamp,
-            .get_by_pending_id,
             => |key, action| {
                 // Get object from lsm.
                 try env.prefetch(key, snapshot);
@@ -783,13 +771,6 @@ const Environment = struct {
                             assert(key == .timestamp);
                             assert(TimestampRange.valid(key.timestamp));
                             break :lsm_object env.get(key);
-                        },
-                        .get_by_pending_id => {
-                            assert(key == .pending_id);
-                            break :lsm_object if (key.pending_id == 0)
-                                null
-                            else
-                                env.get(key);
                         },
                         else => comptime unreachable,
                     }
@@ -928,7 +909,6 @@ pub fn generate_fuzz_ops(
         // Maybe do some gets.
         .get_by_id = if (prng.boolean()) 0 else constants.lsm_compaction_ops,
         .get_by_timestamp = if (prng.boolean()) 0 else constants.lsm_compaction_ops,
-        .get_by_pending_id = if (prng.boolean()) 0 else constants.lsm_compaction_ops,
         // Maybe do some scans.
         .scan = if (prng.boolean()) 0 else constants.lsm_compaction_ops,
     };
@@ -999,25 +979,6 @@ pub fn generate_fuzz_ops(
                     TimestampRange.timestamp_min,
                     fuzz_op_index + 1,
                 ) },
-            },
-            .get_by_pending_id => FuzzOpAction{
-                .get_by_pending_id = .{
-                    .pending_id = id: {
-                        // Not all transfers have the pending_id,
-                        // so it may or may not be found.
-                        const it = id_to_object.keyIterator();
-                        for (0..it.len) |_| {
-                            const index = prng.int_inclusive(usize, it.len - 1);
-                            if (!it.metadata[index].isUsed()) continue;
-
-                            const id = it.items[index];
-                            const object = id_to_object.get(id).?;
-                            break :id object.pending_id;
-                        }
-
-                        break :id 0;
-                    },
-                },
             },
             .scan => blk: {
                 @setEvalBranchQuota(10_000);
@@ -1096,7 +1057,6 @@ pub fn generate_fuzz_ops(
             .remove => puts_since_compact += 1,
             .get_by_id => {},
             .get_by_timestamp => {},
-            .get_by_pending_id => {},
             .scan => {},
         }
     }

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -431,10 +431,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                 .batch_value_count_max = tree_values_count_max.transfers,
                 .primary_key = "id",
                 .primary_key_orphaned = true,
-                .unique_keys = &[_][:0]const u8{
-                    "id",
-                    "pending_id",
-                },
+                .unique_keys = &[_][:0]const u8{"id"},
                 .ignored = &[_][:0]const u8{ "timeout", "flags" },
                 .optional = &[_][:0]const u8{
                     "pending_id",
@@ -500,7 +497,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                 .batch_value_count_max = tree_values_count_max.account_events,
                 .primary_key = "timestamp",
                 .primary_key_orphaned = false,
-                .unique_keys = &[_][:0]const u8{"transfer_pending_id_expired"},
+                .unique_keys = &[_][:0]const u8{},
                 .ignored = &[_][:0]const u8{
                     "dr_account_id",
                     "dr_debits_pending",


### PR DESCRIPTION
Revert unique keys to secondary indexes until we fix the `IndexBlock` binary compatibility.
Related #3808