### PR TITLE
docs: add Ruby client to the list

### DIFF
--- a/docs/coding/clients/README.md
+++ b/docs/coding/clients/README.md
@@ -7,6 +7,7 @@ TigerBeetle has official client libraries for the following languages:
 - [Java](/src/clients/java/) ([maven central package](https://central.sonatype.com/artifact/com.tigerbeetle/tigerbeetle-java), [API docs](https://javadoc.io/doc/com.tigerbeetle/tigerbeetle-java/)).
 - [Node.js](/src/clients/node/) ([npm package](https://www.npmjs.com/package/tigerbeetle-node)).
 - [Python](/src/clients/python/) ([PyPi package](https://pypi.org/project/tigerbeetle/)).
+- [Ruby](/src/clients/ruby/) ([RubyGems package](https://rubygems.org/gems/tigerbeetle)).
 - [Rust](/src/clients/rust/) ([Cargo package](https://crates.io/crates/tigerbeetle)).
 
 See [API Changes](../api-changes.md) for the history of changes introduced in the TigerBeetle

--- a/src/clients/ruby/README.md
+++ b/src/clients/ruby/README.md
@@ -6,7 +6,9 @@ The TigerBeetle client for Ruby.
 >[!IMPORTANT]
 >This gem changed ownership from [Anthony D](https://github.com/antstorm)
 to TigerBeetle. If you're upgrading from a 0.0.x version, please consult
-the [migration guide](./docs/migration.md) for the necessary code changes.
+the [migration guide](
+https://github.com/tigerbeetle/tigerbeetle/blob/main/src/clients/ruby/docs/migration.md
+) for the necessary code changes.
 
 ## Prerequisites
 

--- a/src/clients/ruby/docs.zig
+++ b/src/clients/ruby/docs.zig
@@ -16,7 +16,9 @@ pub const RubyDocs = Docs{
     \\>[!IMPORTANT]
     \\>This gem changed ownership from [Anthony D](https://github.com/antstorm)
     \\to TigerBeetle. If you're upgrading from a 0.0.x version, please consult
-    \\the [migration guide](./docs/migration.md) for the necessary code changes.
+    \\the [migration guide](
+    \\https://github.com/tigerbeetle/tigerbeetle/blob/main/src/clients/ruby/docs/migration.md
+    \\) for the necessary code changes.
     ,
     .prerequisites =
     \\* Ruby >= `3.3`


### PR DESCRIPTION
This change makes the Ruby client docs show up on the docs website.