### PR TITLE
vsr: use full journal

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1649,11 +1649,10 @@ pub const Checkpoint = struct {
 
     pub fn prepare_max_for_checkpoint(checkpoint: u64) ?u64 {
         assert(valid(checkpoint));
-
-        if (trigger_for_checkpoint(checkpoint)) |trigger| {
-            return trigger + (2 * constants.pipeline_prepare_queue_max);
-        } else {
+        if (checkpoint == 0) {
             return null;
+        } else {
+            return checkpoint + constants.journal_slot_count - constants.vsr_checkpoint_ops;
         }
     }
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2159,12 +2159,12 @@ pub fn ReplicaType(
                 assert(vsr.Checkpoint.durable(self.op_checkpoint_next(), self.commit_max));
                 if (message.header.op > @min(
                     // Committed ops can be safely overwritten.
-                    self.commit_min + constants.journal_slot_count,
+                    self.commit_min,
                     // Except op_checkpoint_next to op_checkpoint_next_trigger, which are required
                     // during upgrade (see `release_for_next_checkpoint`) and checkpoint (see
                     // `commit_checkpoint_superblock`), and can't be overwritten.
-                    self.op_checkpoint_next() + constants.journal_slot_count - 1,
-                )) {
+                    self.op_checkpoint_next() - 1,
+                ) + constants.journal_slot_count) {
                     log.warn("{}: on_prepare: ignoring prepare.op={} " ++
                         "(too far ahead, commit_min={} op={} commit_max={} prepare_max={})", .{
                         self.log_prefix(),


### PR DESCRIPTION
Prompted by some thinking that I was doing while reviewing https://github.com/tigerbeetle/tigerbeetle/pull/3825!

Currently, prepare_max is set to `checkpoint_trigger + (2 * pipeline_max)`. However, we round up by `lsm_compaction_ops` while computing `vsr_checkpoint_ops`:
```C
pub const vsr_checkpoint_ops = journal_slot_count -
    lsm_compaction_ops -
    lsm_compaction_ops * stdx.div_ceil(pipeline_prepare_queue_max * 2, lsm_compaction_ops);
```

Since `pipeline_max = 8`, `lsm_compaction_ops = 32`, this means that prepare_max does not go up till the end of the journal. Specifically, it is `trigger + 16`, when it could be `trigger + 32`. _Practically_, this isn't a problem since we can prepare much further once a checkpoint is durable (depending on our `commit_min`):
```C
    assert(vsr.Checkpoint.durable(self.op_checkpoint_next(), self.commit_max));
    if (message.header.op > @min(
        // Committed ops can be safely overwritten.
        self.commit_min + constants.journal_slot_count,
        // Except op_checkpoint_next to op_checkpoint_next_trigger, which are required
        // during upgrade (see `release_for_next_checkpoint`) and checkpoint (see
        // `commit_checkpoint_superblock`), and can't be overwritten.
        self.op_checkpoint_next() + constants.journal_slot_count - 1,
    )) {
```

However, when the checkpoint is not durable, we could be preparing 16 extra ops! So, fix this by mirroring the logic from constants.zig.