### PR TITLE
ci: Remove unnecessary env variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,6 @@ concurrency:
   group: release
   cancel-in-progress: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # Remove once this is the default (June 16th, 2026).
-
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` is no longer necessary, the migration happened on June 16th, 2026.

This is the followup to #3777, I could find no indication that the migration has been further delayed on Github's side.

