### PR TITLE
[Experimental] Remove the stash.

### DIFF
--- a/src/lsm/cache_map.zig
+++ b/src/lsm/cache_map.zig
@@ -28,7 +28,6 @@ pub fn CacheMapType(
     comptime Value: type,
     comptime key_from_value: fn (*const Value) callconv(.@"inline") Key,
     comptime hash_from_key: fn (Key) callconv(.@"inline") u64,
-    comptime tombstone_from_key: fn (Key) callconv(.@"inline") Value,
     comptime tombstone: fn (*const Value) callconv(.@"inline") bool,
 ) type {
     return struct {
@@ -44,24 +43,8 @@ pub fn CacheMapType(
             .{},
         );
 
-        pub const Map = std.HashMapUnmanaged(
-            Value,
-            void,
-            struct {
-                pub inline fn eql(_: @This(), a: Value, b: Value) bool {
-                    return key_from_value(&a) == key_from_value(&b);
-                }
-
-                pub inline fn hash(_: @This(), value: Value) u64 {
-                    return stdx.hash_inline(key_from_value(&value));
-                }
-            },
-            map_load_percentage_max,
-        );
-
         pub const Options = struct {
             cache_value_count_max: u32,
-            stash_value_count_max: u32,
             scope_value_count_max: u32,
             name: []const u8,
         };
@@ -79,13 +62,12 @@ pub fn CacheMapType(
         };
         const RollbackLog = std.ArrayListUnmanaged(RollbackLogAction);
 
-        // The hierarchy for lookups is cache (if present) -> stash -> immutable table -> lsm.
+        // The hierarchy for lookups is cache (if present) -> immutable table -> lsm.
         // Lower levels _may_ have stale values, provided the correct value exists
         // in one of the levels above.
         // Evictions from the cache first flow into stash, with `.compact()` clearing it.
         // When cache is null, the stash mirrors the mutable table.
-        cache: ?Cache,
-        stash: Map,
+        cache: Cache,
 
         // Scopes allow you to perform operations on the CacheMap before either persisting or
         // discarding them.
@@ -95,20 +77,15 @@ pub fn CacheMapType(
         options: Options,
 
         pub fn init(allocator: std.mem.Allocator, options: Options) !CacheMap {
-            assert(options.stash_value_count_max > 0);
-            maybe(options.cache_value_count_max == 0);
+            assert(options.cache_value_count_max > 0);
             maybe(options.scope_value_count_max == 0);
 
-            var cache: ?Cache = if (options.cache_value_count_max == 0) null else try Cache.init(
+            var cache: Cache = try .init(
                 allocator,
                 options.cache_value_count_max,
                 .{ .name = options.name },
             );
-            errdefer if (cache) |*cache_unwrapped| cache_unwrapped.deinit(allocator);
-
-            var stash: Map = .{};
-            try stash.ensureTotalCapacity(allocator, options.stash_value_count_max);
-            errdefer stash.deinit(allocator);
+            errdefer cache.deinit(allocator);
 
             var scope_rollback_log: RollbackLog = try .initCapacity(
                 allocator,
@@ -118,7 +95,6 @@ pub fn CacheMapType(
 
             return CacheMap{
                 .cache = cache,
-                .stash = stash,
                 .scope_rollback_log = scope_rollback_log,
                 .options = options,
             };
@@ -127,24 +103,18 @@ pub fn CacheMapType(
         pub fn deinit(self: *CacheMap, allocator: std.mem.Allocator) void {
             assert(!self.scope_is_active);
             assert(self.scope_rollback_log.items.len == 0);
-            assert(self.stash.count() <= self.options.stash_value_count_max);
 
             self.scope_rollback_log.deinit(allocator);
-            self.stash.deinit(allocator);
-            if (self.cache) |*cache| cache.deinit(allocator);
+            self.cache.deinit(allocator);
         }
 
         pub fn reset(self: *CacheMap) void {
             assert(!self.scope_is_active);
             assert(self.scope_rollback_log.items.len == 0);
-            assert(self.stash.count() <= self.options.stash_value_count_max);
 
-            if (self.cache) |*cache| cache.reset();
-            self.stash.clearRetainingCapacity();
-
+            self.cache.reset();
             self.* = .{
                 .cache = self.cache,
-                .stash = self.stash,
                 .scope_rollback_log = self.scope_rollback_log,
                 .options = self.options,
             };
@@ -155,38 +125,15 @@ pub fn CacheMapType(
         }
 
         pub fn get(self: *const CacheMap, key: Key) ?*Value {
-            return (if (self.cache) |*cache| cache.get(key) else null) orelse stash: {
-                if (self.stash.getKeyPtr(tombstone_from_key(key))) |object| {
-                    // Deleted keys are represented as tombstones in the stash.
-                    break :stash if (tombstone(object)) null else object;
-                }
-                break :stash null;
-            };
-        }
-
-        pub fn get_or_tombstone(self: *const CacheMap, key: Key) union(enum) {
-            found: *Value,
-            not_found,
-            tombstone,
-        } {
-            if (self.cache) |*cache| {
-                if (cache.get(key)) |object| {
-                    return .{ .found = object };
-                }
+            if (self.cache.get(key)) |object| {
+                // Deleted keys are represented as tombstones.
+                return if (tombstone(object)) null else object;
             }
-            if (self.stash.getKeyPtr(tombstone_from_key(key))) |object| {
-                // Deleted keys are represented as tombstones in the stash.
-                return if (tombstone(object)) .tombstone else .{ .found = object };
-            }
-
-            return .not_found;
+            return null;
         }
 
         pub fn cache_entries(self: *const CacheMap) u64 {
-            return if (self.cache) |*cache|
-                cache.metrics.value_count
-            else
-                0;
+            return self.cache.metrics.value_count;
         }
 
         pub fn cache_entries_max(self: *const CacheMap) u64 {
@@ -215,114 +162,50 @@ pub fn CacheMapType(
             }
         }
 
-        // Upserts the cache and stash and returns the old value in case of
+        // Upserts the cache and returns the old value in case of
         // an update.
         fn fetch_upsert(self: *CacheMap, value: *const Value) ?Value {
-            if (self.cache) |*cache| {
-                const key = key_from_value(value);
-                const result = cache.upsert(value);
+            const key = key_from_value(value);
+            const result = self.cache.upsert(value);
 
-                if (result.evicted) |*evicted| {
-                    switch (result.updated) {
-                        .update => {
-                            assert(key_from_value(evicted) == key);
-                            if (constants.verify) {
-                                const stash: ?Value = self.stash.getKey(value.*);
-                                assert(stash == null or tombstone(&stash.?));
-                            }
-
-                            // There was an eviction because an item was updated,
-                            // the evicted item is always its previous version.
-                            return evicted.*;
-                        },
-                        .insert => {
-                            assert(key_from_value(evicted) != key);
-
-                            // There was an eviction because a new item was inserted,
-                            // the evicted item will be added to the stash.
-                            const stash_updated = self.stash_upsert(evicted);
-
-                            // We don't expect stale values on the stash.
-                            assert(stash_updated == null or tombstone(&stash_updated.?));
-                        },
-                    }
-                } else {
-                    // It must be an insert without eviction,
-                    // since updates always evict the old version.
-                    assert(result.updated == .insert);
+            if (result.evicted) |*evicted| {
+                switch (result.updated) {
+                    .update => {
+                        assert(key_from_value(evicted) == key);
+                        // There was an eviction because an item was updated,
+                        // the evicted item is always its previous version.
+                        return evicted.*;
+                    },
+                    .insert => {
+                        assert(key_from_value(evicted) != key);
+                    },
                 }
-
-                // The stash may have the old value if nothing was evicted.
-                return self.stash_remove(key);
             } else {
-                // No cache.
-                // Upserting the stash directly.
-                return self.stash_upsert(value);
+                // It must be an insert without eviction,
+                // since updates always evict the old version.
+                assert(result.updated == .insert);
             }
-        }
 
-        fn stash_upsert(self: *CacheMap, value: *const Value) ?Value {
-            defer assert(self.stash.count() <= self.options.stash_value_count_max);
-            // Using `getOrPutAssumeCapacity` instead of `putAssumeCapacity` is
-            // critical, since we use HashMaps with no Value, `putAssumeCapacity`
-            // _will not_ clobber the existing value.
-            const gop = self.stash.getOrPutAssumeCapacity(value.*);
-            defer gop.key_ptr.* = value.*;
-
-            return if (gop.found_existing)
-                gop.key_ptr.*
-            else
-                null;
+            return null;
         }
 
         /// Removes a key from cache, adding a tombstone to record the action.
-        /// Invariant: The key must be present in cache.
+        /// Invariant: The key must be present in cache. // TODO: really?
         pub fn remove(self: *CacheMap, key: Key) void {
             // Only unit tests and fuzzers call this function.
             // Assert that it is not called from production code.
             comptime assert(constants.verify);
 
-            const cache_removed: ?Value = if (self.cache) |*cache|
-                cache.remove(key)
-            else
-                null;
+            const cache_removed = self.cache.remove(key).?;
+            assert(key_from_value(&cache_removed) == key);
 
-            // We don't allow stale values, so we need to remove from the stash as well,
-            // since both can have different versions with the same key.
-            const stash_removed: ?Value = stash_removed: {
-                assert(self.stash.count() <= self.options.stash_value_count_max);
-
-                const tombstone_object = tombstone_from_key(key);
-                const entry = self.stash.getOrPutAssumeCapacity(tombstone_object);
-
-                // Add a tombstone in the stash, indicating that the
-                // deletion happened and that the key should not be
-                // looked up in the immutable table or LSM tree.
-                defer entry.key_ptr.* = tombstone_object;
-
-                break :stash_removed if (entry.found_existing) entry.key_ptr.* else null;
-            };
-
-            // Does not allow removing a key that is not in the cache.
-            assert(cache_removed != null or stash_removed != null);
-            maybe(cache_removed != null and stash_removed != null);
-
-            const old_value = cache_removed orelse stash_removed orelse unreachable;
             // Cannot remove a value that has already been removed.
-            assert(!tombstone(&old_value));
+            assert(!tombstone(&cache_removed));
             if (self.scope_is_active) {
                 self.scope_rollback_log.appendAssumeCapacity(.{
-                    .restore = old_value,
+                    .restore = cache_removed,
                 });
             }
-        }
-
-        fn stash_remove(self: *CacheMap, key: Key) ?Value {
-            assert(self.stash.count() <= self.options.stash_value_count_max);
-            return if (self.stash.fetchRemove(tombstone_from_key(key))) |kv|
-                kv.key
-            else
-                null;
         }
 
         /// Start a new scope. Within a scope, changes can be persisted
@@ -335,6 +218,9 @@ pub fn CacheMapType(
 
         pub fn scope_close(self: *CacheMap, mode: ScopeCloseMode) void {
             assert(self.scope_is_active);
+            maybe(self.scope_rollback_log.items.len > 0);
+            defer assert(self.scope_rollback_log.items.len == 0);
+
             self.scope_is_active = false;
 
             // We don't need to do anything to persist a scope.
@@ -366,29 +252,19 @@ pub fn CacheMapType(
                             unreachable;
                     },
                     .remove => |key| {
-                        // Reverting an insert consists of removing the value.
-                        const cache_removed: bool =
-                            if (self.cache) |*cache| cache.remove(key) != null else false;
-
-                        // The key should be in the stash iff it wasn't in the cache.
-                        if (self.stash_remove(key)) |*stash_value| {
-                            assert(!cache_removed or tombstone(stash_value));
-                        } else {
-                            assert(cache_removed);
-                        }
+                        // A tombstone in the rollback log can only occur when the value doesn't exist
+                        // in the cache on insert.
+                        const cache_removed: bool = self.cache.remove(key) != null;
+                        assert(cache_removed);
                     },
                 }
             }
-
             self.scope_rollback_log.clearRetainingCapacity();
         }
 
         pub fn compact(self: *CacheMap) void {
             assert(!self.scope_is_active);
             assert(self.scope_rollback_log.items.len == 0);
-            assert(self.stash.count() <= self.options.stash_value_count_max);
-
-            self.stash.clearRetainingCapacity();
         }
     };
 }
@@ -428,7 +304,6 @@ pub const TestCacheMap = CacheMapType(
     TestTable.Value,
     TestTable.key_from_value,
     TestTable.hash,
-    TestTable.tombstone_from_key,
     TestTable.tombstone,
 );
 
@@ -440,7 +315,6 @@ test "cache_map: unit" {
     var cache_map = try TestCacheMap.init(allocator, .{
         .cache_value_count_max = TestCacheMap.Cache.value_count_max_multiple,
         .scope_value_count_max = 32,
-        .stash_value_count_max = 32,
         .name = "test map",
     });
     defer cache_map.deinit(allocator);
@@ -512,24 +386,4 @@ test "cache_map: unit" {
         TestTable.Value{ .key = 2, .value = 2, .tombstone = false },
         cache_map.get(2).?.*,
     );
-
-    // Test scope discard on a sequence of insert->remove->insert.
-    cache_map.upsert(&.{ .key = 4, .value = 4, .tombstone = false });
-    try testing.expectEqual(
-        TestTable.Value{ .key = 4, .value = 4, .tombstone = false },
-        cache_map.get(4).?.*,
-    );
-
-    cache_map.remove(4);
-    assert(!cache_map.has(4));
-    assert(cache_map.get(4) == null);
-    assert(cache_map.get_or_tombstone(4) == .tombstone);
-
-    cache_map.scope_open();
-    cache_map.upsert(&.{ .key = 4, .value = 4, .tombstone = false });
-    cache_map.scope_close(.discard);
-
-    assert(!cache_map.has(4));
-    assert(cache_map.get(4) == null);
-    assert(cache_map.get_or_tombstone(4) == .tombstone);
 }

--- a/src/lsm/cache_map_fuzz.zig
+++ b/src/lsm/cache_map_fuzz.zig
@@ -12,10 +12,10 @@ const log = std.log.scoped(.lsm_cache_map_fuzz);
 const Key = TestTable.Key;
 const Value = TestTable.Value;
 
-const stash_value_count_max = 1024;
-// Use a large scope (relative to stash_value_count_max) to increase the chances of
+// Use a large scope to increase the chances of
 // (SetAssociativeCache) hash collisions.
-const scope_value_count_max = stash_value_count_max;
+const scope_value_count_max = 1024;
+const upserts_since_compact_max: usize = constants.lsm_compaction_ops * scope_value_count_max;
 
 const OpValue = struct {
     op: u32,
@@ -83,7 +83,7 @@ const Environment = struct {
                         // If the entry has an op from one or more compactions ago, it
                         // may have been evicted from the cache.
                         // It must be loaded into the cache before removal, though.
-                        assert(env.model.compacts > model_value.?.op);
+                        stdx.maybe(env.model.compacts > model_value.?.op);
                         env.cache_map.upsert(&model_value.?.value);
                     }
 
@@ -106,8 +106,6 @@ const Environment = struct {
                         if (cache_map_value) |cache_map_value_unwrapped| {
                             assert(std.meta.eql(cache_map_value_unwrapped.*, model_value.?.value));
                         }
-                    } else {
-                        assert(std.meta.eql(model_value.?.value, cache_map_value.?.*));
                     }
                 },
                 .scope => |mode| switch (mode) {
@@ -150,7 +148,7 @@ const Environment = struct {
                 assert(std.meta.eql(kv.value_ptr.value, cache_map_value_unwrapped.*));
             } else {
                 // .compact() support:
-                assert(env.model.compacts > kv.value_ptr.op);
+                stdx.maybe(env.model.compacts > kv.value_ptr.op);
             }
 
             checked += 1;
@@ -160,46 +158,16 @@ const Environment = struct {
 
         // It's fine for the cache_map to have values older than .compact() in it; good, in fact,
         // but they _MUST NOT_ be stale.
-        if (env.cache_map.cache) |*cache| {
-            for (cache.values, 0..) |*cache_value, i| {
-                // If the count for an index is 0, the value doesn't exist.
-                if (cache.counts.get(i) == 0) {
-                    continue;
-                }
 
-                const model_val = env.model.get(TestTable.key_from_value(cache_value));
-                assert(std.meta.eql(cache_value.*, model_val.?.value));
-            }
-        }
-
-        // The stash can have stale values, but in that case the real value _must_ exist
-        // in the cache. It should be impossible for the stash to have a value that isn't in the
-        // model, since cache_map.remove() removes from both the cache and stash.
-        var stash_iterator = env.cache_map.stash.keyIterator();
-        while (stash_iterator.next()) |stash_value| {
-            // Get account from model.
-            const model_value = env.model.get(TestTable.key_from_value(stash_value));
-
-            // Even if the stash has stale values, the key must still exist in the model.
-            if (TestTable.tombstone(stash_value)) {
-                stdx.maybe(model_value == null);
+        for (env.cache_map.cache.values, 0..) |*cache_value, i| {
+            // If the count for an index is 0, the value doesn't exist.
+            if (env.cache_map.cache.counts.get(i) == 0) {
                 continue;
             }
-            assert(!TestTable.tombstone(stash_value));
-            assert(model_value != null);
 
-            const stash_value_equal = std.meta.eql(stash_value.*, model_value.?.value);
-
-            if (!stash_value_equal) {
-                if (env.cache_map.cache) |*cache| {
-                    // We verified all cache entries were equal and correct above, so if it exists,
-                    // it must be right.
-                    const cache_value = cache.get(
-                        TestTable.key_from_value(stash_value),
-                    );
-                    assert(cache_value != null);
-                }
-            }
+            const model_val = env.model.get(TestTable.key_from_value(cache_value));
+            assert(TestTable.tombstone(cache_value) or
+                std.meta.eql(cache_value.*, model_val.?.value));
         }
 
         log.info(
@@ -298,7 +266,7 @@ const Model = struct {
 fn random_id(prng: *stdx.PRNG) u32 {
     return fuzz.random_id(prng, u32, .{
         .average_hot = 8,
-        .average_cold = scope_value_count_max + stash_value_count_max +
+        .average_cold = scope_value_count_max +
             TestCacheMap.Cache.value_count_max_multiple,
     });
 }
@@ -333,7 +301,6 @@ pub fn generate_fuzz_ops(
     var operations_since_scope_open: usize = 0;
     const operations_since_scope_open_max: usize = scope_value_count_max;
     var upserts_since_compact: usize = 0;
-    const upserts_since_compact_max: usize = stash_value_count_max;
     var scope_is_open = false;
     for (fuzz_ops, 0..) |*fuzz_op, i| {
         var fuzz_op_tag: FuzzOpTag = undefined;
@@ -421,11 +388,11 @@ pub fn main(gpa: std.mem.Allocator, fuzz_args: fuzz.FuzzArgs) !void {
     const fuzz_ops = try generate_fuzz_ops(gpa, &prng, fuzz_op_count);
     defer gpa.free(fuzz_ops);
 
-    // Running the same fuzz with and without cache enabled.
-    inline for (&.{ TestCacheMap.Cache.value_count_max_multiple, 0 }) |cache_value_count_max| {
+    // Running the same fuzz with a cache that matches number of operations per compaction,
+    // and and the minimal cache enabled.
+    inline for (&.{ upserts_since_compact_max, TestCacheMap.Cache.value_count_max_multiple }) |cache_value_count_max| {
         const options = TestCacheMap.Options{
             .cache_value_count_max = cache_value_count_max,
-            .stash_value_count_max = stash_value_count_max,
             .scope_value_count_max = scope_value_count_max,
             .name = "fuzz map",
         };

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -691,10 +691,10 @@ const Environment = struct {
                         // sure we manually call groove.objects_cache.compact() every
                         // `stash_value_count_max` operations here.
                         // This is specific to this fuzzing code.
-                        const groove_stash_value_count_max = env.forest.grooves
-                            .transfers.objects_cache.options.stash_value_count_max;
+                        const groove_scope_value_count_max = env.forest.grooves
+                            .transfers.objects_cache.options.scope_value_count_max;
 
-                        if (log_index % groove_stash_value_count_max == 0) {
+                        if (log_index % groove_scope_value_count_max == 0) {
                             env.forest.grooves.transfers.objects_cache.compact();
                         }
                     }

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -571,7 +571,6 @@ pub fn GrooveType(
         Object,
         ObjectsCacheHelpers.key_from_value,
         ObjectsCacheHelpers.hash,
-        ObjectsCacheHelpers.tombstone_from_key,
         ObjectsCacheHelpers.tombstone,
     ) else void;
 
@@ -765,15 +764,16 @@ pub fn GrooveType(
             };
 
             groove.objects_cache = if (ObjectsCache != void) try ObjectsCache.init(allocator, .{
-                .cache_value_count_max = options.cache_entries_max,
-                // In the worst case, each stash must be able to store
+                // In the worst case, the cache must be able to store
                 // batch_value_count_limit per beat (to contain either TableMutable or
                 // TableImmutable) as well as the maximum number of prefetches a bar may
                 // perform, excluding prefetches already accounted
                 // for by batch_value_count_limit.
-                .stash_value_count_max = constants.lsm_compaction_ops *
-                    (options.tree_options_object.batch_value_count_limit +
-                        options.prefetch_entries_for_read_max),
+                .cache_value_count_max = @max(
+                    options.cache_entries_max,
+                    options.tree_options_object.batch_value_count_limit,
+                    options.prefetch_entries_for_read_max,
+                ),
 
                 // Scopes are limited to a single beat, so the maximum number of entries in
                 // a single scope is batch_value_count_limit (total – not per beat).
@@ -883,30 +883,13 @@ pub fn GrooveType(
 
         /// Gets the object from the object cache.
         pub fn get(groove: *const Groove, key: PrimaryKey) ObjectCacheResult {
-            switch (groove.objects_cache.get_or_tombstone(key)) {
-                .found => |object| {
-                    // Orphaned primary key.
-                    if (object.timestamp == 0) {
-                        if (!groove_options.primary_key_orphaned) unreachable;
-                        if (is_primary_key(.timestamp)) unreachable;
-                        comptime assert(groove_options.primary_key_orphaned);
-                        comptime assert(!is_primary_key(.timestamp));
-
-                        if (constants.verify) {
-                            const prefetch_key = groove.prefetch_keys.get(@unionInit(
-                                UniqueKey,
-                                groove_options.primary_key,
-                                key,
-                            ));
-                            assert(prefetch_key == null or
-                                prefetch_key.? == .found_orphaned or
-                                prefetch_key.? == .not_found // not found and then failed.
-                            );
-                        }
-
-                        return .found_orphaned;
-                    }
-                    assert(TimestampRange.valid(object.timestamp));
+            if (groove.objects_cache.get(key)) |object| {
+                // Orphaned primary key.
+                if (object.timestamp == 0) {
+                    if (!groove_options.primary_key_orphaned) unreachable;
+                    if (is_primary_key(.timestamp)) unreachable;
+                    comptime assert(groove_options.primary_key_orphaned);
+                    comptime assert(!is_primary_key(.timestamp));
 
                     if (constants.verify) {
                         const prefetch_key = groove.prefetch_keys.get(@unionInit(
@@ -915,38 +898,37 @@ pub fn GrooveType(
                             key,
                         ));
                         assert(prefetch_key == null or
-                            prefetch_key.? == .found or
-                            prefetch_key.? == .not_found // not found and then inserted.
+                            prefetch_key.? == .found_orphaned or
+                            prefetch_key.? == .not_found // not found and then failed.
                         );
                     }
 
-                    return .{ .found_object = object.* };
-                },
-                .tombstone => {
-                    if (constants.verify) {
-                        const prefetch_key = groove.prefetch_keys.get(@unionInit(
-                            UniqueKey,
-                            groove_options.primary_key,
-                            key,
-                        ));
-                        assert(prefetch_key == null or
-                            prefetch_key.? == .not_found or
-                            prefetch_key.? == .found // found and then deleted.
-                        );
-                    }
+                    return .found_orphaned;
+                }
+                assert(TimestampRange.valid(object.timestamp));
 
-                    return .not_found;
-                },
-                .not_found => {
-                    if (constants.verify) {
-                        const prefetch_key = groove.prefetch_keys.get(
-                            @unionInit(UniqueKey, groove_options.primary_key, key),
-                        );
-                        assert(prefetch_key == null or prefetch_key.? == .not_found);
-                    }
+                if (constants.verify) {
+                    const prefetch_key = groove.prefetch_keys.get(@unionInit(
+                        UniqueKey,
+                        groove_options.primary_key,
+                        key,
+                    ));
+                    assert(prefetch_key == null or
+                        prefetch_key.? == .found or
+                        prefetch_key.? == .not_found // not found and then inserted.
+                    );
+                }
 
-                    return .not_found;
-                },
+                return .{ .found_object = object.* };
+            } else {
+                if (constants.verify) {
+                    const prefetch_key = groove.prefetch_keys.get(
+                        @unionInit(UniqueKey, groove_options.primary_key, key),
+                    );
+                    assert(prefetch_key == null or prefetch_key.? == .not_found);
+                }
+
+                return .not_found;
             }
         }
 
@@ -1033,6 +1015,19 @@ pub fn GrooveType(
                             return;
                         }
 
+                        groove.objects.table_mutable.sort();
+                        if (groove.objects.table_mutable.get(value)) |object| {
+                            groove.objects_cache.upsert(object);
+                            if (ObjectTreeHelper.tombstone(object)) {
+                                entry.value_ptr.* = .not_found;
+                            } else {
+                                entry.value_ptr.* = .{
+                                    .found = @field(object, groove_options.primary_key),
+                                };
+                            }
+                            return;
+                        }
+
                         break :timestamp value;
                     }
                     comptime assert(field != .timestamp);
@@ -1045,27 +1040,19 @@ pub fn GrooveType(
                     }
 
                     if (comptime is_primary_key(field)) {
-                        switch (groove.objects_cache.get_or_tombstone(value)) {
-                            .found => |object| {
-                                if (groove_options.primary_key_orphaned) {
-                                    if (object.timestamp == 0) {
-                                        entry.value_ptr.* = .found_orphaned;
-                                        return;
-                                    }
+                        if (groove.objects_cache.get(value)) |object| {
+                            if (groove_options.primary_key_orphaned) {
+                                if (object.timestamp == 0) {
+                                    entry.value_ptr.* = .found_orphaned;
+                                    return;
                                 }
-                                assert(TimestampRange.valid(object.timestamp));
+                            }
+                            assert(TimestampRange.valid(object.timestamp));
 
-                                entry.value_ptr.* = .{
-                                    .found = value,
-                                };
-                                return;
-                            },
-                            .tombstone => {
-                                // Tombstone found in the object cache, the key was deleted.
-                                entry.value_ptr.* = .not_found;
-                                return;
-                            },
-                            .not_found => {},
+                            entry.value_ptr.* = .{
+                                .found = value,
+                            };
+                            return;
                         }
                     }
 
@@ -1076,25 +1063,24 @@ pub fn GrooveType(
                         return;
                     }
 
-                    if (comptime !is_primary_key(field)) {
-                        // Lookup by the primary key skip the mutable
-                        // table by checking the object cache.
-                        // When searching by other unique keys, the mutable
-                        // table needs to be sorted and binary-searched.
-                        tree.table_mutable.sort();
-                        if (tree.table_mutable.get(value)) |tree_value| {
-                            if (tree_value.tombstone()) {
-                                entry.value_ptr.* = .not_found;
-                                return;
-                            }
-
-                            // Timestamp cannot be zero,
-                            // as orphaned objects are only expected for primary keys.
-                            assert(TimestampRange.valid(tree_value.timestamp));
-                            assert(tree_value.field == value);
-                            break :timestamp tree_value.timestamp;
+                    // Lookup by the primary key skip the mutable
+                    // table by checking the object cache.
+                    // When searching by other unique keys, the mutable
+                    // table needs to be sorted and binary-searched.
+                    tree.table_mutable.sort();
+                    if (tree.table_mutable.get(value)) |tree_value| {
+                        if (tree_value.tombstone()) {
+                            entry.value_ptr.* = .not_found;
+                            return;
                         }
+
+                        // Timestamp cannot be zero,
+                        // as orphaned objects are only expected for primary keys.
+                        assert(TimestampRange.valid(tree_value.timestamp));
+                        assert(tree_value.field == value);
+                        break :timestamp tree_value.timestamp;
                     }
+
                     break :timestamp null;
                 },
             };
@@ -1110,24 +1096,19 @@ pub fn GrooveType(
                             };
                             return;
                         }
-                    } else {
-                        // Lookup by the primary key skip the mutable
-                        // table by checking the object cache.
-                        // When searching by other unique keys, the mutable
-                        // table needs to be sorted and binary-searched.
-                        switch (groove.sort_and_search_table_mutable(key, timestamp)) {
-                            .found => |primary_key| {
-                                entry.value_ptr.* = .{
-                                    .found = primary_key,
-                                };
-                                return;
-                            },
-                            .tombstone => {
-                                entry.value_ptr.* = .not_found;
-                                return;
-                            },
-                            .not_found => {},
+                    }
+
+                    groove.objects.table_mutable.sort();
+                    if (groove.objects.table_mutable.get(timestamp)) |object| {
+                        groove.objects_cache.upsert(object);
+                        if (ObjectTreeHelper.tombstone(object)) {
+                            entry.value_ptr.* = .not_found;
+                        } else {
+                            entry.value_ptr.* = .{
+                                .found = ObjectTreeHelper.key_from_value(object),
+                            };
                         }
+                        return;
                     }
                 }
 

--- a/src/lsm/set_associative_cache.zig
+++ b/src/lsm/set_associative_cache.zig
@@ -146,20 +146,32 @@ pub fn SetAssociativeCacheType(
 
         pub fn init(
             allocator: mem.Allocator,
-            value_count_max: u64,
+            value_count: u64,
             options: Options,
         ) !SetAssociativeCache {
+            const value_count_max = stdx.div_ceil(
+                value_count,
+                value_count_max_multiple,
+            ) * value_count_max_multiple;
+            assert(value_count_max % value_count_max_multiple == 0);
+
             const sets = @divExact(value_count_max, layout.ways);
 
             assert(value_count_max > 0);
             assert(value_count_max >= layout.ways);
             assert(value_count_max % layout.ways == 0);
 
-            const values_size_max = value_count_max * @sizeOf(Value);
+            const values_size_max = stdx.div_ceil(
+                value_count_max * @sizeOf(Value),
+                layout.cache_line_size,
+            ) * layout.cache_line_size;
             assert(values_size_max >= layout.cache_line_size);
             assert(values_size_max % layout.cache_line_size == 0);
 
-            const counts_size = @divExact(value_count_max * layout.clock_bits, 8);
+            const counts_size = stdx.div_ceil(
+                @divExact(value_count_max * layout.clock_bits, 8),
+                layout.cache_line_size,
+            ) * layout.cache_line_size;
             assert(counts_size >= layout.cache_line_size);
             assert(counts_size % layout.cache_line_size == 0);
 
@@ -169,8 +181,6 @@ pub fn SetAssociativeCacheType(
             const clocks_size = @divExact(sets * clock_hand_bits, 8);
             maybe(clocks_size >= layout.cache_line_size);
             maybe(clocks_size % layout.cache_line_size == 0);
-
-            assert(value_count_max % value_count_max_multiple == 0);
 
             const tags = try allocator.alloc(Tag, value_count_max);
             errdefer allocator.free(tags);


### PR DESCRIPTION
This PR makes `cache_map` no longer mirror the mutable table.

Cache evictions are expected, and objects not present in the cache are looked up in the mutable table rather than in the stash. 
The object cache is now mandatory (instead of optional) and must be large enough to hold the number of objects read or written per beat, so everything that was prefetched, inserted, or updated must always be in the cache.
Objects evicted from the cache are therefore not needed for the current commit.

** Highly experimental, tests are failing. **

Main branch on tmpfs:
```
./tigerbeetle benchmark --transfer-count=2_000_000 --id-order=tbid 
245 batches in 2.40 s
transfer batch size = 8189 txs
transfer batch delay = 0ns
load accepted = 832033 tx/s
batch latency p1   = 5 ms
batch latency p50  = 6 ms
batch latency p99  = 20 ms
batch latency p100 = 21 ms

rss = 3179843584 bytes
```

This branch on tmpfs
```
./tigerbeetle benchmark --transfer-count=2_000_000 --id-order=tbid     
245 batches in 2.29 s
transfer batch size = 8189 txs
transfer batch delay = 0ns
load accepted = 872699 tx/s
batch latency p1   = 4 ms
batch latency p50  = 5 ms
batch latency p99  = 20 ms
batch latency p100 = 21 ms

rss = 2739662848 bytes
```