### PR TITLE
time: expose TimeSim and fixtures in vsr

### DIFF
--- a/src/time.zig
+++ b/src/time.zig
@@ -12,6 +12,8 @@ const is_windows = builtin.target.os.tag == .windows;
 const is_linux = builtin.target.os.tag == .linux;
 const Instant = stdx.Instant;
 
+pub const TimeSim = @import("testing/time.zig").TimeSim;
+
 pub const Time = struct {
     context: *anyopaque,
     vtable: *const VTable,

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -39,6 +39,7 @@ pub const testing = .{
     .random_int_exponential = @import("testing/fuzz.zig").random_int_exponential,
     .IdPermutation = @import("testing/id.zig").IdPermutation,
     .parse_seed = @import("testing/fuzz.zig").parse_seed,
+    .fixtures = @import("testing/fixtures.zig"),
 };
 pub const ewah = @import("ewah.zig").ewah;
 pub const checkpoint_trailer = @import("vsr/checkpoint_trailer.zig");


### PR DESCRIPTION
This change exposes `TimeSim` via `src/time.zig` which is exposed in the `vsr` module.
Also, the `init_time` function got moved from `fixtures.zig` into `TimeSim`.