### PR TITLE
rust client, first pass: remove bitflags dependency, enable overflow checks, update doctests

### DIFF
--- a/src/clients/rust/Cargo.toml
+++ b/src/clients/rust/Cargo.toml
@@ -22,9 +22,6 @@ include = [
 [profile.release]
 overflow-checks = true
 
-[dependencies]
-bitflags = "2.6.0"
-
 [dev-dependencies]
 futures = { version = "0.3.31", default-features = false, features = ["executor"] }
 

--- a/src/clients/rust/Cargo.toml
+++ b/src/clients/rust/Cargo.toml
@@ -20,6 +20,13 @@ include = [
 ]
 
 [profile.release]
+# It is *strongly* recommended that Rust applications using TigerBeetle
+# enable overflow checks, because the nature of accounting makes overflow
+# errors catastrophic.
+#
+# Note that the following line enables the checks only for the tests in
+# this crate. In other words, overflow checks must be enabled in the
+# Cargo.toml of the end application.
 overflow-checks = true
 
 [dev-dependencies]

--- a/src/clients/rust/Cargo.toml
+++ b/src/clients/rust/Cargo.toml
@@ -19,8 +19,12 @@ include = [
   "assets/lib/*/{*.a,*.lib}",
 ]
 
+[profile.release]
+overflow-checks = true
+
 [dependencies]
 bitflags = "2.6.0"
 
 [dev-dependencies]
 futures = { version = "0.3.31", default-features = false, features = ["executor"] }
+

--- a/src/clients/rust/ci.zig
+++ b/src/clients/rust/ci.zig
@@ -16,6 +16,9 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
 
         try shell.exec("cargo fmt --check", .{});
         try shell.exec("cargo clippy -- -D clippy::all", .{});
+        try shell.exec("grep -q {checked_arithmetic_text} Cargo.toml", .{
+            .checked_arithmetic_text = "overflow-checks = true",
+        });
 
         var tmp_beetle = try TmpTigerBeetle.init(gpa, .{
             .development = true,

--- a/src/clients/rust/ci.zig
+++ b/src/clients/rust/ci.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const log = std.log;
+const assert = std.debug.assert;
 
 const Shell = @import("stdx").Shell;
 const TmpTigerBeetle = @import("../../testing/tmp_tigerbeetle.zig");
@@ -16,9 +17,10 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
 
         try shell.exec("cargo fmt --check", .{});
         try shell.exec("cargo clippy -- -D clippy::all", .{});
-        try shell.exec("grep -q {checked_arithmetic_text} Cargo.toml", .{
-            .checked_arithmetic_text = "overflow-checks = true",
-        });
+        assert(try file_contains(shell, gpa, "Cargo.toml", .{
+            .needle = "overflow-checks = true",
+            .line_length_max = 100,
+        }));
 
         var tmp_beetle = try TmpTigerBeetle.init(gpa, .{
             .development = true,
@@ -29,6 +31,29 @@ pub fn tests(shell: *Shell, gpa: std.mem.Allocator) !void {
         try shell.env.put("TB_ADDRESS", tmp_beetle.port_str);
         try shell.exec("cargo run", .{});
     }
+}
+
+fn file_contains(
+    shell: *Shell,
+    gpa: std.mem.Allocator,
+    path: []const u8,
+    options: struct {
+        needle: []const u8,
+        line_length_max: u32 = 100,
+    },
+) !bool {
+    const file = try shell.cwd.openFile(path, .{});
+    defer file.close();
+
+    const line_buffer = try gpa.alloc(u8, options.line_length_max + 1);
+    defer gpa.free(line_buffer);
+
+    const reader = file.reader();
+    while (try reader.readUntilDelimiterOrEof(line_buffer, '\n')) |line| {
+        if (std.mem.indexOf(u8, line, options.needle) != null) return true;
+    }
+
+    return false;
 }
 
 pub fn validate_release_package(shell: *Shell, gpa: std.mem.Allocator, options: struct {

--- a/src/clients/rust/rust_bindings.zig
+++ b/src/clients/rust/rust_bindings.zig
@@ -79,22 +79,19 @@ fn resolve_rust_type(comptime Type: type) []const u8 {
     }
 }
 
-fn emit_enum(
-    buffer: *std.ArrayList(u8),
+fn emit_bitflags(
+    writer: anytype,
     comptime Type: type,
-    comptime type_info: anytype,
+    comptime type_info: std.builtin.Type.Struct,
     comptime rust_name: []const u8,
     comptime skip_fields: []const []const u8,
 ) !void {
+    assert(@typeInfo(Type).@"struct".layout == .@"packed");
+
     var suffix_pos = std.mem.lastIndexOf(u8, rust_name, "_").?;
     if (std.mem.count(u8, rust_name, "_") == 1) suffix_pos = rust_name.len;
 
-    const backing_type = switch (@typeInfo(Type)) {
-        .@"struct" => |s| s.backing_integer.?,
-        .@"enum" => |e| e.tag_type,
-        else => @panic("unexpected"),
-    };
-    const rust_backing_type_str = switch (@typeInfo(backing_type)) {
+    const backing_type_text = switch (@typeInfo(type_info.backing_integer.?)) {
         .int => |i| brk: {
             break :brk switch (i.bits) {
                 32 => switch (i.signedness) {
@@ -109,75 +106,145 @@ fn emit_enum(
         else => @panic("unexpected"),
     };
 
-    try buffer.writer().print("pub type {s} = {s};\n", .{ rust_name, rust_backing_type_str });
+    try writer.print(
+        \\#[derive(Copy, Clone, Debug, Default)] 
+        \\#[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
+        \\#[repr(transparent)]
+        \\pub struct {[rust_name]s}({[backing_type_text]s});
+        \\ 
+    , .{ .rust_name = rust_name, .backing_type_text = backing_type_text });
 
-    inline for (type_info.fields, 0..) |field, i| {
+    try writer.print("impl {s} {{\n", .{rust_name});
+    {
+        inline for (type_info.fields, 0..) |field, bit_index| {
+            if (comptime std.mem.startsWith(u8, field.name, "deprecated_")) continue;
+            comptime var skip = false;
+            inline for (skip_fields) |sf| {
+                skip = skip or comptime std.mem.eql(u8, sf, field.name);
+            }
+            if (skip) continue;
+
+            assert(field.type == bool);
+            const field_name = stdx.to_case(field.name, .PascalCase);
+            try writer.print("    pub const {s}: {s} = {s}(1 << {});\n", .{
+                field_name,
+                rust_name,
+                rust_name,
+                bit_index,
+            });
+        }
+        try writer.print("\n", .{});
+        try writer.print("    pub fn empty() -> Self {{ return {s}(0) }}\n", .{rust_name});
+        try writer.print("    pub fn bits(self) -> {s} {{ return self.0 }}\n", .{
+            backing_type_text,
+        });
+        try writer.print(
+            "    pub fn contains(self, other: Self) -> bool {{ (self.0 & other.0) != 0 }}\n",
+            .{},
+        );
+
+        const mask = @as(type_info.backing_integer.?, (1 << type_info.fields.len) - 1);
+        try writer.print(
+            "    pub fn from_bits_truncate(bits: {s}) -> Self {{ Self(bits & 0x{X}) }}\n",
+            .{ backing_type_text, mask },
+        );
+    }
+    try writer.print("}}\n\n", .{});
+
+    try writer.print(
+        \\impl std::ops::BitOr for {[rust_name]s} {{
+        \\    type Output = {[rust_name]s};
+        \\    fn bitor(self, rhs: Self) -> Self::Output {{
+        \\         Self(self.0 | rhs.0)
+        \\    }}
+        \\}}
+        \\
+        \\ 
+    , .{ .rust_name = rust_name });
+}
+
+fn emit_enum(
+    writer: anytype,
+    comptime Type: type,
+    comptime type_info: std.builtin.Type.Enum,
+    comptime rust_name: []const u8,
+    comptime skip_fields: []const []const u8,
+) !void {
+    var suffix_pos = std.mem.lastIndexOf(u8, rust_name, "_").?;
+    if (std.mem.count(u8, rust_name, "_") == 1) suffix_pos = rust_name.len;
+
+    const backing_type_text = switch (@typeInfo(type_info.tag_type)) {
+        .int => |i| brk: {
+            break :brk switch (i.bits) {
+                32 => switch (i.signedness) {
+                    .unsigned => "u32",
+                    .signed => "i32",
+                },
+                16 => "u16",
+                8 => "u8",
+                else => @panic("unexpected"),
+            };
+        },
+        else => @panic("unexpected"),
+    };
+
+    try writer.print("pub type {s} = {s};\n", .{ rust_name, backing_type_text });
+
+    inline for (type_info.fields) |field| {
         if (comptime std.mem.startsWith(u8, field.name, "deprecated_")) continue;
         comptime var skip = false;
         inline for (skip_fields) |sf| {
             skip = skip or comptime std.mem.eql(u8, sf, field.name);
         }
+        if (skip) continue;
 
-        if (!skip) {
-            const field_name = stdx.to_case(field.name, .UPPER_CASE);
-            if (@typeInfo(Type) == .@"enum") {
-                const int_value = @intFromEnum(@field(Type, field.name));
-                try buffer.writer().print("pub const {s}_{s}_{s}: {s} = {s};\n", .{
-                    rust_name,
-                    rust_name[0..suffix_pos],
-                    field_name,
-                    rust_name,
-                    if (int_value == std.math.maxInt(@TypeOf(int_value)))
-                        std.fmt.comptimePrint("0x{X}", .{int_value})
-                    else
-                        std.fmt.comptimePrint("{}", .{int_value}),
-                });
-            } else {
-                // Packed structs.
-                try buffer.writer().print("pub const {s}_{s}_{s}: {s} = 1 << {};\n", .{
-                    rust_name,
-                    rust_name[0..suffix_pos],
-                    field_name,
-                    rust_name,
-                    i,
-                });
-            }
-        }
+        const field_name = stdx.to_case(field.name, .UPPER_CASE);
+        const int_value = @intFromEnum(@field(Type, field.name));
+        try writer.print("pub const {s}_{s}_{s}: {s} = {s};\n", .{
+            rust_name,
+            rust_name[0..suffix_pos],
+            @as([]const u8, &field_name),
+            rust_name,
+            if (int_value == std.math.maxInt(@TypeOf(int_value)))
+                std.fmt.comptimePrint("0x{X}", .{int_value})
+            else
+                std.fmt.comptimePrint("{}", .{int_value}),
+        });
     }
 
-    try buffer.writer().print("\n", .{});
+    try writer.print("\n", .{});
 }
 
 fn emit_struct(
-    buffer: *std.ArrayList(u8),
+    writer: anytype,
     comptime type_info: anytype,
     comptime rust_name: []const u8,
 ) !void {
-    try buffer.writer().print("#[repr(C)]\n", .{});
-    try buffer.writer().print("#[derive(Debug, Copy, Clone)]\n", .{});
-    try buffer.writer().print("pub struct {s} {{\n", .{rust_name});
+    try writer.print("#[repr(C)]\n", .{});
+    try writer.print("#[derive(Debug, Copy, Clone)]\n", .{});
+    try writer.print("pub struct {s} {{\n", .{rust_name});
 
     inline for (type_info.fields) |field| {
         switch (@typeInfo(field.type)) {
             .array => |array| {
-                try buffer.writer().print("    pub {s}: [{s}; {}]", .{
+                try writer.print("    pub {s}: [{s}; {}]", .{
                     field.name,
                     resolve_rust_type(field.type),
                     array.len,
                 });
             },
             else => {
-                try buffer.writer().print("    pub {s}: {s}", .{
+                try writer.print("    pub {s}: {s}", .{
                     field.name,
                     resolve_rust_type(field.type),
                 });
             },
         }
 
-        try buffer.writer().print(",\n", .{});
+        try writer.print(",\n", .{});
     }
 
-    try buffer.writer().print("}}\n\n", .{});
+    try writer.print("}}\n\n", .{});
 }
 
 pub fn main() !void {
@@ -186,7 +253,8 @@ pub fn main() !void {
     const allocator = arena.allocator();
 
     var buffer = std.ArrayList(u8).init(allocator);
-    try buffer.writer().print(
+    var writer = buffer.writer();
+    try writer.print(
         \\ ///////////////////////////////////////////////////////
         \\ // This file was auto-generated by rust_bindings.zig //
         \\ //              Do not manually modify.              //
@@ -200,27 +268,27 @@ pub fn main() !void {
         const rust_name = type_mapping[1];
         if (type_mapping.len == 3) {
             const comments: []const u8 = type_mapping[2];
-            try buffer.writer().print(comments, .{});
-            try buffer.writer().print("\n", .{});
+            try writer.print(comments, .{});
+            try writer.print("\n", .{});
         }
 
         switch (@typeInfo(ZigType)) {
             .@"struct" => |info| switch (info.layout) {
                 .auto => @compileError("Invalid C struct type: " ++ @typeName(ZigType)),
-                .@"packed" => try emit_enum(&buffer, ZigType, info, rust_name, &.{"padding"}),
-                .@"extern" => try emit_struct(&buffer, info, rust_name),
+                .@"packed" => try emit_bitflags(writer, ZigType, info, rust_name, &.{"padding"}),
+                .@"extern" => try emit_struct(writer, info, rust_name),
             },
             .@"enum" => |info| {
-                try emit_enum(&buffer, ZigType, info, rust_name, &.{});
+                try emit_enum(writer, ZigType, info, rust_name, &.{});
             },
-            else => try buffer.writer().print("pub type {s} = {s};\n\n", .{
+            else => try writer.print("pub type {s} = {s};\n\n", .{
                 rust_name,
                 resolve_rust_type(ZigType),
             }),
         }
     }
 
-    try buffer.writer().print(
+    try writer.print(
         \\extern "C" {{
         \\    // Initialize a new TigerBeetle client which connects to the addresses provided and
         \\    // completes submitted packets by invoking the callback with the given context.

--- a/src/clients/rust/rust_bindings.zig
+++ b/src/clients/rust/rust_bindings.zig
@@ -111,7 +111,7 @@ fn emit_bitflags(
         \\#[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
         \\#[repr(transparent)]
         \\pub struct {[rust_name]s}({[backing_type_text]s});
-        \\ 
+        \\
     , .{ .rust_name = rust_name, .backing_type_text = backing_type_text });
 
     try writer.print("impl {s} {{\n", .{rust_name});

--- a/src/clients/rust/rust_bindings.zig
+++ b/src/clients/rust/rust_bindings.zig
@@ -134,8 +134,8 @@ fn emit_bitflags(
             });
         }
         try writer.print("\n", .{});
-        try writer.print("    pub fn empty() -> Self {{ return {s}(0) }}\n", .{rust_name});
-        try writer.print("    pub fn bits(self) -> {s} {{ return self.0 }}\n", .{
+        try writer.print("    pub fn empty() -> Self {{ {s}(0) }}\n", .{rust_name});
+        try writer.print("    pub fn bits(self) -> {s} {{ self.0 }}\n", .{
             backing_type_text,
         });
         try writer.print(
@@ -203,7 +203,7 @@ fn emit_enum(
         try writer.print("pub const {s}_{s}_{s}: {s} = {s};\n", .{
             rust_name,
             rust_name[0..suffix_pos],
-            @as([]const u8, &field_name),
+            field_name,
             rust_name,
             if (int_value == std.math.maxInt(@TypeOf(int_value)))
                 std.fmt.comptimePrint("0x{X}", .{int_value})

--- a/src/clients/rust/rust_bindings.zig
+++ b/src/clients/rust/rust_bindings.zig
@@ -5,19 +5,19 @@ const assert = std.debug.assert;
 const stdx = vsr.stdx;
 
 const type_mappings = .{
-    .{ exports.tb_account_flags, "TB_ACCOUNT_FLAGS" },
+    .{ exports.tb_account_flags, "AccountFlags" },
     .{ exports.tb_account_t, "tb_account_t" },
-    .{ exports.tb_transfer_flags, "TB_TRANSFER_FLAGS" },
+    .{ exports.tb_transfer_flags, "TransferFlags" },
     .{ exports.tb_transfer_t, "tb_transfer_t" },
     .{ exports.tb_create_account_status, "TB_CREATE_ACCOUNT_STATUS" },
     .{ exports.tb_create_transfer_status, "TB_CREATE_TRANSFER_STATUS" },
     .{ exports.tb_create_account_result_t, "tb_create_account_result_t" },
     .{ exports.tb_create_transfer_result_t, "tb_create_transfer_result_t" },
     .{ exports.tb_account_filter_t, "tb_account_filter_t" },
-    .{ exports.tb_account_filter_flags, "TB_ACCOUNT_FILTER_FLAGS" },
+    .{ exports.tb_account_filter_flags, "AccountFilterFlags" },
     .{ exports.tb_account_balance_t, "tb_account_balance_t" },
     .{ exports.tb_query_filter_t, "tb_query_filter_t" },
-    .{ exports.tb_query_filter_flags, "TB_QUERY_FILTER_FLAGS" },
+    .{ exports.tb_query_filter_flags, "QueryFilterFlags" },
     .{
         exports.tb_client_t, "tb_client_t",
         \\// Opaque struct serving as a handle for the client instance.
@@ -87,9 +87,8 @@ fn emit_bitflags(
     comptime skip_fields: []const []const u8,
 ) !void {
     assert(@typeInfo(Type).@"struct".layout == .@"packed");
-
-    var suffix_pos = std.mem.lastIndexOf(u8, rust_name, "_").?;
-    if (std.mem.count(u8, rust_name, "_") == 1) suffix_pos = rust_name.len;
+    assert(std.mem.count(u8, rust_name, "_") == 0);
+    assert(rust_name[0] >= 'A' and rust_name[0] <= 'Z');
 
     const backing_type_text = switch (@typeInfo(type_info.backing_integer.?)) {
         .int => |i| brk: {
@@ -110,7 +109,7 @@ fn emit_bitflags(
         \\#[derive(Copy, Clone, Debug, Default)] 
         \\#[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
         \\#[repr(transparent)]
-        \\pub struct {[rust_name]s}({[backing_type_text]s});
+        \\pub struct {[rust_name]s}(pub {[backing_type_text]s});
         \\
     , .{ .rust_name = rust_name, .backing_type_text = backing_type_text });
 
@@ -135,19 +134,6 @@ fn emit_bitflags(
         }
         try writer.print("\n", .{});
         try writer.print("    pub fn empty() -> Self {{ {s}(0) }}\n", .{rust_name});
-        try writer.print("    pub fn bits(self) -> {s} {{ self.0 }}\n", .{
-            backing_type_text,
-        });
-        try writer.print(
-            "    pub fn contains(self, other: Self) -> bool {{ (self.0 & other.0) != 0 }}\n",
-            .{},
-        );
-
-        const mask = @as(type_info.backing_integer.?, (1 << type_info.fields.len) - 1);
-        try writer.print(
-            "    pub fn from_bits_truncate(bits: {s}) -> Self {{ Self(bits & 0x{X}) }}\n",
-            .{ backing_type_text, mask },
-        );
     }
     try writer.print("}}\n\n", .{});
 
@@ -159,7 +145,7 @@ fn emit_bitflags(
         \\    }}
         \\}}
         \\
-        \\ 
+        \\
     , .{ .rust_name = rust_name });
 }
 

--- a/src/clients/rust/samples/basic/Cargo.toml
+++ b/src/clients/rust/samples/basic/Cargo.toml
@@ -6,3 +6,13 @@ edition = "2021"
 [dependencies]
 futures = { version = "0.3.31", default-features = false, features = ["executor"] }
 tigerbeetle.path = "../.."
+
+[profile.release]
+# It is *strongly* recommended that Rust applications using TigerBeetle
+# enable overflow checks, because the nature of accounting makes overflow
+# errors catastrophic.
+#
+# Note that the following line enables the checks only for the tests in
+# this crate. In other words, overflow checks must be enabled in the
+# Cargo.toml of the end application.
+overflow-checks = true

--- a/src/clients/rust/samples/two-phase-many/Cargo.toml
+++ b/src/clients/rust/samples/two-phase-many/Cargo.toml
@@ -7,3 +7,13 @@ edition = "2021"
 tokio.version = "=1.38.1"
 tokio.features = ["rt-multi-thread"]
 tigerbeetle.path = "../.."
+
+[profile.release]
+# It is *strongly* recommended that Rust applications using TigerBeetle
+# enable overflow checks, because the nature of accounting makes overflow
+# errors catastrophic.
+#
+# Note that the following line enables the checks only for the tests in
+# this crate. In other words, overflow checks must be enabled in the
+# Cargo.toml of the end application.
+overflow-checks = true

--- a/src/clients/rust/samples/two-phase-many/src/main.rs
+++ b/src/clients/rust/samples/two-phase-many/src/main.rs
@@ -1,50 +1,5 @@
 use tigerbeetle as tb;
 
-async fn assert_account_balances(
-    client: &tb::Client,
-    expected_accounts: &[tb::Account],
-    debug_msg: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let ids: Vec<u128> = expected_accounts.iter().map(|a| a.id).collect();
-    let found_accounts = client.lookup_accounts(&ids)?.await?;
-    assert_eq!(expected_accounts.len(), found_accounts.len(), "accounts");
-
-    for found_account in &found_accounts {
-        let mut requested = false;
-        for expected_account in expected_accounts {
-            if expected_account.id == found_account.id {
-                requested = true;
-                assert_eq!(
-                    expected_account.debits_posted, found_account.debits_posted,
-                    "account {} debits, {}",
-                    expected_account.id, debug_msg
-                );
-                assert_eq!(
-                    expected_account.credits_posted, found_account.credits_posted,
-                    "account {} credits, {}",
-                    expected_account.id, debug_msg
-                );
-                assert_eq!(
-                    expected_account.debits_pending, found_account.debits_pending,
-                    "account {} debits pending, {}",
-                    expected_account.id, debug_msg
-                );
-                assert_eq!(
-                    expected_account.credits_pending, found_account.credits_pending,
-                    "account {} credits pending, {}",
-                    expected_account.id, debug_msg
-                );
-            }
-        }
-
-        if !requested {
-            panic!("Unexpected account: {}", found_account.id);
-        }
-    }
-
-    Ok(())
-}
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -378,6 +333,51 @@ async fn main_async() -> Result<(), Box<dyn std::error::Error>> {
         "after completing 5 pending transfers",
     )
     .await?;
+
+    Ok(())
+}
+
+async fn assert_account_balances(
+    client: &tb::Client,
+    expected_accounts: &[tb::Account],
+    debug_msg: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let ids: Vec<u128> = expected_accounts.iter().map(|a| a.id).collect();
+    let found_accounts = client.lookup_accounts(&ids)?.await?;
+    assert_eq!(expected_accounts.len(), found_accounts.len(), "accounts");
+
+    for found_account in &found_accounts {
+        let mut requested = false;
+        for expected_account in expected_accounts {
+            if expected_account.id == found_account.id {
+                requested = true;
+                assert_eq!(
+                    expected_account.debits_posted, found_account.debits_posted,
+                    "account {} debits, {}",
+                    expected_account.id, debug_msg
+                );
+                assert_eq!(
+                    expected_account.credits_posted, found_account.credits_posted,
+                    "account {} credits, {}",
+                    expected_account.id, debug_msg
+                );
+                assert_eq!(
+                    expected_account.debits_pending, found_account.debits_pending,
+                    "account {} debits pending, {}",
+                    expected_account.id, debug_msg
+                );
+                assert_eq!(
+                    expected_account.credits_pending, found_account.credits_pending,
+                    "account {} credits pending, {}",
+                    expected_account.id, debug_msg
+                );
+            }
+        }
+
+        if !requested {
+            panic!("Unexpected account: {}", found_account.id);
+        }
+    }
 
     Ok(())
 }

--- a/src/clients/rust/samples/two-phase/Cargo.toml
+++ b/src/clients/rust/samples/two-phase/Cargo.toml
@@ -7,3 +7,13 @@ edition = "2021"
 tokio.version = "=1.38.1"
 tokio.features = ["rt-multi-thread"]
 tigerbeetle.path = "../.."
+
+[profile.release]
+# It is *strongly* recommended that Rust applications using TigerBeetle
+# enable overflow checks, because the nature of accounting makes overflow
+# errors catastrophic.
+#
+# Note that the following line enables the checks only for the tests in
+# this crate. In other words, overflow checks must be enabled in the
+# Cargo.toml of the end application.
+overflow-checks = true

--- a/src/clients/rust/samples/two-phase/src/main.rs
+++ b/src/clients/rust/samples/two-phase/src/main.rs
@@ -114,24 +114,20 @@ async fn main_async() -> Result<(), Box<dyn std::error::Error>> {
     for transfer in &transfers {
         if transfer.id == 1 {
             assert!(
-                transfer.flags.contains(tb::TransferFlags::Pending),
+                transfer.flags.0 & tb::TransferFlags::Pending.0 != 0,
                 "transfer 1 pending"
             );
             assert!(
-                !transfer
-                    .flags
-                    .contains(tb::TransferFlags::PostPendingTransfer),
+                transfer.flags.0 & tb::TransferFlags::PostPendingTransfer.0 == 0,
                 "transfer 1 post_pending_transfer"
             );
         } else if transfer.id == 2 {
             assert!(
-                !transfer.flags.contains(tb::TransferFlags::Pending),
+                transfer.flags.0 & tb::TransferFlags::Pending.0 == 0,
                 "transfer 2 pending"
             );
             assert!(
-                transfer
-                    .flags
-                    .contains(tb::TransferFlags::PostPendingTransfer),
+                transfer.flags.0 & tb::TransferFlags::PostPendingTransfer.0 != 0,
                 "transfer 2 post_pending_transfer"
             );
         } else {

--- a/src/clients/rust/samples/walkthrough/Cargo.toml
+++ b/src/clients/rust/samples/walkthrough/Cargo.toml
@@ -6,3 +6,13 @@ edition = "2021"
 [dependencies]
 futures = { version = "0.3.31", default-features = false, features = ["executor"] }
 tigerbeetle.path = "../.."
+
+[profile.release]
+# It is *strongly* recommended that Rust applications using TigerBeetle
+# enable overflow checks, because the nature of accounting makes overflow
+# errors catastrophic.
+#
+# Note that the following line enables the checks only for the tests in
+# this crate. In other words, overflow checks must be enabled in the
+# Cargo.toml of the end application.
+overflow-checks = true

--- a/src/clients/rust/src/lib.rs
+++ b/src/clients/rust/src/lib.rs
@@ -1185,7 +1185,6 @@ pub struct Transfer {
 /// [`Transfer.flags`](https://docs.tigerbeetle.com/reference/transfer/#flags).
 pub type TransferFlags = tbc::TB_TRANSFER_FLAGS;
 
-
 /// Filter for querying transfers and historical balances.
 ///
 /// # Protocol reference
@@ -1255,7 +1254,6 @@ pub struct QueryFilter {
 ///
 /// [`QueryFilter.flags`](https://docs.tigerbeetle.com/reference/query-filter/#flags).
 pub type QueryFilterFlags = tbc::TB_QUERY_FILTER_FLAGS;
-
 
 /// The result of a single [`create_accounts`] event.
 ///

--- a/src/clients/rust/src/lib.rs
+++ b/src/clients/rust/src/lib.rs
@@ -314,8 +314,6 @@
 //!
 //! [The TigerBeetle Reference](https://docs.tigerbeetle.com/reference/).
 
-use bitflags::bitflags;
-
 use std::future::Future;
 use std::os::raw::{c_char, c_void};
 use std::{fmt, mem, ptr};
@@ -1150,27 +1148,12 @@ pub struct Account {
     pub timestamp: u64,
 }
 
-bitflags! {
-    /// Bitflags for the `flags` field of [`Account`].
-    ///
-    /// See the [`bitflags` crate](https://docs.rs/bitflags) for an explanation of Rust bitflags.
-    ///
-    /// # Protocol reference
-    ///
-    /// [`Account.flags`](https://docs.tigerbeetle.com/reference/account/#flags).
-    #[repr(transparent)]
-    #[derive(Copy, Clone, Debug, Default)]
-    #[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
-    pub struct AccountFlags: u16 {
-        const None = 0;
-        const Linked = tbc::TB_ACCOUNT_FLAGS_TB_ACCOUNT_LINKED;
-        const DebitsMustNotExceedCredits = tbc::TB_ACCOUNT_FLAGS_TB_ACCOUNT_DEBITS_MUST_NOT_EXCEED_CREDITS;
-        const CreditsMustNotExceedDebits = tbc::TB_ACCOUNT_FLAGS_TB_ACCOUNT_CREDITS_MUST_NOT_EXCEED_DEBITS;
-        const History = tbc::TB_ACCOUNT_FLAGS_TB_ACCOUNT_HISTORY;
-        const Imported = tbc::TB_ACCOUNT_FLAGS_TB_ACCOUNT_IMPORTED;
-        const Closed = tbc::TB_ACCOUNT_FLAGS_TB_ACCOUNT_CLOSED;
-    }
-}
+/// Bitflags for the `flags` field of [`Account`].
+///
+/// # Protocol reference
+///
+/// [`Account.flags`](https://docs.tigerbeetle.com/reference/account/#flags).
+pub type AccountFlags = tbc::TB_ACCOUNT_FLAGS;
 
 /// A transfer between accounts.
 ///
@@ -1195,29 +1178,13 @@ pub struct Transfer {
     pub timestamp: u64,
 }
 
-bitflags! {
-    /// Bitflags for the `flags` field of [`Transfer`].
-    ///
-    /// See the [`bitflags` crate](https://docs.rs/bitflags) for an explanation of Rust bitflags.
-    ///
-    /// # Protocol reference
-    ///
-    /// [`Transfer.flags`](https://docs.tigerbeetle.com/reference/transfer/#flags).
-    #[repr(transparent)]
-    #[derive(Copy, Clone, Debug, Default)]
-    #[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
-    pub struct TransferFlags: u16 {
-        const Linked = tbc::TB_TRANSFER_FLAGS_TB_TRANSFER_LINKED;
-        const Pending = tbc::TB_TRANSFER_FLAGS_TB_TRANSFER_PENDING;
-        const PostPendingTransfer = tbc::TB_TRANSFER_FLAGS_TB_TRANSFER_POST_PENDING_TRANSFER;
-        const VoidPendingTransfer = tbc::TB_TRANSFER_FLAGS_TB_TRANSFER_VOID_PENDING_TRANSFER;
-        const BalancingDebit = tbc::TB_TRANSFER_FLAGS_TB_TRANSFER_BALANCING_DEBIT;
-        const BalancingCredit = tbc::TB_TRANSFER_FLAGS_TB_TRANSFER_BALANCING_CREDIT;
-        const ClosingDebit = tbc::TB_TRANSFER_FLAGS_TB_TRANSFER_CLOSING_DEBIT;
-        const ClosingCredit = tbc::TB_TRANSFER_FLAGS_TB_TRANSFER_CLOSING_CREDIT;
-        const Imported = tbc::TB_TRANSFER_FLAGS_TB_TRANSFER_IMPORTED;
-    }
-}
+/// Bitflags for the `flags` field of [`Transfer`].
+///
+/// # Protocol reference
+///
+/// [`Transfer.flags`](https://docs.tigerbeetle.com/reference/transfer/#flags).
+pub type TransferFlags = tbc::TB_TRANSFER_FLAGS;
+
 
 /// Filter for querying transfers and historical balances.
 ///
@@ -1239,23 +1206,12 @@ pub struct AccountFilter {
     pub flags: AccountFilterFlags,
 }
 
-bitflags! {
-    /// Bitflags for the `flags` field of [`AccountFilter`].
-    ///
-    /// See the [`bitflags` crate](https://docs.rs/bitflags) for an explanation of Rust bitflags.
-    ///
-    /// # Protocol reference
-    ///
-    /// [`AccountFilter.flags`](https://docs.tigerbeetle.com/reference/account-filter/#flags).
-    #[repr(transparent)]
-    #[derive(Copy, Clone, Debug, Default)]
-    #[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
-    pub struct AccountFilterFlags: u32 {
-        const Debits = tbc::TB_ACCOUNT_FILTER_FLAGS_TB_ACCOUNT_FILTER_DEBITS;
-        const Credits = tbc::TB_ACCOUNT_FILTER_FLAGS_TB_ACCOUNT_FILTER_CREDITS;
-        const Reversed = tbc::TB_ACCOUNT_FILTER_FLAGS_TB_ACCOUNT_FILTER_REVERSED;
-    }
-}
+/// Bitflags for the `flags` field of [`AccountFilter`].
+///
+/// # Protocol reference
+///
+/// [`AccountFilter.flags`](https://docs.tigerbeetle.com/reference/account-filter/#flags).
+pub type AccountFilterFlags = tbc::TB_ACCOUNT_FILTER_FLAGS;
 
 /// An account balance at a point in time.
 ///
@@ -1293,21 +1249,13 @@ pub struct QueryFilter {
     pub flags: QueryFilterFlags,
 }
 
-bitflags! {
-    /// Bitflags for the `flags` field of [`QueryFilter`].
-    ///
-    /// See the [`bitflags` crate](https://docs.rs/bitflags) for an explanation of Rust bitflags.
-    ///
-    /// # Protocol reference
-    ///
-    /// [`QueryFilter.flags`](https://docs.tigerbeetle.com/reference/query-filter/#flags).
-    #[repr(transparent)]
-    #[derive(Copy, Clone, Debug, Default)]
-    #[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
-    pub struct QueryFilterFlags: u32 {
-        const Reversed = tbc::TB_QUERY_FILTER_FLAGS_TB_QUERY_FILTER_REVERSED;
-    }
-}
+/// Bitflags for the `flags` field of [`QueryFilter`].
+///
+/// # Protocol reference
+///
+/// [`QueryFilter.flags`](https://docs.tigerbeetle.com/reference/query-filter/#flags).
+pub type QueryFilterFlags = tbc::TB_QUERY_FILTER_FLAGS;
+
 
 /// The result of a single [`create_accounts`] event.
 ///

--- a/src/clients/rust/src/lib.rs
+++ b/src/clients/rust/src/lib.rs
@@ -139,7 +139,7 @@
 //!         End,
 //!     }
 //!
-//!     let is_reverse = event.flags.contains(tb::AccountFilterFlags::Reversed);
+//!     let is_reverse = (event.flags.0 & tb::AccountFilterFlags::Reversed.0) != 0;
 //!
 //!     futures::stream::unfold(State::Start, move |state| async move {
 //!         let event = match state {
@@ -1060,14 +1060,6 @@ fn assert_abi_compatibility() {
         std::mem::align_of::<tbc::tb_account_t>()
     );
     assert_eq!(
-        std::mem::size_of::<AccountFlags>(),
-        std::mem::size_of::<tbc::TB_ACCOUNT_FLAGS>()
-    );
-    assert_eq!(
-        std::mem::align_of::<AccountFlags>(),
-        std::mem::align_of::<tbc::TB_ACCOUNT_FLAGS>()
-    );
-    assert_eq!(
         std::mem::size_of::<Transfer>(),
         std::mem::size_of::<tbc::tb_transfer_t>()
     );
@@ -1076,28 +1068,12 @@ fn assert_abi_compatibility() {
         std::mem::align_of::<tbc::tb_transfer_t>()
     );
     assert_eq!(
-        std::mem::size_of::<TransferFlags>(),
-        std::mem::size_of::<tbc::TB_TRANSFER_FLAGS>()
-    );
-    assert_eq!(
-        std::mem::align_of::<TransferFlags>(),
-        std::mem::align_of::<tbc::TB_TRANSFER_FLAGS>()
-    );
-    assert_eq!(
         std::mem::size_of::<AccountFilter>(),
         std::mem::size_of::<tbc::tb_account_filter_t>()
     );
     assert_eq!(
         std::mem::align_of::<AccountFilter>(),
         std::mem::align_of::<tbc::tb_account_filter_t>()
-    );
-    assert_eq!(
-        std::mem::size_of::<AccountFilterFlags>(),
-        std::mem::size_of::<tbc::TB_ACCOUNT_FILTER_FLAGS>()
-    );
-    assert_eq!(
-        std::mem::align_of::<AccountFilterFlags>(),
-        std::mem::align_of::<tbc::TB_ACCOUNT_FILTER_FLAGS>()
     );
     assert_eq!(
         std::mem::size_of::<AccountBalance>(),
@@ -1114,14 +1090,6 @@ fn assert_abi_compatibility() {
     assert_eq!(
         std::mem::align_of::<QueryFilter>(),
         std::mem::align_of::<tbc::tb_query_filter_t>()
-    );
-    assert_eq!(
-        std::mem::size_of::<QueryFilterFlags>(),
-        std::mem::size_of::<tbc::TB_QUERY_FILTER_FLAGS>()
-    );
-    assert_eq!(
-        std::mem::align_of::<QueryFilterFlags>(),
-        std::mem::align_of::<tbc::TB_QUERY_FILTER_FLAGS>()
     );
 }
 
@@ -1153,7 +1121,7 @@ pub struct Account {
 /// # Protocol reference
 ///
 /// [`Account.flags`](https://docs.tigerbeetle.com/reference/account/#flags).
-pub type AccountFlags = tbc::TB_ACCOUNT_FLAGS;
+pub use tbc::AccountFlags;
 
 /// A transfer between accounts.
 ///
@@ -1183,7 +1151,7 @@ pub struct Transfer {
 /// # Protocol reference
 ///
 /// [`Transfer.flags`](https://docs.tigerbeetle.com/reference/transfer/#flags).
-pub type TransferFlags = tbc::TB_TRANSFER_FLAGS;
+pub use tbc::TransferFlags;
 
 /// Filter for querying transfers and historical balances.
 ///
@@ -1210,7 +1178,7 @@ pub struct AccountFilter {
 /// # Protocol reference
 ///
 /// [`AccountFilter.flags`](https://docs.tigerbeetle.com/reference/account-filter/#flags).
-pub type AccountFilterFlags = tbc::TB_ACCOUNT_FILTER_FLAGS;
+pub use tbc::AccountFilterFlags;
 
 /// An account balance at a point in time.
 ///
@@ -1253,7 +1221,7 @@ pub struct QueryFilter {
 /// # Protocol reference
 ///
 /// [`QueryFilter.flags`](https://docs.tigerbeetle.com/reference/query-filter/#flags).
-pub type QueryFilterFlags = tbc::TB_QUERY_FILTER_FLAGS;
+pub use tbc::QueryFilterFlags;
 
 /// The result of a single [`create_accounts`] event.
 ///

--- a/src/clients/rust/src/lib.rs
+++ b/src/clients/rust/src/lib.rs
@@ -26,7 +26,7 @@
 //! // Connect to TigerBeetle
 //! let client = tb::Client::new(0, "127.0.0.1:3000")?;
 //!
-//! // Create accounts
+//! // Create accounts. Using TigerBeetle IDs is recommended.
 //! let account_id1 = tb::id();
 //! let account_id2 = tb::id();
 //!
@@ -49,9 +49,8 @@
 //!
 //! let account_results = client.create_accounts(&accounts)?.await?;
 //!
-//! // If no results are returned, then all input events were successful -
-//! // to save resources only unsuccessful inputs return results.
-//! assert_eq!(account_results.len(), 0);
+//! // A successful reply contains one result code for each account.
+//! assert_eq!(account_results.len(), 2);
 //!
 //! // Create a transfer between accounts
 //! let transfer_id = tb::id();
@@ -66,7 +65,7 @@
 //! }];
 //!
 //! let transfer_results = client.create_transfers(&transfers)?.await?;
-//! assert_eq!(transfer_results.len(), 0);
+//! assert_eq!(transfer_results.len(), 1);
 //!
 //! // Look up the accounts to see the transfer result
 //! let accounts = client.lookup_accounts(&[account_id1, account_id2])?.await?;
@@ -112,7 +111,7 @@
 //! can be paged by incrementing `timeout_max` to one greater than the highest
 //! timeout returned in the previous batch, and issuing a new query with
 //! otherwise the same filter. This process can be repeated until the server
-//! returns an unfull batch.
+//! returns a partial batch.
 //!
 //! [`get_account_transfers`]: `Client::get_account_transfers`
 //! [`get_account_balances`]: `Client::get_account_balances`

--- a/src/clients/rust/src/tb_client.rs
+++ b/src/clients/rust/src/tb_client.rs
@@ -7,7 +7,7 @@
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
 pub struct TB_ACCOUNT_FLAGS(u16);
- impl TB_ACCOUNT_FLAGS {
+impl TB_ACCOUNT_FLAGS {
     pub const Linked: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 0);
     pub const DebitsMustNotExceedCredits: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 1);
     pub const CreditsMustNotExceedDebits: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 2);
@@ -50,7 +50,7 @@ pub struct tb_account_t {
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
 pub struct TB_TRANSFER_FLAGS(u16);
- impl TB_TRANSFER_FLAGS {
+impl TB_TRANSFER_FLAGS {
     pub const Linked: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 0);
     pub const Pending: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 1);
     pub const PostPendingTransfer: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 2);
@@ -226,7 +226,7 @@ pub struct tb_account_filter_t {
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
 pub struct TB_ACCOUNT_FILTER_FLAGS(u32);
- impl TB_ACCOUNT_FILTER_FLAGS {
+impl TB_ACCOUNT_FILTER_FLAGS {
     pub const Debits: TB_ACCOUNT_FILTER_FLAGS = TB_ACCOUNT_FILTER_FLAGS(1 << 0);
     pub const Credits: TB_ACCOUNT_FILTER_FLAGS = TB_ACCOUNT_FILTER_FLAGS(1 << 1);
     pub const Reversed: TB_ACCOUNT_FILTER_FLAGS = TB_ACCOUNT_FILTER_FLAGS(1 << 2);
@@ -274,7 +274,7 @@ pub struct tb_query_filter_t {
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
 pub struct TB_QUERY_FILTER_FLAGS(u32);
- impl TB_QUERY_FILTER_FLAGS {
+impl TB_QUERY_FILTER_FLAGS {
     pub const Reversed: TB_QUERY_FILTER_FLAGS = TB_QUERY_FILTER_FLAGS(1 << 0);
 
     pub fn empty() -> Self { return TB_QUERY_FILTER_FLAGS(0) }

--- a/src/clients/rust/src/tb_client.rs
+++ b/src/clients/rust/src/tb_client.rs
@@ -6,29 +6,26 @@
 #[derive(Copy, Clone, Debug, Default)] 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
-pub struct TB_ACCOUNT_FLAGS(u16);
-impl TB_ACCOUNT_FLAGS {
-    pub const Linked: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 0);
-    pub const DebitsMustNotExceedCredits: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 1);
-    pub const CreditsMustNotExceedDebits: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 2);
-    pub const History: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 3);
-    pub const Imported: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 4);
-    pub const Closed: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 5);
+pub struct AccountFlags(pub u16);
+impl AccountFlags {
+    pub const Linked: AccountFlags = AccountFlags(1 << 0);
+    pub const DebitsMustNotExceedCredits: AccountFlags = AccountFlags(1 << 1);
+    pub const CreditsMustNotExceedDebits: AccountFlags = AccountFlags(1 << 2);
+    pub const History: AccountFlags = AccountFlags(1 << 3);
+    pub const Imported: AccountFlags = AccountFlags(1 << 4);
+    pub const Closed: AccountFlags = AccountFlags(1 << 5);
 
-    pub fn empty() -> Self { TB_ACCOUNT_FLAGS(0) }
-    pub fn bits(self) -> u16 { self.0 }
-    pub fn contains(self, other: Self) -> bool { (self.0 & other.0) != 0 }
-    pub fn from_bits_truncate(bits: u16) -> Self { Self(bits & 0x7F) }
+    pub fn empty() -> Self { AccountFlags(0) }
 }
 
-impl std::ops::BitOr for TB_ACCOUNT_FLAGS {
-    type Output = TB_ACCOUNT_FLAGS;
+impl std::ops::BitOr for AccountFlags {
+    type Output = AccountFlags;
     fn bitor(self, rhs: Self) -> Self::Output {
          Self(self.0 | rhs.0)
     }
 }
 
- #[repr(C)]
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tb_account_t {
     pub id: u128,
@@ -49,32 +46,29 @@ pub struct tb_account_t {
 #[derive(Copy, Clone, Debug, Default)] 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
-pub struct TB_TRANSFER_FLAGS(u16);
-impl TB_TRANSFER_FLAGS {
-    pub const Linked: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 0);
-    pub const Pending: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 1);
-    pub const PostPendingTransfer: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 2);
-    pub const VoidPendingTransfer: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 3);
-    pub const BalancingDebit: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 4);
-    pub const BalancingCredit: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 5);
-    pub const ClosingDebit: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 6);
-    pub const ClosingCredit: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 7);
-    pub const Imported: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 8);
+pub struct TransferFlags(pub u16);
+impl TransferFlags {
+    pub const Linked: TransferFlags = TransferFlags(1 << 0);
+    pub const Pending: TransferFlags = TransferFlags(1 << 1);
+    pub const PostPendingTransfer: TransferFlags = TransferFlags(1 << 2);
+    pub const VoidPendingTransfer: TransferFlags = TransferFlags(1 << 3);
+    pub const BalancingDebit: TransferFlags = TransferFlags(1 << 4);
+    pub const BalancingCredit: TransferFlags = TransferFlags(1 << 5);
+    pub const ClosingDebit: TransferFlags = TransferFlags(1 << 6);
+    pub const ClosingCredit: TransferFlags = TransferFlags(1 << 7);
+    pub const Imported: TransferFlags = TransferFlags(1 << 8);
 
-    pub fn empty() -> Self { TB_TRANSFER_FLAGS(0) }
-    pub fn bits(self) -> u16 { self.0 }
-    pub fn contains(self, other: Self) -> bool { (self.0 & other.0) != 0 }
-    pub fn from_bits_truncate(bits: u16) -> Self { Self(bits & 0x3FF) }
+    pub fn empty() -> Self { TransferFlags(0) }
 }
 
-impl std::ops::BitOr for TB_TRANSFER_FLAGS {
-    type Output = TB_TRANSFER_FLAGS;
+impl std::ops::BitOr for TransferFlags {
+    type Output = TransferFlags;
     fn bitor(self, rhs: Self) -> Self::Output {
          Self(self.0 | rhs.0)
     }
 }
 
- #[repr(C)]
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tb_transfer_t {
     pub id: u128,
@@ -225,26 +219,23 @@ pub struct tb_account_filter_t {
 #[derive(Copy, Clone, Debug, Default)] 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
-pub struct TB_ACCOUNT_FILTER_FLAGS(u32);
-impl TB_ACCOUNT_FILTER_FLAGS {
-    pub const Debits: TB_ACCOUNT_FILTER_FLAGS = TB_ACCOUNT_FILTER_FLAGS(1 << 0);
-    pub const Credits: TB_ACCOUNT_FILTER_FLAGS = TB_ACCOUNT_FILTER_FLAGS(1 << 1);
-    pub const Reversed: TB_ACCOUNT_FILTER_FLAGS = TB_ACCOUNT_FILTER_FLAGS(1 << 2);
+pub struct AccountFilterFlags(pub u32);
+impl AccountFilterFlags {
+    pub const Debits: AccountFilterFlags = AccountFilterFlags(1 << 0);
+    pub const Credits: AccountFilterFlags = AccountFilterFlags(1 << 1);
+    pub const Reversed: AccountFilterFlags = AccountFilterFlags(1 << 2);
 
-    pub fn empty() -> Self { TB_ACCOUNT_FILTER_FLAGS(0) }
-    pub fn bits(self) -> u32 { self.0 }
-    pub fn contains(self, other: Self) -> bool { (self.0 & other.0) != 0 }
-    pub fn from_bits_truncate(bits: u32) -> Self { Self(bits & 0xF) }
+    pub fn empty() -> Self { AccountFilterFlags(0) }
 }
 
-impl std::ops::BitOr for TB_ACCOUNT_FILTER_FLAGS {
-    type Output = TB_ACCOUNT_FILTER_FLAGS;
+impl std::ops::BitOr for AccountFilterFlags {
+    type Output = AccountFilterFlags;
     fn bitor(self, rhs: Self) -> Self::Output {
          Self(self.0 | rhs.0)
     }
 }
 
- #[repr(C)]
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tb_account_balance_t {
     pub debits_pending: u128,
@@ -273,24 +264,21 @@ pub struct tb_query_filter_t {
 #[derive(Copy, Clone, Debug, Default)] 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
-pub struct TB_QUERY_FILTER_FLAGS(u32);
-impl TB_QUERY_FILTER_FLAGS {
-    pub const Reversed: TB_QUERY_FILTER_FLAGS = TB_QUERY_FILTER_FLAGS(1 << 0);
+pub struct QueryFilterFlags(pub u32);
+impl QueryFilterFlags {
+    pub const Reversed: QueryFilterFlags = QueryFilterFlags(1 << 0);
 
-    pub fn empty() -> Self { TB_QUERY_FILTER_FLAGS(0) }
-    pub fn bits(self) -> u32 { self.0 }
-    pub fn contains(self, other: Self) -> bool { (self.0 & other.0) != 0 }
-    pub fn from_bits_truncate(bits: u32) -> Self { Self(bits & 0x3) }
+    pub fn empty() -> Self { QueryFilterFlags(0) }
 }
 
-impl std::ops::BitOr for TB_QUERY_FILTER_FLAGS {
-    type Output = TB_QUERY_FILTER_FLAGS;
+impl std::ops::BitOr for QueryFilterFlags {
+    type Output = QueryFilterFlags;
     fn bitor(self, rhs: Self) -> Self::Output {
          Self(self.0 | rhs.0)
     }
 }
 
- // Opaque struct serving as a handle for the client instance.
+// Opaque struct serving as a handle for the client instance.
 // This struct must be "pinned" (not copyable or movable), as its address must remain stable
 // throughout the lifetime of the client instance.
 #[repr(C)]

--- a/src/clients/rust/src/tb_client.rs
+++ b/src/clients/rust/src/tb_client.rs
@@ -3,15 +3,32 @@
  //              Do not manually modify.              //
  ///////////////////////////////////////////////////////
 
-pub type TB_ACCOUNT_FLAGS = u16;
-pub const TB_ACCOUNT_FLAGS_TB_ACCOUNT_LINKED: TB_ACCOUNT_FLAGS = 1 << 0;
-pub const TB_ACCOUNT_FLAGS_TB_ACCOUNT_DEBITS_MUST_NOT_EXCEED_CREDITS: TB_ACCOUNT_FLAGS = 1 << 1;
-pub const TB_ACCOUNT_FLAGS_TB_ACCOUNT_CREDITS_MUST_NOT_EXCEED_DEBITS: TB_ACCOUNT_FLAGS = 1 << 2;
-pub const TB_ACCOUNT_FLAGS_TB_ACCOUNT_HISTORY: TB_ACCOUNT_FLAGS = 1 << 3;
-pub const TB_ACCOUNT_FLAGS_TB_ACCOUNT_IMPORTED: TB_ACCOUNT_FLAGS = 1 << 4;
-pub const TB_ACCOUNT_FLAGS_TB_ACCOUNT_CLOSED: TB_ACCOUNT_FLAGS = 1 << 5;
+#[derive(Copy, Clone, Debug, Default)] 
+#[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(transparent)]
+pub struct TB_ACCOUNT_FLAGS(u16);
+ impl TB_ACCOUNT_FLAGS {
+    pub const Linked: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 0);
+    pub const DebitsMustNotExceedCredits: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 1);
+    pub const CreditsMustNotExceedDebits: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 2);
+    pub const History: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 3);
+    pub const Imported: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 4);
+    pub const Closed: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 5);
 
-#[repr(C)]
+    pub fn empty() -> Self { return TB_ACCOUNT_FLAGS(0) }
+    pub fn bits(self) -> u16 { return self.0 }
+    pub fn contains(self, other: Self) -> bool { (self.0 & other.0) != 0 }
+    pub fn from_bits_truncate(bits: u16) -> Self { Self(bits & 0x7F) }
+}
+
+impl std::ops::BitOr for TB_ACCOUNT_FLAGS {
+    type Output = TB_ACCOUNT_FLAGS;
+    fn bitor(self, rhs: Self) -> Self::Output {
+         Self(self.0 | rhs.0)
+    }
+}
+
+ #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tb_account_t {
     pub id: u128,
@@ -29,18 +46,35 @@ pub struct tb_account_t {
     pub timestamp: u64,
 }
 
-pub type TB_TRANSFER_FLAGS = u16;
-pub const TB_TRANSFER_FLAGS_TB_TRANSFER_LINKED: TB_TRANSFER_FLAGS = 1 << 0;
-pub const TB_TRANSFER_FLAGS_TB_TRANSFER_PENDING: TB_TRANSFER_FLAGS = 1 << 1;
-pub const TB_TRANSFER_FLAGS_TB_TRANSFER_POST_PENDING_TRANSFER: TB_TRANSFER_FLAGS = 1 << 2;
-pub const TB_TRANSFER_FLAGS_TB_TRANSFER_VOID_PENDING_TRANSFER: TB_TRANSFER_FLAGS = 1 << 3;
-pub const TB_TRANSFER_FLAGS_TB_TRANSFER_BALANCING_DEBIT: TB_TRANSFER_FLAGS = 1 << 4;
-pub const TB_TRANSFER_FLAGS_TB_TRANSFER_BALANCING_CREDIT: TB_TRANSFER_FLAGS = 1 << 5;
-pub const TB_TRANSFER_FLAGS_TB_TRANSFER_CLOSING_DEBIT: TB_TRANSFER_FLAGS = 1 << 6;
-pub const TB_TRANSFER_FLAGS_TB_TRANSFER_CLOSING_CREDIT: TB_TRANSFER_FLAGS = 1 << 7;
-pub const TB_TRANSFER_FLAGS_TB_TRANSFER_IMPORTED: TB_TRANSFER_FLAGS = 1 << 8;
+#[derive(Copy, Clone, Debug, Default)] 
+#[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(transparent)]
+pub struct TB_TRANSFER_FLAGS(u16);
+ impl TB_TRANSFER_FLAGS {
+    pub const Linked: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 0);
+    pub const Pending: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 1);
+    pub const PostPendingTransfer: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 2);
+    pub const VoidPendingTransfer: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 3);
+    pub const BalancingDebit: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 4);
+    pub const BalancingCredit: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 5);
+    pub const ClosingDebit: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 6);
+    pub const ClosingCredit: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 7);
+    pub const Imported: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 8);
 
-#[repr(C)]
+    pub fn empty() -> Self { return TB_TRANSFER_FLAGS(0) }
+    pub fn bits(self) -> u16 { return self.0 }
+    pub fn contains(self, other: Self) -> bool { (self.0 & other.0) != 0 }
+    pub fn from_bits_truncate(bits: u16) -> Self { Self(bits & 0x3FF) }
+}
+
+impl std::ops::BitOr for TB_TRANSFER_FLAGS {
+    type Output = TB_TRANSFER_FLAGS;
+    fn bitor(self, rhs: Self) -> Self::Output {
+         Self(self.0 | rhs.0)
+    }
+}
+
+ #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tb_transfer_t {
     pub id: u128,
@@ -188,12 +222,29 @@ pub struct tb_account_filter_t {
     pub flags: u32,
 }
 
-pub type TB_ACCOUNT_FILTER_FLAGS = u32;
-pub const TB_ACCOUNT_FILTER_FLAGS_TB_ACCOUNT_FILTER_DEBITS: TB_ACCOUNT_FILTER_FLAGS = 1 << 0;
-pub const TB_ACCOUNT_FILTER_FLAGS_TB_ACCOUNT_FILTER_CREDITS: TB_ACCOUNT_FILTER_FLAGS = 1 << 1;
-pub const TB_ACCOUNT_FILTER_FLAGS_TB_ACCOUNT_FILTER_REVERSED: TB_ACCOUNT_FILTER_FLAGS = 1 << 2;
+#[derive(Copy, Clone, Debug, Default)] 
+#[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(transparent)]
+pub struct TB_ACCOUNT_FILTER_FLAGS(u32);
+ impl TB_ACCOUNT_FILTER_FLAGS {
+    pub const Debits: TB_ACCOUNT_FILTER_FLAGS = TB_ACCOUNT_FILTER_FLAGS(1 << 0);
+    pub const Credits: TB_ACCOUNT_FILTER_FLAGS = TB_ACCOUNT_FILTER_FLAGS(1 << 1);
+    pub const Reversed: TB_ACCOUNT_FILTER_FLAGS = TB_ACCOUNT_FILTER_FLAGS(1 << 2);
 
-#[repr(C)]
+    pub fn empty() -> Self { return TB_ACCOUNT_FILTER_FLAGS(0) }
+    pub fn bits(self) -> u32 { return self.0 }
+    pub fn contains(self, other: Self) -> bool { (self.0 & other.0) != 0 }
+    pub fn from_bits_truncate(bits: u32) -> Self { Self(bits & 0xF) }
+}
+
+impl std::ops::BitOr for TB_ACCOUNT_FILTER_FLAGS {
+    type Output = TB_ACCOUNT_FILTER_FLAGS;
+    fn bitor(self, rhs: Self) -> Self::Output {
+         Self(self.0 | rhs.0)
+    }
+}
+
+ #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct tb_account_balance_t {
     pub debits_pending: u128,
@@ -219,10 +270,27 @@ pub struct tb_query_filter_t {
     pub flags: u32,
 }
 
-pub type TB_QUERY_FILTER_FLAGS = u32;
-pub const TB_QUERY_FILTER_FLAGS_TB_QUERY_FILTER_REVERSED: TB_QUERY_FILTER_FLAGS = 1 << 0;
+#[derive(Copy, Clone, Debug, Default)] 
+#[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(transparent)]
+pub struct TB_QUERY_FILTER_FLAGS(u32);
+ impl TB_QUERY_FILTER_FLAGS {
+    pub const Reversed: TB_QUERY_FILTER_FLAGS = TB_QUERY_FILTER_FLAGS(1 << 0);
 
-// Opaque struct serving as a handle for the client instance.
+    pub fn empty() -> Self { return TB_QUERY_FILTER_FLAGS(0) }
+    pub fn bits(self) -> u32 { return self.0 }
+    pub fn contains(self, other: Self) -> bool { (self.0 & other.0) != 0 }
+    pub fn from_bits_truncate(bits: u32) -> Self { Self(bits & 0x3) }
+}
+
+impl std::ops::BitOr for TB_QUERY_FILTER_FLAGS {
+    type Output = TB_QUERY_FILTER_FLAGS;
+    fn bitor(self, rhs: Self) -> Self::Output {
+         Self(self.0 | rhs.0)
+    }
+}
+
+ // Opaque struct serving as a handle for the client instance.
 // This struct must be "pinned" (not copyable or movable), as its address must remain stable
 // throughout the lifetime of the client instance.
 #[repr(C)]

--- a/src/clients/rust/src/tb_client.rs
+++ b/src/clients/rust/src/tb_client.rs
@@ -15,8 +15,8 @@ impl TB_ACCOUNT_FLAGS {
     pub const Imported: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 4);
     pub const Closed: TB_ACCOUNT_FLAGS = TB_ACCOUNT_FLAGS(1 << 5);
 
-    pub fn empty() -> Self { return TB_ACCOUNT_FLAGS(0) }
-    pub fn bits(self) -> u16 { return self.0 }
+    pub fn empty() -> Self { TB_ACCOUNT_FLAGS(0) }
+    pub fn bits(self) -> u16 { self.0 }
     pub fn contains(self, other: Self) -> bool { (self.0 & other.0) != 0 }
     pub fn from_bits_truncate(bits: u16) -> Self { Self(bits & 0x7F) }
 }
@@ -61,8 +61,8 @@ impl TB_TRANSFER_FLAGS {
     pub const ClosingCredit: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 7);
     pub const Imported: TB_TRANSFER_FLAGS = TB_TRANSFER_FLAGS(1 << 8);
 
-    pub fn empty() -> Self { return TB_TRANSFER_FLAGS(0) }
-    pub fn bits(self) -> u16 { return self.0 }
+    pub fn empty() -> Self { TB_TRANSFER_FLAGS(0) }
+    pub fn bits(self) -> u16 { self.0 }
     pub fn contains(self, other: Self) -> bool { (self.0 & other.0) != 0 }
     pub fn from_bits_truncate(bits: u16) -> Self { Self(bits & 0x3FF) }
 }
@@ -231,8 +231,8 @@ impl TB_ACCOUNT_FILTER_FLAGS {
     pub const Credits: TB_ACCOUNT_FILTER_FLAGS = TB_ACCOUNT_FILTER_FLAGS(1 << 1);
     pub const Reversed: TB_ACCOUNT_FILTER_FLAGS = TB_ACCOUNT_FILTER_FLAGS(1 << 2);
 
-    pub fn empty() -> Self { return TB_ACCOUNT_FILTER_FLAGS(0) }
-    pub fn bits(self) -> u32 { return self.0 }
+    pub fn empty() -> Self { TB_ACCOUNT_FILTER_FLAGS(0) }
+    pub fn bits(self) -> u32 { self.0 }
     pub fn contains(self, other: Self) -> bool { (self.0 & other.0) != 0 }
     pub fn from_bits_truncate(bits: u32) -> Self { Self(bits & 0xF) }
 }
@@ -277,8 +277,8 @@ pub struct TB_QUERY_FILTER_FLAGS(u32);
 impl TB_QUERY_FILTER_FLAGS {
     pub const Reversed: TB_QUERY_FILTER_FLAGS = TB_QUERY_FILTER_FLAGS(1 << 0);
 
-    pub fn empty() -> Self { return TB_QUERY_FILTER_FLAGS(0) }
-    pub fn bits(self) -> u32 { return self.0 }
+    pub fn empty() -> Self { TB_QUERY_FILTER_FLAGS(0) }
+    pub fn bits(self) -> u32 { self.0 }
     pub fn contains(self, other: Self) -> bool { (self.0 & other.0) != 0 }
     pub fn from_bits_truncate(bits: u32) -> Self { Self(bits & 0x3) }
 }

--- a/src/clients/rust/tests/status_codes_and_flags.rs
+++ b/src/clients/rust/tests/status_codes_and_flags.rs
@@ -177,8 +177,8 @@ fn round_trip_account_flags() {
         &[],
         // We use from_bits_truncate here to discard unknown flags.
         // This will fail a round-trip test if we see one.
-        |c_value| tb::AccountFlags::from_bits_truncate(c_value),
-        |rust_value| rust_value.bits(),
+        |c_value| tb::AccountFlags(c_value),
+        |rust_value| rust_value.0,
     );
 }
 
@@ -187,8 +187,8 @@ fn round_trip_transfer_flags() {
     round_trip_test::<tb::TransferFlags, u16>(
         "TB_TRANSFER_FLAGS",
         &[],
-        |c_value| tb::TransferFlags::from_bits_truncate(c_value),
-        |rust_value| rust_value.bits(),
+        |c_value| tb::TransferFlags(c_value),
+        |rust_value| rust_value.0,
     );
 }
 
@@ -197,8 +197,8 @@ fn round_trip_account_filter_flags() {
     round_trip_test::<tb::AccountFilterFlags, u32>(
         "TB_ACCOUNT_FILTER_FLAGS",
         &[],
-        |c_value| tb::AccountFilterFlags::from_bits_truncate(c_value),
-        |rust_value| rust_value.bits(),
+        |c_value| tb::AccountFilterFlags(c_value),
+        |rust_value| rust_value.0,
     );
 }
 
@@ -207,7 +207,7 @@ fn round_trip_query_filter_flags() {
     round_trip_test::<tb::QueryFilterFlags, u32>(
         "TB_QUERY_FILTER_FLAGS",
         &[],
-        |c_value| tb::QueryFilterFlags::from_bits_truncate(c_value),
-        |rust_value| rust_value.bits(),
+        |c_value| tb::QueryFilterFlags(c_value),
+        |rust_value| rust_value.0,
     );
 }

--- a/src/clients/rust/tests/tests.rs
+++ b/src/clients/rust/tests/tests.rs
@@ -748,7 +748,7 @@ fn get_account_transfers_paged(
         End,
     }
 
-    let is_reverse = event.flags.contains(tb::AccountFilterFlags::Reversed);
+    let is_reverse = (event.flags.0 & tb::AccountFilterFlags::Reversed.0) != 0;
 
     futures::stream::unfold(State::Start, move |state| async move {
         let event = match state {


### PR DESCRIPTION
This first rust client PR 
- enables checked arithmetic even in the release profile,
- updates the doctests to the new client behavior from #3258 
- removes the last runtime dependency (`bitflags`)

The bitflags crate exposes a macro used to generate type-safe bitflag operations (in our case, basically just OR) for account flags, transfer flags, and so on.
This PR replaces the `bitflags!` rust macro with code generation in the rust bindings generator.
