### PR TITLE
docs: add layout for print

### DIFF
--- a/src/docs_website/assets/style/style.css
+++ b/src/docs_website/assets/style/style.css
@@ -1205,3 +1205,31 @@ article {
     }
   }
 }
+
+@media print {
+
+  nav.left-pane,
+  body>.resizer,
+  body>.expand-button,
+  #github-link,
+  #single-page-link,
+  .edit-link,
+  .code-wrapper button {
+    display: none !important;
+  }
+
+  body {
+    display: block;
+    height: unset;
+  }
+
+  article {
+    display: block;
+    overflow-y: unset;
+  }
+
+  pre {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+}


### PR DESCRIPTION
For printing this hides the left menu and some other elements such as the GitHub links, copy code button and wraps pre-formatted text.

This also fixes an issue where the viewport clipped the text content in Safari.