### PR TITLE
Vortex: On network flake during build, fail on curl not unzip

### DIFF
--- a/src/build/fetch.zig
+++ b/src/build/fetch.zig
@@ -87,7 +87,7 @@ fn fetch(arena: Allocator, options: struct {
                 "--retry-delay",    "30",
                 "--location",       options.url,
                 "--output",         curl_output,
-                "--verbose",
+                "--verbose",        "--fail",
             }),
             .max_output_bytes = 1024 * 1024,
         }) catch |err| {


### PR DESCRIPTION
If github releases returns "504 Gateway Timeout", curl should consider that a failure. Weirdly it already considered it a failure for the purpose of retries, but _not_ for the purpose of curl's exit code.