### PR TITLE
[draft] rewrite cache_map.

### DIFF
--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -198,9 +198,35 @@ pub fn CacheMapType(
             return self.options.cache_value_count_max;
         }
 
-        pub fn upsert(self: *CacheMap, value: *const Value) void {
-            const updated = self.fetch_upsert(value);
+        pub fn prefetch_upsert(self: *CacheMap, value: *const Value) void {
+            assert(!self.scope_is_active);
+            assert(!tombstone(value));
+            _ = self.stash_upsert(value);
+        }
 
+        pub fn insert(self: *CacheMap, value: *const Value) void {
+            switch (self.get_or_tombstone(key_from_value(value))) {
+                .found => unreachable,
+                .not_found, .tombstone => {},
+            }
+
+            const updated = self.fetch_upsert(value);
+            assert(updated == null or tombstone(&updated.?));
+            self.rollback_log_append_update(value, updated);
+        }
+
+        pub fn update(self: *CacheMap, value: *const Value) void {
+            switch (self.get_or_tombstone(key_from_value(value))) {
+                .found => {},
+                .not_found, .tombstone => unreachable,
+            }
+
+            const updated = self.fetch_upsert(value).?;
+            assert(!tombstone(&updated));
+            self.rollback_log_append_update(value, updated);
+        }
+
+        fn rollback_log_append_update(self: *CacheMap, value: *const Value, updated: ?Value) void {
             // When upserting into a scope:
             if (self.scope_is_active) {
                 const rollback_action: RollbackLogAction = rollback_action: {
@@ -307,7 +333,8 @@ pub fn CacheMapType(
                         // Reverting an update or delete
                         // consists of an insert of the original value.
                         assert(!tombstone(rollback_value));
-                        self.upsert(rollback_value);
+                        const updated = self.fetch_upsert(rollback_value);
+                        assert(updated != null);
                     },
                     .restore_tombstone => |key| {
                         // Reverting an insert that overwrote a tombstone
@@ -408,7 +435,7 @@ test "cache_map: unit" {
         cache_map.cache_entries_max(),
     );
 
-    cache_map.upsert(&.{ .key = 1, .value = 1, .tombstone = false });
+    cache_map.insert(&.{ .key = 1, .value = 1, .tombstone = false });
     try testing.expectEqual(@as(u64, 1), cache_map.cache_entries());
     try testing.expectEqual(
         TestTable.Value{ .key = 1, .value = 1, .tombstone = false },
@@ -417,7 +444,7 @@ test "cache_map: unit" {
 
     // Test scope persisting.
     cache_map.scope_open();
-    cache_map.upsert(&.{ .key = 2, .value = 2, .tombstone = false });
+    cache_map.insert(&.{ .key = 2, .value = 2, .tombstone = false });
     try testing.expectEqual(
         TestTable.Value{ .key = 2, .value = 2, .tombstone = false },
         cache_map.get(2).?.*,
@@ -430,9 +457,9 @@ test "cache_map: unit" {
 
     // Test scope discard on updates.
     cache_map.scope_open();
-    cache_map.upsert(&.{ .key = 2, .value = 22, .tombstone = false });
-    cache_map.upsert(&.{ .key = 2, .value = 222, .tombstone = false });
-    cache_map.upsert(&.{ .key = 2, .value = 2222, .tombstone = false });
+    cache_map.update(&.{ .key = 2, .value = 22, .tombstone = false });
+    cache_map.update(&.{ .key = 2, .value = 222, .tombstone = false });
+    cache_map.update(&.{ .key = 2, .value = 2222, .tombstone = false });
     try testing.expectEqual(
         TestTable.Value{ .key = 2, .value = 2222, .tombstone = false },
         cache_map.get(2).?.*,
@@ -445,12 +472,12 @@ test "cache_map: unit" {
 
     // Test scope discard on inserts.
     cache_map.scope_open();
-    cache_map.upsert(&.{ .key = 3, .value = 3, .tombstone = false });
+    cache_map.insert(&.{ .key = 3, .value = 3, .tombstone = false });
     try testing.expectEqual(
         TestTable.Value{ .key = 3, .value = 3, .tombstone = false },
         cache_map.get(3).?.*,
     );
-    cache_map.upsert(&.{ .key = 3, .value = 33, .tombstone = false });
+    cache_map.update(&.{ .key = 3, .value = 33, .tombstone = false });
     try testing.expectEqual(
         TestTable.Value{ .key = 3, .value = 33, .tombstone = false },
         cache_map.get(3).?.*,
@@ -471,7 +498,7 @@ test "cache_map: unit" {
     );
 
     // Test scope discard on a sequence of insert->remove->insert.
-    cache_map.upsert(&.{ .key = 4, .value = 4, .tombstone = false });
+    cache_map.insert(&.{ .key = 4, .value = 4, .tombstone = false });
     try testing.expectEqual(
         TestTable.Value{ .key = 4, .value = 4, .tombstone = false },
         cache_map.get(4).?.*,
@@ -483,7 +510,7 @@ test "cache_map: unit" {
     assert(cache_map.get_or_tombstone(4) == .tombstone);
 
     cache_map.scope_open();
-    cache_map.upsert(&.{ .key = 4, .value = 4, .tombstone = false });
+    cache_map.insert(&.{ .key = 4, .value = 4, .tombstone = false });
     cache_map.scope_close(.discard);
 
     assert(!cache_map.has(4));
@@ -504,7 +531,7 @@ test "cache_map: stash shadows cache until compact" {
     });
     defer cache_map.deinit(allocator);
 
-    cache_map.upsert(&.{ .key = 1, .value = 1, .tombstone = false });
+    cache_map.insert(&.{ .key = 1, .value = 1, .tombstone = false });
     try testing.expectEqual(@as(u64, 0), cache_map.cache_entries());
     try testing.expectEqual(
         TestTable.Value{ .key = 1, .value = 1, .tombstone = false },
@@ -519,7 +546,7 @@ test "cache_map: stash shadows cache until compact" {
         cache_map.cache.?.get(1).?.*,
     );
 
-    cache_map.upsert(&.{ .key = 1, .value = 2, .tombstone = false });
+    cache_map.update(&.{ .key = 1, .value = 2, .tombstone = false });
     try testing.expectEqual(
         TestTable.Value{ .key = 1, .value = 1, .tombstone = false },
         cache_map.cache.?.get(1).?.*,

--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -257,24 +257,12 @@ pub fn CacheMapType(
             const old_value = (self.get(key) orelse unreachable).*;
             assert(!tombstone(&old_value));
 
-            const stash_removed: ?Value = stash_removed: {
-                assert(self.stash.count() <= self.options.stash_value_count_max);
-
-                const tombstone_object = tombstone_from_key(key);
-                const entry = self.stash.getOrPutAssumeCapacity(tombstone_object);
-
-                // Add a tombstone in the stash, indicating that the
-                // deletion happened and that the key should not be
-                // looked up in the immutable table or LSM tree.
-                defer entry.key_ptr.* = tombstone_object;
-
-                break :stash_removed if (entry.found_existing) entry.key_ptr.* else null;
-            };
-
+            const tombstone_object = tombstone_from_key(key);
+            const stash_removed = self.stash_upsert(&tombstone_object);
             maybe(stash_removed != null);
-
             // Cannot remove a value that has already been removed.
             if (stash_removed) |stash_value| assert(!tombstone(&stash_value));
+
             if (self.scope_is_active) {
                 self.scope_rollback_log.appendAssumeCapacity(.{
                     .restore = old_value,

--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -8,21 +8,20 @@ const maybe = stdx.maybe;
 const SetAssociativeCacheType = @import("set_associative_cache.zig").SetAssociativeCacheType;
 const ScopeCloseMode = @import("tree.zig").ScopeCloseMode;
 
-/// A CacheMap is a hybrid between our SetAssociativeCache and a HashMap (stash). The
-/// SetAssociativeCache sits on top and absorbs the majority of get / put requests. Below that,
-/// lives a HashMap. Should an insert() cause an eviction (which can happen either because the Key
-/// is the same, or because our Way is full), the evicted value is caught and put in the stash.
+/// A CacheMap is a hybrid between our SetAssociativeCache and a HashMap (stash). The stash is the
+/// authoritative layer for values needed by the current commit; the SetAssociativeCache is a
+/// best-effort recency cache for values from previous commits.
 ///
 /// This allows for a potentially huge cache, with all the advantages of CLOCK Nth-Chance, while
-/// still being able to give hard guarantees that values will be present. The stash will often be
-/// significantly smaller, as the amount of values we're required to guarantee is less than what
-/// we'd like to optimistically keep in memory.
+/// still being able to give hard guarantees that values prefetched into the stash will be present.
+/// The stash will often be significantly smaller, as the amount of values we're required to
+/// guarantee is less than what we'd like to optimistically keep in memory.
 ///
 /// Within our LSM, the CacheMap is the backing for the combined Groove prefetch + cache. The cache
 /// part fills the use case of an object cache, while the stash ensures that prefetched values
 /// are available in memory during their respective commit.
 ///
-/// Cache invalidation for the stash is handled by `compact`.
+/// `compact()` promotes the stash into the recency cache, then clears the stash.
 pub fn CacheMapType(
     comptime Key: type,
     comptime Value: type,
@@ -79,10 +78,10 @@ pub fn CacheMapType(
         };
         const RollbackLog = std.ArrayListUnmanaged(RollbackLogAction);
 
-        // The hierarchy for lookups is cache (if present) -> stash -> immutable table -> lsm.
-        // Lower levels _may_ have stale values, provided the correct value exists
-        // in one of the levels above.
-        // Evictions from the cache first flow into stash, with `.compact()` clearing it.
+        // The hierarchy for lookups is stash -> cache (if present) -> immutable table -> lsm.
+        // Lower levels _may_ have stale values, provided the correct value exists in one of the
+        // levels above. Cache evictions are discarded; only `compact()` promotes stash values into
+        // the recency cache.
         // When cache is null, the stash mirrors the mutable table.
         cache: ?Cache,
         stash: Map,
@@ -155,13 +154,18 @@ pub fn CacheMapType(
         }
 
         pub fn get(self: *const CacheMap, key: Key) ?*Value {
-            return (if (self.cache) |*cache| cache.get(key) else null) orelse stash: {
-                if (self.stash.getKeyPtr(tombstone_from_key(key))) |object| {
-                    // Deleted keys are represented as tombstones in the stash.
-                    break :stash if (tombstone(object)) null else object;
+            if (self.stash.getKeyPtr(tombstone_from_key(key))) |object| {
+                // Deleted keys are represented as tombstones in the stash.
+                return if (tombstone(object)) null else object;
+            }
+
+            if (self.cache) |*cache| {
+                if (cache.get(key)) |object| {
+                    return if (tombstone(object)) null else object;
                 }
-                break :stash null;
-            };
+            }
+
+            return null;
         }
 
         pub fn get_or_tombstone(self: *const CacheMap, key: Key) union(enum) {
@@ -169,14 +173,15 @@ pub fn CacheMapType(
             not_found,
             tombstone,
         } {
-            if (self.cache) |*cache| {
-                if (cache.get(key)) |object| {
-                    return .{ .found = object };
-                }
-            }
             if (self.stash.getKeyPtr(tombstone_from_key(key))) |object| {
                 // Deleted keys are represented as tombstones in the stash.
                 return if (tombstone(object)) .tombstone else .{ .found = object };
+            }
+
+            if (self.cache) |*cache| {
+                if (cache.get(key)) |object| {
+                    return if (tombstone(object)) .tombstone else .{ .found = object };
+                }
             }
 
             return .not_found;
@@ -215,50 +220,17 @@ pub fn CacheMapType(
             }
         }
 
-        // Upserts the cache and stash and returns the old value in case of
-        // an update.
+        // Upserts the stash and returns the old visible value in case of an update.
         fn fetch_upsert(self: *CacheMap, value: *const Value) ?Value {
+            const key = key_from_value(value);
+            const old_stash = self.stash_upsert(value);
+            if (old_stash) |old| return old;
+
             if (self.cache) |*cache| {
-                const key = key_from_value(value);
-                const result = cache.upsert(value);
-
-                if (result.evicted) |*evicted| {
-                    switch (result.updated) {
-                        .update => {
-                            assert(key_from_value(evicted) == key);
-                            if (constants.verify) {
-                                const stash: ?Value = self.stash.getKey(value.*);
-                                assert(stash == null or tombstone(&stash.?));
-                            }
-
-                            // There was an eviction because an item was updated,
-                            // the evicted item is always its previous version.
-                            return evicted.*;
-                        },
-                        .insert => {
-                            assert(key_from_value(evicted) != key);
-
-                            // There was an eviction because a new item was inserted,
-                            // the evicted item will be added to the stash.
-                            const stash_updated = self.stash_upsert(evicted);
-
-                            // We don't expect stale values on the stash.
-                            assert(stash_updated == null or tombstone(&stash_updated.?));
-                        },
-                    }
-                } else {
-                    // It must be an insert without eviction,
-                    // since updates always evict the old version.
-                    assert(result.updated == .insert);
-                }
-
-                // The stash may have the old value if nothing was evicted.
-                return self.stash_remove(key);
-            } else {
-                // No cache.
-                // Upserting the stash directly.
-                return self.stash_upsert(value);
+                if (cache.get(key)) |old| return old.*;
             }
+
+            return null;
         }
 
         fn stash_upsert(self: *CacheMap, value: *const Value) ?Value {
@@ -275,20 +247,16 @@ pub fn CacheMapType(
                 null;
         }
 
-        /// Removes a key from cache, adding a tombstone to record the action.
-        /// Invariant: The key must be present in cache.
+        /// Removes a key by adding a tombstone to the stash.
+        /// Invariant: The key must be visible through the cache map.
         pub fn remove(self: *CacheMap, key: Key) void {
             // Only unit tests and fuzzers call this function.
             // Assert that it is not called from production code.
             comptime assert(constants.verify);
 
-            const cache_removed: ?Value = if (self.cache) |*cache|
-                cache.remove(key)
-            else
-                null;
+            const old_value = (self.get(key) orelse unreachable).*;
+            assert(!tombstone(&old_value));
 
-            // We don't allow stale values, so we need to remove from the stash as well,
-            // since both can have different versions with the same key.
             const stash_removed: ?Value = stash_removed: {
                 assert(self.stash.count() <= self.options.stash_value_count_max);
 
@@ -303,13 +271,10 @@ pub fn CacheMapType(
                 break :stash_removed if (entry.found_existing) entry.key_ptr.* else null;
             };
 
-            // Does not allow removing a key that is not in the cache.
-            assert(cache_removed != null or stash_removed != null);
-            maybe(cache_removed != null and stash_removed != null);
+            maybe(stash_removed != null);
 
-            const old_value = cache_removed orelse stash_removed orelse unreachable;
             // Cannot remove a value that has already been removed.
-            assert(!tombstone(&old_value));
+            if (stash_removed) |stash_value| assert(!tombstone(&stash_value));
             if (self.scope_is_active) {
                 self.scope_rollback_log.appendAssumeCapacity(.{
                     .restore = old_value,
@@ -367,15 +332,8 @@ pub fn CacheMapType(
                     },
                     .remove => |key| {
                         // Reverting an insert consists of removing the value.
-                        const cache_removed: bool =
-                            if (self.cache) |*cache| cache.remove(key) != null else false;
-
-                        // The key should be in the stash iff it wasn't in the cache.
-                        if (self.stash_remove(key)) |*stash_value| {
-                            assert(!cache_removed or tombstone(stash_value));
-                        } else {
-                            assert(cache_removed);
-                        }
+                        const stash_value = self.stash_remove(key).?;
+                        assert(!tombstone(&stash_value));
                     },
                 }
             }
@@ -388,6 +346,17 @@ pub fn CacheMapType(
             assert(self.scope_rollback_log.items.len == 0);
             assert(self.stash.count() <= self.options.stash_value_count_max);
 
+            if (self.cache) |*cache| {
+                var stash_iterator = self.stash.keyIterator();
+                while (stash_iterator.next()) |object| {
+                    const key = key_from_value(object);
+                    if (tombstone(object)) {
+                        _ = cache.remove(key);
+                    } else {
+                        _ = cache.upsert(object);
+                    }
+                }
+            }
             self.stash.clearRetainingCapacity();
         }
     };
@@ -532,4 +501,61 @@ test "cache_map: unit" {
     assert(!cache_map.has(4));
     assert(cache_map.get(4) == null);
     assert(cache_map.get_or_tombstone(4) == .tombstone);
+}
+
+test "cache_map: stash shadows cache until compact" {
+    const testing = std.testing;
+
+    const allocator = testing.allocator;
+
+    var cache_map = try TestCacheMap.init(allocator, .{
+        .cache_value_count_max = TestCacheMap.Cache.value_count_max_multiple,
+        .scope_value_count_max = 32,
+        .stash_value_count_max = 32,
+        .name = "test map",
+    });
+    defer cache_map.deinit(allocator);
+
+    cache_map.upsert(&.{ .key = 1, .value = 1, .tombstone = false });
+    try testing.expectEqual(@as(u64, 0), cache_map.cache_entries());
+    try testing.expectEqual(
+        TestTable.Value{ .key = 1, .value = 1, .tombstone = false },
+        cache_map.get(1).?.*,
+    );
+
+    cache_map.compact();
+    try testing.expectEqual(@as(u64, 1), cache_map.cache_entries());
+    try testing.expectEqual(@as(u64, 0), cache_map.stash.count());
+    try testing.expectEqual(
+        TestTable.Value{ .key = 1, .value = 1, .tombstone = false },
+        cache_map.cache.?.get(1).?.*,
+    );
+
+    cache_map.upsert(&.{ .key = 1, .value = 2, .tombstone = false });
+    try testing.expectEqual(
+        TestTable.Value{ .key = 1, .value = 1, .tombstone = false },
+        cache_map.cache.?.get(1).?.*,
+    );
+    try testing.expectEqual(
+        TestTable.Value{ .key = 1, .value = 2, .tombstone = false },
+        cache_map.get(1).?.*,
+    );
+
+    cache_map.compact();
+    try testing.expectEqual(@as(u64, 0), cache_map.stash.count());
+    try testing.expectEqual(
+        TestTable.Value{ .key = 1, .value = 2, .tombstone = false },
+        cache_map.cache.?.get(1).?.*,
+    );
+
+    cache_map.remove(1);
+    assert(cache_map.get(1) == null);
+    try testing.expectEqual(
+        TestTable.Value{ .key = 1, .value = 2, .tombstone = false },
+        cache_map.cache.?.get(1).?.*,
+    );
+
+    cache_map.compact();
+    assert(cache_map.get(1) == null);
+    assert(cache_map.cache.?.get(1) == null);
 }

--- a/src/lsm/cache_map_fuzz.zig
+++ b/src/lsm/cache_map_fuzz.zig
@@ -70,7 +70,19 @@ const Environment = struct {
                     env.model.compact();
                 },
                 .upsert => |value| {
-                    env.cache_map.upsert(&value);
+                    const key = TestTable.key_from_value(&value);
+                    if (env.model.get(key)) |model_value| {
+                        const cache_map_value = env.cache_map.get(key);
+                        if (cache_map_value == null or
+                            !std.meta.eql(cache_map_value.?.*, model_value.value))
+                        {
+                            if (env.cache_map.scope_is_active) continue;
+                            env.cache_map.prefetch_upsert(&model_value.value);
+                        }
+                        env.cache_map.update(&value);
+                    } else {
+                        env.cache_map.insert(&value);
+                    }
                     try env.model.upsert(&value);
                 },
                 .remove => |key| {
@@ -85,7 +97,8 @@ const Environment = struct {
                         // been evicted from the recency cache. It must be loaded into the stash
                         // before removal, though.
                         assert(env.model.compacts > model_value.?.op);
-                        env.cache_map.upsert(&model_value.?.value);
+                        if (env.cache_map.scope_is_active) continue;
+                        env.cache_map.prefetch_upsert(&model_value.?.value);
                     }
 
                     env.cache_map.remove(key);

--- a/src/lsm/cache_map_fuzz.zig
+++ b/src/lsm/cache_map_fuzz.zig
@@ -55,7 +55,8 @@ const Environment = struct {
 
     pub fn apply(env: *Environment, fuzz_ops: []const FuzzOp) !void {
         // The cache_map should behave exactly like a hash map, with some exceptions:
-        // * .compact() removes values added more than one .compact() ago.
+        // * .compact() moves stashed values into the recency cache; old values may then be
+        //   evicted from the recency cache.
         // * .scope_close(.discard) rolls back all operations done from the corresponding
         //   .scope_open()
 
@@ -80,9 +81,9 @@ const Environment = struct {
                     } else {
                         if (model_value == null) continue; // The key doesn't exist.
 
-                        // If the entry has an op from one or more compactions ago, it
-                        // may have been evicted from the cache.
-                        // It must be loaded into the cache before removal, though.
+                        // If the entry has an op from one or more compactions ago, it may have
+                        // been evicted from the recency cache. It must be loaded into the stash
+                        // before removal, though.
                         assert(env.model.compacts > model_value.?.op);
                         env.cache_map.upsert(&model_value.?.value);
                     }
@@ -101,7 +102,7 @@ const Environment = struct {
                     } else if (env.model.compacts > model_value.?.op) {
                         // .compact() support; if the entry has an op 1 or more compacts ago, it
                         // doesn't have to exist in the cache_map. It may still be served from the
-                        // cache layer, however.
+                        // recency cache, however.
                         stdx.maybe(cache_map_value == null);
                         if (cache_map_value) |cache_map_value_unwrapped| {
                             assert(std.meta.eql(cache_map_value_unwrapped.*, model_value.?.value));
@@ -129,16 +130,14 @@ const Environment = struct {
     }
 
     /// Verifies both the positive and negative spaces, as both are equally important. We verify
-    /// the positive space by iterating over our model, and ensuring everything exists and is
-    /// equal in the cache_map.
+    /// the positive space by iterating over our model, and ensuring everything still visible in
+    /// the cache_map is equal.
     ///
     /// We verify the negative space by iterating over the cache_map's cache and maps directly,
     /// ensuring that:
-    /// 1. The values in the cache all exist and are equal in the model.
-    /// 2. The values in stash either exists and are equal in the model, or there's the same key
-    ///    in the cache.
-    /// 3. The values in stash_2 either exists and are equal in the model, or there's the same key
-    ///    in stash_1 or the cache.
+    /// 1. The values in the cache exist and are equal in the model, or are shadowed by the stash.
+    /// 2. The values in stash exist and are equal in the model, or are tombstones for keys that
+    ///    do not exist in the model.
     pub fn verify(env: *Environment) void {
         var checked: u32 = 0;
         var it = env.model.iterator();
@@ -158,8 +157,22 @@ const Environment = struct {
 
         log.info("Verified {} items from model exist and match in cache_map.", .{checked});
 
-        // It's fine for the cache_map to have values older than .compact() in it; good, in fact,
-        // but they _MUST NOT_ be stale.
+        // The stash is the authoritative layer for the current commit and must not be stale.
+        var stash_iterator = env.cache_map.stash.keyIterator();
+        while (stash_iterator.next()) |stash_value| {
+            const key = TestTable.key_from_value(stash_value);
+            const model_value = env.model.get(key);
+
+            if (TestTable.tombstone(stash_value)) {
+                assert(model_value == null);
+            } else {
+                assert(model_value != null);
+                assert(std.meta.eql(stash_value.*, model_value.?.value));
+            }
+        }
+
+        // It's fine for the cache_map to have values older than .compact() in it; good, in fact.
+        // If a cache value is stale, the stash must shadow it with the current value or tombstone.
         if (env.cache_map.cache) |*cache| {
             for (cache.values, 0..) |*cache_value, i| {
                 // If the count for an index is 0, the value doesn't exist.
@@ -167,43 +180,25 @@ const Environment = struct {
                     continue;
                 }
 
-                const model_val = env.model.get(TestTable.key_from_value(cache_value));
-                assert(std.meta.eql(cache_value.*, model_val.?.value));
-            }
-        }
+                const key = TestTable.key_from_value(cache_value);
+                const model_value = env.model.get(key);
+                if (model_value) |model_value_unwrapped| {
+                    if (std.meta.eql(cache_value.*, model_value_unwrapped.value)) continue;
+                }
 
-        // The stash can have stale values, but in that case the real value _must_ exist
-        // in the cache. It should be impossible for the stash to have a value that isn't in the
-        // model, since cache_map.remove() removes from both the cache and stash.
-        var stash_iterator = env.cache_map.stash.keyIterator();
-        while (stash_iterator.next()) |stash_value| {
-            // Get account from model.
-            const model_value = env.model.get(TestTable.key_from_value(stash_value));
-
-            // Even if the stash has stale values, the key must still exist in the model.
-            if (TestTable.tombstone(stash_value)) {
-                stdx.maybe(model_value == null);
-                continue;
-            }
-            assert(!TestTable.tombstone(stash_value));
-            assert(model_value != null);
-
-            const stash_value_equal = std.meta.eql(stash_value.*, model_value.?.value);
-
-            if (!stash_value_equal) {
-                if (env.cache_map.cache) |*cache| {
-                    // We verified all cache entries were equal and correct above, so if it exists,
-                    // it must be right.
-                    const cache_value = cache.get(
-                        TestTable.key_from_value(stash_value),
-                    );
-                    assert(cache_value != null);
+                const stash_value = env.cache_map.stash.getKey(TestTable.tombstone_from_key(key));
+                assert(stash_value != null);
+                if (TestTable.tombstone(&stash_value.?)) {
+                    assert(model_value == null);
+                } else {
+                    assert(model_value != null);
+                    assert(std.meta.eql(stash_value.?, model_value.?.value));
                 }
             }
         }
 
         log.info(
-            "Verified all items in the cache and stash exist and match the model.",
+            "Verified all items in the stash are current and cache items are current or shadowed.",
             .{},
         );
     }

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -1187,7 +1187,7 @@ pub fn GrooveType(
                                 // Zeroed timestamp indicates the object is not present,
                                 // and this id cannot be used anymore.
                                 entry.value_ptr.* = .found_orphaned;
-                                groove.insert_orphaned_object(value);
+                                groove.prefetch_orphaned_object(value);
                                 return;
                             }
                             assert(TimestampRange.valid(tree_value.timestamp));
@@ -1270,7 +1270,7 @@ pub fn GrooveType(
                             assert(IndexHelper.get(object).? == value);
                         },
                     }
-                    groove.objects_cache.upsert(object);
+                    groove.objects_cache.prefetch_upsert(object);
                     options.entry.value_ptr.* = .{
                         .found = @field(object, groove_options.primary_key),
                     };
@@ -1648,7 +1648,7 @@ pub fn GrooveType(
                             comptime assert(groove_options.primary_key_orphaned);
                             comptime assert(is_primary_key(field));
 
-                            worker.context.groove.insert_orphaned_object(tree_value.field);
+                            worker.context.groove.prefetch_orphaned_object(tree_value.field);
                             entry.value_ptr.* = .found_orphaned;
 
                             worker.current = null;
@@ -1753,7 +1753,7 @@ pub fn GrooveType(
                             assert(IndexHelper.get(object).? == value);
                         },
                     }
-                    worker.context.groove.objects_cache.upsert(object);
+                    worker.context.groove.objects_cache.prefetch_upsert(object);
                     entry.value_ptr.* = .{
                         .found = @field(object, groove_options.primary_key),
                     };
@@ -1773,7 +1773,7 @@ pub fn GrooveType(
             if (ObjectsCache != void) {
                 const primary_key = @field(object, groove_options.primary_key);
                 assert(!groove.objects_cache.has(primary_key));
-                groove.objects_cache.upsert(object);
+                groove.objects_cache.insert(object);
             }
 
             groove.objects.put(object);
@@ -1868,7 +1868,7 @@ pub fn GrooveType(
             // unless old comes from the stash) and no secondary indexes will be updated!
 
             if (ObjectsCache != void) {
-                groove.objects_cache.upsert(new);
+                groove.objects_cache.update(new);
             }
             groove.objects.put(new);
         }
@@ -1945,7 +1945,19 @@ pub fn GrooveType(
 
             var orphaned: Object = std.mem.zeroInit(Object, .{});
             @field(orphaned, groove_options.primary_key) = key;
-            groove.objects_cache.upsert(&orphaned);
+            groove.objects_cache.insert(&orphaned);
+        }
+
+        fn prefetch_orphaned_object(groove: *Groove, key: PrimaryKey) void {
+            comptime assert(groove_options.primary_key_orphaned);
+            comptime assert(!is_primary_key(.timestamp));
+
+            assert(key != 0);
+            assert(key != std.math.maxInt(PrimaryKey));
+
+            var orphaned: Object = std.mem.zeroInit(Object, .{});
+            @field(orphaned, groove_options.primary_key) = key;
+            groove.objects_cache.prefetch_upsert(&orphaned);
         }
 
         pub fn remove_orphaned_primary_key(groove: *Groove, id: u128) void {

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -791,7 +791,7 @@ const Environment = struct {
         ) orelse return false;
         // Simulate what prefetch does in the real state machine: ensure the old object is in
         // the objects cache before calling update, which asserts its presence.
-        env.forest.grooves.things.objects_cache.upsert(old);
+        env.forest.grooves.things.objects_cache.prefetch_upsert(old);
         env.forest.grooves.things.update(.{ .old = old, .new = &new });
         env.model.items[model_index] = new;
 


### PR DESCRIPTION
This is only a PoC for now. It is leapfrogged, and the API/naming is not quite right yet. I also plan to build a small custom hash table that should perform much better for our specific use case.

That being said:  The main idea is to flip our current cache/stash design upside down. Today, we have a cache, and when values are evicted from the cache, we catch them in the stash as a kind of overflow collection.
In the past, this caused some problems because pointers and lifetimes had to be handled carefully. It also led to fairly complex rollback machinery, since we needed to maintain both a cache and a stash and make sure that despite rollback they are consistent (especially now with tombstones).

The insight of this PR is that we can decouple execution (which deals with rollback) from the recency cache. 
Thus, this PR reverses that model: we primarily operate on the stash. Execution within one bar (or beat) happens only there. When we call `compact()`, we transfer the updated values into the recency cache.

This decouples the “recency” cache, which needs to handle eviction and related bookkeeping, from the execution guarantee that we never want to miss required values. Thus it also, ensures that the recency cache only sees values that are committed and never need to be rolled back. 

It also enables a few useful simplifications:

(1) It simplifies some of the complicated logic around eviction during execution.
(2) It would let us use pointers again.
(3) It gives us room for more specialized APIs.  For example, during prefetching we do not need a rollback log, because we are not modifying values. During execution, instead of using the general-purpose upsert, we can choose explicitly whether we want to insert or update:
  - prefetch_upsert() for prefetch/stash population, with assert(!scope_is_active).
  - insert() for execute-time new values, asserting that the key is not currently found.
  - update() for execute-time existing values, asserting that the key is found.
  -  we need to find better names though ;-) 
(4) Not in this PR, but fuzzing should be much easier. 