### PR TITLE
cache_map: Guard tombstone insertion capacity

### DIFF
--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -293,14 +293,21 @@ pub fn CacheMapType(
                 assert(self.stash.count() <= self.options.stash_value_count_max);
 
                 const tombstone_object = tombstone_from_key(key);
+                if (self.stash.getKeyPtr(tombstone_object)) |stash_value| {
+                    const old_value = stash_value.*;
+                    stash_value.* = tombstone_object;
+                    break :stash_removed old_value;
+                }
+
+                assert(self.stash.count() < self.options.stash_value_count_max);
                 const entry = self.stash.getOrPutAssumeCapacity(tombstone_object);
+                assert(!entry.found_existing);
 
                 // Add a tombstone in the stash, indicating that the
                 // deletion happened and that the key should not be
                 // looked up in the immutable table or LSM tree.
-                defer entry.key_ptr.* = tombstone_object;
-
-                break :stash_removed if (entry.found_existing) entry.key_ptr.* else null;
+                entry.key_ptr.* = tombstone_object;
+                break :stash_removed null;
             };
 
             // Does not allow removing a key that is not in the cache.


### PR DESCRIPTION
#3802 made `CacheMap.remove()` leave a tombstone in the stash instead of removing the stash entry outright. That fixed lookup fallthrough after remove, but there's an issue remaining because the code does not distinguish replacing an existing stash entry from inserting a new one.

AFAICT you can end up at `getOrPutAssumeCapacity()` with a full stash and no existing entry for the key. This PR checks for an existing stash entry first, and only asserts spare stash capacity (`< self.options.stash_value_count_max`) when inserting a new tombstone.

It's an edge case but it seems to me the code should assert rather than allow the stash to exceed `stash_value_count_max`.