### PR TITLE
Validate schema equality, coherent key_min/key_max when reading data

### DIFF
--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -436,9 +436,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         // state, the two blocks are popped off the queues and passed down to the merge. At this
         // point, any number of the blocks still in the queues can continue their read operations.
         //
-        // For index blocks, queues of length one are used. Because an index block is freed as soon
-        // as the read for the last value block is scheduled, the pipeline should not dry out even
-        // when switching between the tables.
+        // An index block is dropped whenever all its value blocks are fully merged.
         //
         // Note that level_{a,b}_position fields track the logical, deterministic progression of
         // compaction.
@@ -938,7 +936,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         }
 
         pub fn compaction_iop_release_callback(ctx: *anyopaque) void {
-            const compaction: *Compaction = @ptrCast(@alignCast(ctx));
+            const compaction: *Compaction = @alignCast(@ptrCast(ctx));
             compaction.compaction_dispatch();
         }
 

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -558,7 +558,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             const tree_id = compaction.tree.config.id;
             assert(value_block.stage == .merge);
             assert(index_block.stage == .read_index_block_done);
-            Table.verify_value_block_schema_and_range(value_block.ptr, index_block.ptr, tree_id);
+            Table.verify_value_block(value_block.ptr, index_block.ptr, tree_id);
         }
 
         fn idle(compaction: *const Compaction) bool {

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -1209,7 +1209,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 } else {
                     if (compaction.level_a_index_block.head()) |index_block| {
                         if (index_block.stage == .read_index_block_done) {
-                            const index_schema = Table.index.from_block(
+                            const index_schema = Table.index.from_block_with_schema(
                                 index_block.ptr,
                                 compaction.tree.config.id,
                             );
@@ -1241,7 +1241,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 // Read level B value block.
                 if (compaction.level_b_index_block.head()) |index_block| {
                     if (index_block.stage == .read_index_block_done) {
-                        const index_schema = Table.index.from_block(
+                        const index_schema = Table.index.from_block_with_schema(
                             index_block.ptr,
                             compaction.tree.config.id,
                         );
@@ -1473,8 +1473,10 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 }
             };
 
-            const index_schema = Table.index.from_block(index_block, compaction.tree.config.id);
-
+            const index_schema = Table.index.from_block_with_schema(
+                index_block,
+                compaction.tree.config.id,
+            );
             const value_block_addresses = index_schema.value_addresses_used(index_block);
             const value_block_address = value_block_addresses[value_block_index];
             const value_block_checksum =
@@ -1510,7 +1512,10 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             compaction: *Compaction,
             index_block: BlockPtrConst,
         ) void {
-            const index_schema = Table.index.from_block(index_block, compaction.tree.config.id);
+            const index_schema = Table.index.from_block_with_schema(
+                index_block,
+                compaction.tree.config.id,
+            );
             const index_block_address = Table.block_address(index_block);
             const value_block_addresses = index_schema.value_addresses_used(index_block);
 
@@ -1869,7 +1874,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
                         const index_block = compaction.level_a_index_block.head().?;
                         assert(index_block.stage == .read_index_block_done);
-                        const index_schema = Table.index.from_block(
+                        const index_schema = Table.index.from_block_with_schema(
                             index_block.ptr,
                             compaction.tree.config.id,
                         );
@@ -1916,7 +1921,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
                     const index_block = compaction.level_b_index_block.head().?;
                     assert(index_block.stage == .read_index_block_done);
-                    const index_schema = Table.index.from_block(
+                    const index_schema = Table.index.from_block_with_schema(
                         index_block.ptr,
                         compaction.tree.config.id,
                     );

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -926,7 +926,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         }
 
         pub fn compaction_iop_release_callback(ctx: *anyopaque) void {
-            const compaction: *Compaction = @ptrCast(@alignCast(ctx));
+            const compaction: *Compaction = @alignCast(@ptrCast(ctx));
             compaction.compaction_dispatch();
         }
 

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -50,7 +50,6 @@ const BlockPtr = @import("../vsr/grid.zig").BlockPtr;
 const BlockPtrConst = @import("../vsr/grid.zig").BlockPtrConst;
 const TableInfoType = @import("manifest.zig").TreeTableInfoType;
 const ManifestType = @import("manifest.zig").ManifestType;
-const schema = @import("schema.zig");
 const RingBufferType = stdx.RingBufferType;
 
 /// The upper-bound count of input tables to a single tree's compaction.
@@ -928,7 +927,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         }
 
         pub fn compaction_iop_release_callback(ctx: *anyopaque) void {
-            const compaction: *Compaction = @alignCast(@ptrCast(ctx));
+            const compaction: *Compaction = @ptrCast(@alignCast(ctx));
             compaction.compaction_dispatch();
         }
 
@@ -1207,7 +1206,10 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 } else {
                     if (compaction.level_a_index_block.head()) |index_block| {
                         if (index_block.stage == .read_index_block_done) {
-                            const index_schema = schema.TableIndex.from(index_block.ptr);
+                            const index_schema = Table.index.from_block(
+                                index_block.ptr,
+                                compaction.tree.config.id,
+                            );
                             const value_blocks_count =
                                 index_schema.value_blocks_used(index_block.ptr);
                             if (!compaction.level_a_value_block.full() and
@@ -1236,7 +1238,10 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 // Read level B value block.
                 if (compaction.level_b_index_block.head()) |index_block| {
                     if (index_block.stage == .read_index_block_done) {
-                        const index_schema = schema.TableIndex.from(index_block.ptr);
+                        const index_schema = Table.index.from_block(
+                            index_block.ptr,
+                            compaction.tree.config.id,
+                        );
                         const value_blocks_count =
                             index_schema.value_blocks_used(index_block.ptr);
 
@@ -1457,7 +1462,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 }
             };
 
-            const index_schema = schema.TableIndex.from(index_block.ptr);
+            const index_schema = Table.index.from_block(index_block.ptr, compaction.tree.config.id);
 
             const value_block_address =
                 index_schema.value_addresses_used(index_block.ptr)[value_block_index];
@@ -1485,7 +1490,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             compaction: *Compaction,
             index_block: BlockPtrConst,
         ) void {
-            const index_schema = schema.TableIndex.from(index_block);
+            const index_schema = Table.index.from_block(index_block, compaction.tree.config.id);
             const index_block_address = Table.block_address(index_block);
             const value_block_addresses = index_schema.value_addresses_used(index_block);
 
@@ -1687,10 +1692,9 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             compaction.level_b_position.value += merge_result.consumed_b;
             compaction.table_builder.value_count += merge_result.produced;
 
-            if (compaction.table_info_a.? == .immutable) {
-                assert(compaction.level_a_position.value <= Table.value_count_max);
-            } else {
-                assert(compaction.level_a_position.value <= Table.data.value_count_max);
+            switch (compaction.table_info_a.?) {
+                .immutable => assert(compaction.level_a_position.value <= Table.value_count_max),
+                .disk => assert(compaction.level_a_position.value <= Table.data.value_count_max),
             }
             assert(compaction.level_b_position.value <= Table.data.value_count_max);
             assert(compaction.table_builder.value_count <= Table.data.value_count_max);
@@ -1738,6 +1742,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             const level_b_values_used: ?[]const Value = values: {
                 if (compaction.level_b_value_block.head()) |block| {
                     assert(block.stage == .merge);
+                    Table.data.assert_matching_block_schema(block.ptr, compaction.tree.config.id);
                     break :values Table.value_block_values_used(block.ptr);
                 } else {
                     break :values null;
@@ -1765,6 +1770,10 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                     .disk => {
                         if (compaction.level_a_value_block.head()) |block| {
                             assert(block.stage == .merge);
+                            Table.data.assert_matching_block_schema(
+                                block.ptr,
+                                compaction.tree.config.id,
+                            );
                             break :values Table.value_block_values_used(block.ptr);
                         } else {
                             break :values null;
@@ -1776,6 +1785,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             const level_b_values_used: ?[]const Value = values: {
                 if (compaction.level_b_value_block.head()) |block| {
                     assert(block.stage == .merge);
+                    Table.data.assert_matching_block_schema(block.ptr, compaction.tree.config.id);
                     break :values Table.value_block_values_used(block.ptr);
                 } else {
                     break :values null;
@@ -1835,7 +1845,10 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
                         const index_block = compaction.level_a_index_block.head().?;
                         assert(index_block.stage == .read_index_block_done);
-                        const index_schema = schema.TableIndex.from(index_block.ptr);
+                        const index_schema = Table.index.from_block(
+                            index_block.ptr,
+                            compaction.tree.config.id,
+                        );
                         const value_blocks_count =
                             index_schema.value_blocks_used(index_block.ptr);
 
@@ -1879,7 +1892,10 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
                     const index_block = compaction.level_b_index_block.head().?;
                     assert(index_block.stage == .read_index_block_done);
-                    const index_schema = schema.TableIndex.from(index_block.ptr);
+                    const index_schema = Table.index.from_block(
+                        index_block.ptr,
+                        compaction.tree.config.id,
+                    );
                     const value_blocks_count =
                         index_schema.value_blocks_used(index_block.ptr);
 

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -1284,7 +1284,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                     if (index_block.stage == .read_index_block_done) {
                         compaction.assert_valid_source_index_block(
                             index_block,
-                            compaction.level_a_table_info_current(),
+                            compaction.level_b_table_info_current(),
                         );
                         const index_schema = Table.index.from_block(
                             index_block.ptr,

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -553,29 +553,9 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             value_block: *const ResourcePool.Block,
             index_block: *const ResourcePool.Block,
         ) void {
-            const tree_id = compaction.tree.config.id;
             assert(value_block.stage == .merge);
             assert(index_block.stage == .read_index_block_done);
-            Table.verify_value_block(value_block.ptr, index_block.ptr, tree_id);
-        }
-
-        fn assert_valid_source_index_block(
-            compaction: *const Compaction,
-            index_block: *const ResourcePool.Block,
-            table_info: *const TableInfo,
-        ) void {
-            assert(index_block.stage == .read_index_block_done);
-
-            const index_schema = Table.index.from_block(index_block.ptr, compaction.tree.config.id);
-            const keys_min = Table.index_value_keys_used(index_block.ptr, .key_min);
-            const keys_max = Table.index_value_keys_used(index_block.ptr, .key_max);
-
-            assert(keys_min.len > 0);
-            assert(keys_min.len == keys_max.len);
-            assert(keys_min.len == index_schema.value_blocks_used(index_block.ptr));
-
-            assert(keys_min[0] == table_info.key_min);
-            assert(keys_max[keys_max.len - 1] == table_info.key_max);
+            Table.verify_value_block(value_block.ptr, index_block.ptr, compaction.tree.config.id);
         }
 
         fn level_a_table_info_current(compaction: *const Compaction) *const TableInfo {
@@ -1246,13 +1226,13 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 } else {
                     if (compaction.level_a_index_block.head()) |index_block| {
                         if (index_block.stage == .read_index_block_done) {
-                            compaction.assert_valid_source_index_block(
-                                index_block,
-                                compaction.level_a_table_info_current(),
-                            );
-                            const index_schema = Table.index.from_block(
+                            assert(index_block.stage == .read_index_block_done);
+                            const table_info = compaction.level_a_table_info_current();
+                            const index_schema = Table.verify_index_block(
                                 index_block.ptr,
                                 compaction.tree.config.id,
+                                table_info.key_min,
+                                table_info.key_max,
                             );
                             const value_blocks_count =
                                 index_schema.value_blocks_used(index_block.ptr);
@@ -1282,13 +1262,12 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 // Read level B value block.
                 if (compaction.level_b_index_block.head()) |index_block| {
                     if (index_block.stage == .read_index_block_done) {
-                        compaction.assert_valid_source_index_block(
-                            index_block,
-                            compaction.level_b_table_info_current(),
-                        );
-                        const index_schema = Table.index.from_block(
+                        const table_info = compaction.level_b_table_info_current();
+                        const index_schema = Table.verify_index_block(
                             index_block.ptr,
                             compaction.tree.config.id,
+                            table_info.key_min,
+                            table_info.key_max,
                         );
                         const value_blocks_count =
                             index_schema.value_blocks_used(index_block.ptr);

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -100,6 +100,7 @@ pub fn ResourcePoolType(comptime Grid: type) type {
             counters: ?*CompactionCounters = null,
             block: *Block,
             pool: *ResourcePool,
+            verify: [96]u8,
         };
 
         const BlockWrite = struct {
@@ -548,28 +549,6 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             assert(compaction.manifest_entries.empty());
         }
 
-        fn assert_valid_source_value_block(
-            compaction: *const Compaction,
-            value_block: *const ResourcePool.Block,
-            index_block: *const ResourcePool.Block,
-        ) void {
-            assert(value_block.stage == .merge);
-            assert(index_block.stage == .read_index_block_done);
-            Table.verify_value_block(value_block.ptr, index_block.ptr, compaction.tree.config.id);
-        }
-
-        fn level_a_table_info_current(compaction: *const Compaction) *const TableInfo {
-            assert(compaction.table_info_a.? == .disk);
-            return compaction.table_info_a.?.disk.table_info;
-        }
-
-        fn level_b_table_info_current(compaction: *const Compaction) *const TableInfo {
-            assert(compaction.level_b_position.index_block < compaction.range_b.?.tables.count());
-            return compaction.range_b.?.tables.get(
-                compaction.level_b_position.index_block,
-            ).table_info;
-        }
-
         fn idle(compaction: *const Compaction) bool {
             return compaction.pool == null and
                 compaction.callback == null and
@@ -947,7 +926,7 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
         }
 
         pub fn compaction_iop_release_callback(ctx: *anyopaque) void {
-            const compaction: *Compaction = @alignCast(@ptrCast(ctx));
+            const compaction: *Compaction = @ptrCast(@alignCast(ctx));
             compaction.compaction_dispatch();
         }
 
@@ -1227,12 +1206,9 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                     if (compaction.level_a_index_block.head()) |index_block| {
                         if (index_block.stage == .read_index_block_done) {
                             assert(index_block.stage == .read_index_block_done);
-                            const table_info = compaction.level_a_table_info_current();
-                            const index_schema = Table.verify_index_block(
+                            const index_schema = Table.index.from_block(
                                 index_block.ptr,
                                 compaction.tree.config.id,
-                                table_info.key_min,
-                                table_info.key_max,
                             );
                             const value_blocks_count =
                                 index_schema.value_blocks_used(index_block.ptr);
@@ -1262,12 +1238,9 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 // Read level B value block.
                 if (compaction.level_b_index_block.head()) |index_block| {
                     if (index_block.stage == .read_index_block_done) {
-                        const table_info = compaction.level_b_table_info_current();
-                        const index_schema = Table.verify_index_block(
+                        const index_schema = Table.index.from_block(
                             index_block.ptr,
                             compaction.tree.config.id,
-                            table_info.key_min,
-                            table_info.key_max,
                         );
                         const value_blocks_count =
                             index_schema.value_blocks_used(index_block.ptr);
@@ -1402,6 +1375,25 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             return progressed;
         }
 
+        const VerifyIndexBlock = struct {
+            key_min: Table.Key,
+            key_max: Table.Key,
+            read: *const ResourcePool.BlockRead,
+            tree_id: u16,
+        };
+
+        const VerifyValueBlock = struct {
+            key_min: Table.Key,
+            key_max: Table.Key,
+            read: *const ResourcePool.BlockRead,
+            tree_id: u16,
+        };
+
+        fn block_read_verify_data(Verify: type, read: *ResourcePool.BlockRead) *align(1) Verify {
+            assert(@sizeOf(Verify) <= @sizeOf(@TypeOf(read.verify)));
+            return std.mem.bytesAsValue(Verify, read.verify[0..@sizeOf(Verify)]);
+        }
+
         fn read_index_block(
             compaction: *Compaction,
             level: enum { level_a, level_b },
@@ -1430,6 +1422,14 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             read.* = .{
                 .block = index_block,
                 .pool = compaction.pool.?,
+                .verify = @splat(0),
+            };
+
+            block_read_verify_data(VerifyIndexBlock, read).* = VerifyIndexBlock{
+                .key_min = table_ref.table_info.key_min,
+                .key_max = table_ref.table_info.key_max,
+                .tree_id = compaction.tree.config.id,
+                .read = read,
             };
 
             compaction.grid.read_block(
@@ -1448,6 +1448,15 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             assert(read.block.stage == .read_index_block);
             assert(read.counters == null);
 
+            const verify = block_read_verify_data(VerifyIndexBlock, read);
+            assert(verify.read == read);
+            _ = Table.verify_index_block(
+                index_block,
+                verify.tree_id,
+                verify.key_min,
+                verify.key_max,
+            );
+
             grid.block_unref(read.block.ptr);
             read.block.ptr = @constCast(grid.block_ref(index_block));
             read.block.stage = .read_index_block_done;
@@ -1465,8 +1474,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             if (level == .level_a) assert(compaction.table_info_a.? == .disk);
 
             const index_block = switch (level) {
-                .level_a => compaction.level_a_index_block.head().?,
-                .level_b => compaction.level_b_index_block.head().?,
+                .level_a => compaction.level_a_index_block.head().?.ptr,
+                .level_b => compaction.level_b_index_block.head().?.ptr,
             };
 
             const level_a_value_block_next =
@@ -1489,17 +1498,25 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 }
             };
 
-            const index_schema = Table.index.from_block(index_block.ptr, compaction.tree.config.id);
+            const index_schema = Table.index.from_block(index_block, compaction.tree.config.id);
 
-            const value_block_address =
-                index_schema.value_addresses_used(index_block.ptr)[value_block_index];
+            const value_block_addresses = index_schema.value_addresses_used(index_block);
+            const value_block_address = value_block_addresses[value_block_index];
             const value_block_checksum =
-                index_schema.value_checksums_used(index_block.ptr)[value_block_index];
+                index_schema.value_checksums_used(index_block)[value_block_index];
 
             read.* = .{
                 .block = value_block,
                 .pool = compaction.pool.?,
                 .counters = &compaction.counters,
+                .verify = @splat(0),
+            };
+
+            block_read_verify_data(VerifyValueBlock, read).* = .{
+                .key_min = Table.index_value_keys_used(index_block, .key_min)[value_block_index],
+                .key_max = Table.index_value_keys_used(index_block, .key_max)[value_block_index],
+                .read = read,
+                .tree_id = compaction.tree.config.id,
             };
 
             compaction.grid.read_block(
@@ -1540,6 +1557,14 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             read.counters.?.in += Table.value_block_values_used(value_block).len;
 
             assert(read.block.stage == .read_value_block);
+            const verify = block_read_verify_data(VerifyValueBlock, read);
+            assert(verify.read == read);
+            Table.verify_value_block(
+                value_block,
+                verify.tree_id,
+                verify.key_min,
+                verify.key_max,
+            );
 
             grid.block_unref(read.block.ptr);
             read.block.ptr = @constCast(grid.block_ref(value_block));
@@ -1768,10 +1793,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
             const level_b_values_used: ?[]const Value = values: {
                 if (compaction.level_b_value_block.head()) |value_block| {
-                    compaction.assert_valid_source_value_block(
-                        value_block,
-                        compaction.level_b_index_block.head().?,
-                    );
+                    assert(value_block.stage == .merge);
+                    assert(compaction.level_b_index_block.head().?.stage == .read_index_block_done);
                     break :values Table.value_block_values_used(value_block.ptr);
                 } else {
                     break :values null;
@@ -1798,10 +1821,9 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                     },
                     .disk => {
                         if (compaction.level_a_value_block.head()) |value_block| {
-                            compaction.assert_valid_source_value_block(
-                                value_block,
-                                compaction.level_a_index_block.head().?,
-                            );
+                            assert(value_block.stage == .merge);
+                            assert(compaction.level_a_index_block.head().?.stage ==
+                                .read_index_block_done);
                             break :values Table.value_block_values_used(value_block.ptr);
                         } else {
                             break :values null;
@@ -1812,10 +1834,8 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
 
             const level_b_values_used: ?[]const Value = values: {
                 if (compaction.level_b_value_block.head()) |value_block| {
-                    compaction.assert_valid_source_value_block(
-                        value_block,
-                        compaction.level_b_index_block.head().?,
-                    );
+                    assert(value_block.stage == .merge);
+                    assert(compaction.level_b_index_block.head().?.stage == .read_index_block_done);
                     break :values Table.value_block_values_used(value_block.ptr);
                 } else {
                     break :values null;

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -559,6 +559,37 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             Table.verify_value_block(value_block.ptr, index_block.ptr, tree_id);
         }
 
+        fn assert_valid_source_index_block(
+            compaction: *const Compaction,
+            index_block: *const ResourcePool.Block,
+            table_info: *const TableInfo,
+        ) void {
+            assert(index_block.stage == .read_index_block_done);
+
+            const index_schema = Table.index.from_block(index_block.ptr, compaction.tree.config.id);
+            const keys_min = Table.index_value_keys_used(index_block.ptr, .key_min);
+            const keys_max = Table.index_value_keys_used(index_block.ptr, .key_max);
+
+            assert(keys_min.len > 0);
+            assert(keys_min.len == keys_max.len);
+            assert(keys_min.len == index_schema.value_blocks_used(index_block.ptr));
+
+            assert(keys_min[0] == table_info.key_min);
+            assert(keys_max[keys_max.len - 1] == table_info.key_max);
+        }
+
+        fn level_a_table_info_current(compaction: *const Compaction) *const TableInfo {
+            assert(compaction.table_info_a.? == .disk);
+            return compaction.table_info_a.?.disk.table_info;
+        }
+
+        fn level_b_table_info_current(compaction: *const Compaction) *const TableInfo {
+            assert(compaction.level_b_position.index_block < compaction.range_b.?.tables.count());
+            return compaction.range_b.?.tables.get(
+                compaction.level_b_position.index_block,
+            ).table_info;
+        }
+
         fn idle(compaction: *const Compaction) bool {
             return compaction.pool == null and
                 compaction.callback == null and
@@ -1215,6 +1246,10 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 } else {
                     if (compaction.level_a_index_block.head()) |index_block| {
                         if (index_block.stage == .read_index_block_done) {
+                            compaction.assert_valid_source_index_block(
+                                index_block,
+                                compaction.level_a_table_info_current(),
+                            );
                             const index_schema = Table.index.from_block(
                                 index_block.ptr,
                                 compaction.tree.config.id,
@@ -1247,6 +1282,10 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 // Read level B value block.
                 if (compaction.level_b_index_block.head()) |index_block| {
                     if (index_block.stage == .read_index_block_done) {
+                        compaction.assert_valid_source_index_block(
+                            index_block,
+                            compaction.level_a_table_info_current(),
+                        );
                         const index_schema = Table.index.from_block(
                             index_block.ptr,
                             compaction.tree.config.id,

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -550,6 +550,17 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             assert(compaction.manifest_entries.empty());
         }
 
+        fn assert_valid_source_value_block(
+            compaction: *const Compaction,
+            value_block: *const ResourcePool.Block,
+            index_block: *const ResourcePool.Block,
+        ) void {
+            const tree_id = compaction.tree.config.id;
+            assert(value_block.stage == .merge);
+            assert(index_block.stage == .read_index_block_done);
+            Table.verify_value_block_schema_and_range(value_block.ptr, index_block.ptr, tree_id);
+        }
+
         fn idle(compaction: *const Compaction) bool {
             return compaction.pool == null and
                 compaction.callback == null and
@@ -1740,10 +1751,12 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             };
 
             const level_b_values_used: ?[]const Value = values: {
-                if (compaction.level_b_value_block.head()) |block| {
-                    assert(block.stage == .merge);
-                    Table.data.assert_matching_block_schema(block.ptr, compaction.tree.config.id);
-                    break :values Table.value_block_values_used(block.ptr);
+                if (compaction.level_b_value_block.head()) |value_block| {
+                    compaction.assert_valid_source_value_block(
+                        value_block,
+                        compaction.level_b_index_block.head().?,
+                    );
+                    break :values Table.value_block_values_used(value_block.ptr);
                 } else {
                     break :values null;
                 }
@@ -1768,13 +1781,12 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                         unreachable;
                     },
                     .disk => {
-                        if (compaction.level_a_value_block.head()) |block| {
-                            assert(block.stage == .merge);
-                            Table.data.assert_matching_block_schema(
-                                block.ptr,
-                                compaction.tree.config.id,
+                        if (compaction.level_a_value_block.head()) |value_block| {
+                            compaction.assert_valid_source_value_block(
+                                value_block,
+                                compaction.level_a_index_block.head().?,
                             );
-                            break :values Table.value_block_values_used(block.ptr);
+                            break :values Table.value_block_values_used(value_block.ptr);
                         } else {
                             break :values null;
                         }
@@ -1783,10 +1795,12 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             };
 
             const level_b_values_used: ?[]const Value = values: {
-                if (compaction.level_b_value_block.head()) |block| {
-                    assert(block.stage == .merge);
-                    Table.data.assert_matching_block_schema(block.ptr, compaction.tree.config.id);
-                    break :values Table.value_block_values_used(block.ptr);
+                if (compaction.level_b_value_block.head()) |value_block| {
+                    compaction.assert_valid_source_value_block(
+                        value_block,
+                        compaction.level_b_index_block.head().?,
+                    );
+                    break :values Table.value_block_values_used(value_block.ptr);
                 } else {
                     break :values null;
                 }

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -100,7 +100,11 @@ pub fn ResourcePoolType(comptime Grid: type) type {
             counters: ?*CompactionCounters = null,
             block: *Block,
             pool: *ResourcePool,
-            verify: [96]u8,
+            verify: struct {
+                key_min: u256,
+                key_max: u256,
+                tree_id: u16,
+            },
         };
 
         const BlockWrite = struct {
@@ -1205,7 +1209,6 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 } else {
                     if (compaction.level_a_index_block.head()) |index_block| {
                         if (index_block.stage == .read_index_block_done) {
-                            assert(index_block.stage == .read_index_block_done);
                             const index_schema = Table.index.from_block(
                                 index_block.ptr,
                                 compaction.tree.config.id,
@@ -1375,25 +1378,6 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             return progressed;
         }
 
-        const VerifyIndexBlock = struct {
-            key_min: Table.Key,
-            key_max: Table.Key,
-            read: *const ResourcePool.BlockRead,
-            tree_id: u16,
-        };
-
-        const VerifyValueBlock = struct {
-            key_min: Table.Key,
-            key_max: Table.Key,
-            read: *const ResourcePool.BlockRead,
-            tree_id: u16,
-        };
-
-        fn block_read_verify_data(Verify: type, read: *ResourcePool.BlockRead) *align(1) Verify {
-            assert(@sizeOf(Verify) <= @sizeOf(@TypeOf(read.verify)));
-            return std.mem.bytesAsValue(Verify, read.verify[0..@sizeOf(Verify)]);
-        }
-
         fn read_index_block(
             compaction: *Compaction,
             level: enum { level_a, level_b },
@@ -1419,18 +1403,11 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 .level_b => compaction.range_b.?.tables.get(level_b_index_block_next - 1),
             };
 
-            read.* = .{
-                .block = index_block,
-                .pool = compaction.pool.?,
-                .verify = @splat(0),
-            };
-
-            block_read_verify_data(VerifyIndexBlock, read).* = VerifyIndexBlock{
-                .key_min = table_ref.table_info.key_min,
-                .key_max = table_ref.table_info.key_max,
+            read.* = .{ .block = index_block, .pool = compaction.pool.?, .verify = .{
+                .key_min = @intCast(table_ref.table_info.key_min),
+                .key_max = @intCast(table_ref.table_info.key_max),
                 .tree_id = compaction.tree.config.id,
-                .read = read,
-            };
+            } };
 
             compaction.grid.read_block(
                 .{ .from_local_or_global_storage = read_index_block_callback },
@@ -1448,13 +1425,11 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             assert(read.block.stage == .read_index_block);
             assert(read.counters == null);
 
-            const verify = block_read_verify_data(VerifyIndexBlock, read);
-            assert(verify.read == read);
             _ = Table.verify_index_block(
                 index_block,
-                verify.tree_id,
-                verify.key_min,
-                verify.key_max,
+                read.verify.tree_id,
+                @intCast(read.verify.key_min),
+                @intCast(read.verify.key_max),
             );
 
             grid.block_unref(read.block.ptr);
@@ -1509,14 +1484,15 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 .block = value_block,
                 .pool = compaction.pool.?,
                 .counters = &compaction.counters,
-                .verify = @splat(0),
-            };
-
-            block_read_verify_data(VerifyValueBlock, read).* = .{
-                .key_min = Table.index_value_keys_used(index_block, .key_min)[value_block_index],
-                .key_max = Table.index_value_keys_used(index_block, .key_max)[value_block_index],
-                .read = read,
-                .tree_id = compaction.tree.config.id,
+                .verify = .{
+                    .key_min = @intCast(
+                        Table.index_value_keys_used(index_block, .key_min)[value_block_index],
+                    ),
+                    .key_max = @intCast(
+                        Table.index_value_keys_used(index_block, .key_max)[value_block_index],
+                    ),
+                    .tree_id = compaction.tree.config.id,
+                },
             };
 
             compaction.grid.read_block(
@@ -1557,13 +1533,11 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             read.counters.?.in += Table.value_block_values_used(value_block).len;
 
             assert(read.block.stage == .read_value_block);
-            const verify = block_read_verify_data(VerifyValueBlock, read);
-            assert(verify.read == read);
             Table.verify_value_block(
                 value_block,
-                verify.tree_id,
-                verify.key_min,
-                verify.key_max,
+                read.verify.tree_id,
+                @intCast(read.verify.key_min),
+                @intCast(read.verify.key_max),
             );
 
             grid.block_unref(read.block.ptr);

--- a/src/lsm/compaction.zig
+++ b/src/lsm/compaction.zig
@@ -1403,11 +1403,15 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 .level_b => compaction.range_b.?.tables.get(level_b_index_block_next - 1),
             };
 
-            read.* = .{ .block = index_block, .pool = compaction.pool.?, .verify = .{
-                .key_min = @intCast(table_ref.table_info.key_min),
-                .key_max = @intCast(table_ref.table_info.key_max),
-                .tree_id = compaction.tree.config.id,
-            } };
+            read.* = .{
+                .block = index_block,
+                .pool = compaction.pool.?,
+                .verify = .{
+                    .key_min = table_ref.table_info.key_min,
+                    .key_max = table_ref.table_info.key_max,
+                    .tree_id = compaction.tree.config.id,
+                },
+            };
 
             compaction.grid.read_block(
                 .{ .from_local_or_global_storage = read_index_block_callback },
@@ -1473,6 +1477,20 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
                 }
             };
 
+            const key_min = Table.index_value_keys_used(index_block, .key_min)[value_block_index];
+            const key_max = Table.index_value_keys_used(index_block, .key_max)[value_block_index];
+
+            read.* = .{
+                .block = value_block,
+                .pool = compaction.pool.?,
+                .counters = &compaction.counters,
+                .verify = .{
+                    .key_min = key_min,
+                    .key_max = key_max,
+                    .tree_id = compaction.tree.config.id,
+                },
+            };
+
             const index_schema = Table.index.from_block_with_schema(
                 index_block,
                 compaction.tree.config.id,
@@ -1481,21 +1499,6 @@ pub fn CompactionType(comptime Tree: type, comptime Storage: type) type {
             const value_block_address = value_block_addresses[value_block_index];
             const value_block_checksum =
                 index_schema.value_checksums_used(index_block)[value_block_index];
-
-            read.* = .{
-                .block = value_block,
-                .pool = compaction.pool.?,
-                .counters = &compaction.counters,
-                .verify = .{
-                    .key_min = @intCast(
-                        Table.index_value_keys_used(index_block, .key_min)[value_block_index],
-                    ),
-                    .key_max = @intCast(
-                        Table.index_value_keys_used(index_block, .key_max)[value_block_index],
-                    ),
-                    .tree_id = compaction.tree.config.id,
-                },
-            };
 
             compaction.grid.read_block(
                 .{ .from_local_or_global_storage = read_value_block_callback },

--- a/src/lsm/manifest.zig
+++ b/src/lsm/manifest.zig
@@ -715,7 +715,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
             return true;
         }
 
-        pub fn verify(manifest: *const Manifest, snapshot: u64) void {
+        pub fn verify(manifest: *const Manifest, snapshot: u64, tree_id: u16) void {
             assert(snapshot <= snapshot_latest);
 
             switch (Table.usage) {
@@ -768,6 +768,7 @@ pub fn ManifestType(comptime Table: type, comptime Storage: type) type {
                             table_info.address,
                             table_info.key_min,
                             table_info.key_max,
+                            tree_id,
                         );
                     }
                 }

--- a/src/lsm/scan_tree.zig
+++ b/src/lsm/scan_tree.zig
@@ -498,6 +498,8 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
             loading_manifest,
             loading_index: struct {
                 key_exclusive_next: Key,
+                table_key_min: Key,
+                table_key_max: Key,
                 address: u64,
                 checksum: u128,
                 read: Grid.Read = undefined,
@@ -754,6 +756,8 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
                 self.state = .{
                     .loading_index = .{
                         .key_exclusive_next = key_exclusive_next,
+                        .table_key_min = table_info.key_min,
+                        .table_key_max = table_info.key_max,
                         .address = table_info.address,
                         .checksum = table_info.checksum,
                     },
@@ -788,6 +792,7 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
                 const scan_key_min = @min(self.scan.key_lower, self.scan.key_upper);
                 const scan_key_max = @max(self.scan.key_lower, self.scan.key_upper);
 
+                const index_schema = Table.index.from_block(index_block, self.scan.tree.config.id);
                 const keys_max = Table.index_value_keys_used(self.buffer.index_block, .key_max);
                 const keys_min = Table.index_value_keys_used(self.buffer.index_block, .key_min);
                 // The `index_block` *might* contain the key range,
@@ -796,6 +801,13 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
                 assert(keys_min.len == keys_max.len);
                 assert(keys_min[0] <= scan_key_max);
                 assert(scan_key_min <= keys_max[keys_max.len - 1]);
+
+                assert(keys_min.len > 0);
+                assert(keys_min.len == keys_max.len);
+                assert(keys_min.len == index_schema.value_blocks_used(index_block));
+
+                assert(keys_min[0] == state.loading_index.table_key_min);
+                assert(keys_max[keys_max.len - 1] == state.loading_index.table_key_max);
 
                 const indexes = binary_search.binary_search_keys_range_upsert_indexes(
                     Key,

--- a/src/lsm/scan_tree.zig
+++ b/src/lsm/scan_tree.zig
@@ -5,7 +5,6 @@ const assert = std.debug.assert;
 const stdx = @import("stdx");
 const maybe = stdx.maybe;
 const constants = @import("../constants.zig");
-const schema = @import("schema.zig");
 const binary_search = @import("binary_search.zig");
 const k_way_merge = @import("k_way_merge.zig");
 
@@ -506,6 +505,8 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
             },
             iterating: struct {
                 key_exclusive_next: Key,
+                index_key_min: Key,
+                index_key_max: Key,
                 values: union(enum) {
                     none,
                     iterator: TableValueIterator,
@@ -784,6 +785,13 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
             assert(self.scan.state == .buffering);
             assert(self.scan.state.buffering.pending_count > 0);
 
+            const index_schema = Table.verify_index_block(
+                index_block,
+                self.scan.tree.config.id,
+                state.loading_index.table_key_min,
+                state.loading_index.table_key_max,
+            );
+
             self.scan.tree.grid.block_unref(self.buffer.index_block);
             self.buffer.index_block = self.scan.tree.grid.block_ref(index_block);
 
@@ -792,7 +800,6 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
                 const scan_key_min = @min(self.scan.key_lower, self.scan.key_upper);
                 const scan_key_max = @max(self.scan.key_lower, self.scan.key_upper);
 
-                const index_schema = Table.index.from_block(index_block, self.scan.tree.config.id);
                 const keys_max = Table.index_value_keys_used(self.buffer.index_block, .key_max);
                 const keys_min = Table.index_value_keys_used(self.buffer.index_block, .key_min);
                 // The `index_block` *might* contain the key range,
@@ -801,13 +808,6 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
                 assert(keys_min.len == keys_max.len);
                 assert(keys_min[0] <= scan_key_max);
                 assert(scan_key_min <= keys_max[keys_max.len - 1]);
-
-                assert(keys_min.len > 0);
-                assert(keys_min.len == keys_max.len);
-                assert(keys_min.len == index_schema.value_blocks_used(index_block));
-
-                assert(keys_min[0] == state.loading_index.table_key_min);
-                assert(keys_max[keys_max.len - 1] == state.loading_index.table_key_max);
 
                 const indexes = binary_search.binary_search_keys_range_upsert_indexes(
                     Key,
@@ -837,7 +837,6 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
                 };
             };
 
-            const index_schema = schema.TableIndex.from(self.buffer.index_block);
             const data_addresses = index_schema.value_addresses_used(self.buffer.index_block);
             const data_checksums = index_schema.value_checksums_used(self.buffer.index_block);
             assert(data_addresses.len == data_checksums.len);
@@ -847,6 +846,8 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
                 break :iterating .{
                     .iterating = .{
                         .key_exclusive_next = key_exclusive_next,
+                        .index_key_min = self.state.loading_index.table_key_min,
+                        .index_key_max = self.state.loading_index.table_key_max,
                         .values = .none,
                     },
                 };
@@ -894,6 +895,7 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
             assert(self.values == .fetching);
             assert(self.scan.state == .buffering);
             assert(self.scan.state.buffering.pending_count > 0);
+            Table.data.assert_matching_block_schema(value_block, self.scan.tree.config.id);
 
             const values = Table.value_block_values_used(value_block);
             const scan_key_min = @min(self.scan.key_lower, self.scan.key_upper);
@@ -922,6 +924,8 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
                 const key_max = key_from_value(&values[values.len - 1]);
                 assert(key_min < scan_key_min);
                 assert(scan_key_max < key_max);
+                assert(key_min >= self.state.iterating.index_key_min);
+                assert(key_max <= self.state.iterating.index_key_max);
 
                 // Keep fetching if there are more value blocks on this table,
                 // or move to the next table otherwise.

--- a/src/lsm/scan_tree.zig
+++ b/src/lsm/scan_tree.zig
@@ -898,6 +898,11 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
             Table.data.assert_matching_block_schema(value_block, self.scan.tree.config.id);
 
             const values = Table.value_block_values_used(value_block);
+            const key_min = key_from_value(&values[0]);
+            const key_max = key_from_value(&values[values.len - 1]);
+            assert(key_min >= self.state.iterating.index_key_min);
+            assert(key_max <= self.state.iterating.index_key_max);
+
             const scan_key_min = @min(self.scan.key_lower, self.scan.key_upper);
             const scan_key_max = @max(self.scan.key_lower, self.scan.key_upper);
             const range = binary_search.binary_search_values_range(
@@ -920,12 +925,8 @@ fn ScanTreeLevelType(comptime ScanTree: type, comptime Storage: type) type {
             } else {
                 // The `value_block` *might* contain the key range,
                 // otherwise, it shouldn't have been returned by the iterator.
-                const key_min = key_from_value(&values[0]);
-                const key_max = key_from_value(&values[values.len - 1]);
                 assert(key_min < scan_key_min);
                 assert(scan_key_max < key_max);
-                assert(key_min >= self.state.iterating.index_key_min);
-                assert(key_max <= self.state.iterating.index_key_max);
 
                 // Keep fetching if there are more value blocks on this table,
                 // or move to the next table otherwise.

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -212,6 +212,9 @@ pub const TableIndex = struct {
         const header_metadata = std.mem.bytesAsValue(Metadata, &header.metadata_bytes);
         assert(header_metadata.value_block_count <= header_metadata.value_block_count_max);
         assert(stdx.zeroed(&header_metadata.reserved));
+        assert(header.size == @sizeOf(vsr.Header) +
+            header_metadata.value_block_count_max *
+                (checksum_size + address_size + header_metadata.key_size * 2));
         return header_metadata;
     }
 

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -157,7 +157,7 @@ pub const TableIndex = struct {
         };
     }
 
-    pub fn from(index_block: BlockPtrConst) TableIndex {
+    pub fn from_block_without_schema(index_block: BlockPtrConst) TableIndex {
         const header = header_from_block(index_block);
         assert(header.command == .block);
         assert(header.block_type == .index);
@@ -177,31 +177,19 @@ pub const TableIndex = struct {
         return index;
     }
 
-    pub fn from_block(
+    pub fn from_block_with_schema(
         schema: *const TableIndex,
         index_block: BlockPtrConst,
         tree_id: u16,
     ) TableIndex {
-        const header = header_from_block(index_block);
-        assert(header.command == .block);
-        assert(header.block_type == .index);
-        assert(header.address > 0);
-        assert(header.snapshot > 0);
-
         const header_metadata = metadata(index_block);
-
         assert(header_metadata.tree_id == tree_id);
         assert(header_metadata.key_size == schema.key_size);
         assert(header_metadata.value_block_count_max == schema.value_block_count_max);
-        assert(stdx.zeroed(&header_metadata.reserved));
-
         // The other schema fields are computed from key_size and value_block_count_max at runtime
         // and not saved in metadata. There is currently no way to detect whether this computation
         // itself has changed between versions.
-        return TableIndex.init(.{
-            .key_size = header_metadata.key_size,
-            .value_block_count_max = header_metadata.value_block_count_max,
-        });
+        return from_block_without_schema(index_block);
     }
 
     pub fn metadata(index_block: BlockPtrConst) *const Metadata {

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -195,9 +195,9 @@ pub const TableIndex = struct {
         assert(header_metadata.value_block_count_max == schema.value_block_count_max);
         assert(stdx.zeroed(&header_metadata.reserved));
 
-        // The other schema fields are computed from key_size and value_block_count_max in .init and
-        // not saved in metadata. There is no way to detect whether the computation itself has
-        // changed between versions.
+        // The other schema fields are computed from key_size and value_block_count_max at runtime
+        // and not saved in metadata. There is currently no way to detect whether this computation
+        // itself has changed between versions.
         return TableIndex.init(.{
             .key_size = header_metadata.key_size,
             .value_block_count_max = header_metadata.value_block_count_max,
@@ -386,9 +386,9 @@ pub const TableValue = struct {
         assert(header_metadata.value_size == schema.value_size);
         assert(header_metadata.value_count_max == schema.value_count_max);
         assert(stdx.zeroed(&header_metadata.reserved));
-        // The other schema fields are computed from value_size and value_count_max in .init and not
-        // saved in metadata. There is no way to detect whether the computation itself has changed
-        // between versions.
+        // The other schema fields are computed from value_size and value_count_max at runtime and
+        // not saved in metadata. There is currently no way to detect whether this computation
+        // itself has changed between versions.
     }
 
     pub fn metadata(value_block: BlockPtrConst) *const Metadata {

--- a/src/lsm/schema.zig
+++ b/src/lsm/schema.zig
@@ -177,6 +177,33 @@ pub const TableIndex = struct {
         return index;
     }
 
+    pub fn from_block(
+        schema: *const TableIndex,
+        index_block: BlockPtrConst,
+        tree_id: u16,
+    ) TableIndex {
+        const header = header_from_block(index_block);
+        assert(header.command == .block);
+        assert(header.block_type == .index);
+        assert(header.address > 0);
+        assert(header.snapshot > 0);
+
+        const header_metadata = metadata(index_block);
+
+        assert(header_metadata.tree_id == tree_id);
+        assert(header_metadata.key_size == schema.key_size);
+        assert(header_metadata.value_block_count_max == schema.value_block_count_max);
+        assert(stdx.zeroed(&header_metadata.reserved));
+
+        // The other schema fields are computed from key_size and value_block_count_max in .init and
+        // not saved in metadata. There is no way to detect whether the computation itself has
+        // changed between versions.
+        return TableIndex.init(.{
+            .key_size = header_metadata.key_size,
+            .value_block_count_max = header_metadata.value_block_count_max,
+        });
+    }
+
     pub fn metadata(index_block: BlockPtrConst) *const Metadata {
         const header = header_from_block(index_block);
         assert(header.command == .block);
@@ -337,6 +364,28 @@ pub const TableValue = struct {
             .value_count_max = header_metadata.value_count_max,
             .value_size = header_metadata.value_size,
         });
+    }
+
+    pub fn assert_matching_block_schema(
+        schema: *const TableValue,
+        value_block: BlockPtrConst,
+        tree_id: u16,
+    ) void {
+        const header = header_from_block(value_block);
+        assert(header.command == .block);
+        assert(header.block_type == .value);
+        assert(header.address > 0);
+        assert(header.snapshot > 0);
+
+        const header_metadata = metadata(value_block);
+
+        assert(header_metadata.tree_id == tree_id);
+        assert(header_metadata.value_size == schema.value_size);
+        assert(header_metadata.value_count_max == schema.value_count_max);
+        assert(stdx.zeroed(&header_metadata.reserved));
+        // The other schema fields are computed from value_size and value_count_max in .init and not
+        // saved in metadata. There is no way to detect whether the computation itself has changed
+        // between versions.
     }
 
     pub fn metadata(value_block: BlockPtrConst) *const Metadata {

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -543,7 +543,7 @@ pub fn TableType(
             );
         }
 
-        pub fn verify_value_block_schema_and_range(
+        pub fn verify_value_block(
             value_block: BlockPtrConst,
             index_block: BlockPtrConst,
             tree_id: u16,
@@ -575,22 +575,18 @@ pub fn TableType(
 
             assert(index_key_min <= value_key_min);
             assert(index_key_max >= value_key_max);
-            if (values.len > 1) assert(value_key_min < value_key_max);
-
+            if (values.len > 1) {
+                assert(value_key_min < value_key_max);
+                assert(index_key_min < value_key_max);
+                assert(index_key_max > value_key_min);
+            }
             if (value_block_index > 0 and value_block_index < index_block_addresses.len - 1) {
                 assert(index_key_min < value_key_min);
                 assert(index_key_max > value_key_max);
             }
-
-            if (value_block_index == 0) {
-                assert(index_key_min == value_key_min);
-                if (values.len > 1) assert(index_key_min < value_key_max);
-            }
-
-            if (value_block_index == index_block_addresses.len - 1) {
+            if (value_block_index == 0) assert(index_key_min == value_key_min);
+            if (value_block_index == index_block_addresses.len - 1)
                 assert(index_key_max == value_key_max);
-                if (values.len > 1) assert(index_key_max > value_key_min);
-            }
 
             if (constants.verify) {
                 for (values[0 .. values.len - 1], values[1..]) |*a, *b| {

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -596,6 +596,27 @@ pub fn TableType(
             }
         }
 
+        pub fn verify_index_block(
+            index_block: BlockPtrConst,
+            tree_id: u16,
+            key_min: Key,
+            key_max: Key,
+        ) schema.TableIndex {
+            const index_schema = index.from_block(index_block, tree_id);
+
+            const keys_min = index_value_keys_used(index_block, .key_min);
+            const keys_max = index_value_keys_used(index_block, .key_max);
+
+            assert(keys_min.len > 0);
+            assert(keys_min.len == keys_max.len);
+            assert(keys_min.len == index_schema.value_blocks_used(index_block));
+
+            assert(keys_min[0] == key_min);
+            assert(keys_max[keys_max.len - 1] == key_max);
+
+            return index_schema;
+        }
+
         pub fn verify(
             comptime Storage: type,
             storage: *const Storage,

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -581,7 +581,7 @@ pub fn TableType(
             key_min: Key,
             key_max: Key,
         ) schema.TableIndex {
-            const index_schema = index.from_block(index_block, tree_id);
+            const index_schema = index.from_block_with_schema(index_block, tree_id);
 
             const keys_min = index_value_keys_used(index_block, .key_min);
             const keys_max = index_value_keys_used(index_block, .key_max);

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -543,6 +543,62 @@ pub fn TableType(
             );
         }
 
+        pub fn verify_value_block_schema_and_range(
+            value_block: BlockPtrConst,
+            index_block: BlockPtrConst,
+            tree_id: u16,
+        ) void {
+            data.assert_matching_block_schema(value_block, tree_id);
+
+            const index_block_addresses = index.value_addresses_used(index_block);
+            const index_block_keys_min = index_value_keys_used(index_block, .key_min);
+            const index_block_keys_max = index_value_keys_used(index_block, .key_max);
+
+            assert(index_block_addresses.len > 0);
+            assert(index_block_keys_min.len == index_block_keys_max.len);
+            assert(index_block_keys_min.len == index_block_addresses.len);
+
+            const value_block_address = block_address(value_block);
+            const values = value_block_values_used(value_block);
+            assert(values.len > 0);
+
+            const value_block_index = std.mem.indexOfScalar(
+                u64,
+                index_block_addresses,
+                value_block_address,
+            ).?;
+
+            const index_key_min = index_block_keys_min[0];
+            const index_key_max = index_block_keys_max[index_block_keys_max.len - 1];
+            const value_key_min = key_from_value(&values[0]);
+            const value_key_max = key_from_value(&values[values.len - 1]);
+
+            assert(index_key_min <= value_key_min);
+            assert(index_key_max >= value_key_max);
+            if (values.len > 1) assert(value_key_min < value_key_max);
+
+            if (value_block_index > 0 and value_block_index < index_block_addresses.len - 1) {
+                assert(index_key_min < value_key_min);
+                assert(index_key_max > value_key_max);
+            }
+
+            if (value_block_index == 0) {
+                assert(index_key_min == value_key_min);
+                if (values.len > 1) assert(index_key_min < value_key_max);
+            }
+
+            if (value_block_index == index_block_addresses.len - 1) {
+                assert(index_key_max == value_key_max);
+                if (values.len > 1) assert(index_key_max > value_key_min);
+            }
+
+            if (constants.verify) {
+                for (values[0 .. values.len - 1], values[1..]) |*a, *b| {
+                    assert(key_from_value(a) < key_from_value(b));
+                }
+            }
+        }
+
         pub fn verify(
             comptime Storage: type,
             storage: *const Storage,

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -559,14 +559,15 @@ pub fn TableType(
             assert(index_block_keys_min.len == index_block_addresses.len);
 
             const value_block_address = block_address(value_block);
-            const values = value_block_values_used(value_block);
-            assert(values.len > 0);
-
             const value_block_index = std.mem.indexOfScalar(
                 u64,
                 index_block_addresses,
                 value_block_address,
             ).?;
+
+            const values = value_block_values_used(value_block);
+            assert(values.len > 0);
+            assert(values.len <= data.value_count_max);
 
             const index_key_min = index_block_keys_min[0];
             const index_key_max = index_block_keys_max[index_block_keys_max.len - 1];

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -623,6 +623,7 @@ pub fn TableType(
             index_address: u64,
             key_min: ?Key,
             key_max: ?Key,
+            tree_id: u16,
         ) void {
             if (Storage != @import("../testing/storage.zig").Storage)
                 // Too complicated to do async verification
@@ -631,6 +632,10 @@ pub fn TableType(
             const index_block = storage.grid_block(index_address).?;
             const value_block_addresses = index.value_addresses_used(index_block);
             const value_block_checksums = index.value_checksums_used(index_block);
+
+            if (key_min != null and key_max != null) {
+                _ = Table.verify_index_block(index_block, tree_id, key_min.?, key_max.?);
+            }
 
             for (
                 value_block_addresses,
@@ -641,6 +646,8 @@ pub fn TableType(
                 const value_block_header = schema.header_from_block(value_block);
                 assert(value_block_header.address == value_block_address);
                 assert(value_block_header.checksum == value_block_checksum.value);
+
+                Table.verify_value_block(value_block, index_block, tree_id);
 
                 const values = value_block_values_used(value_block);
                 if (values.len > 0) {

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -504,6 +504,8 @@ pub fn TableType(
         pub const IndexBlocks = struct {
             value_block_address: u64,
             value_block_checksum: u128,
+            value_block_key_min: Key,
+            value_block_key_max: Key,
         };
 
         /// Returns all data stored in the index block relating to a given key
@@ -513,6 +515,8 @@ pub fn TableType(
             return if (Table.index_value_block_for_key(index_block, key)) |i| .{
                 .value_block_address = index.value_addresses_used(index_block)[i],
                 .value_block_checksum = index.value_checksums_used(index_block)[i].value,
+                .value_block_key_min = index_value_keys_used(index_block, .key_min)[i],
+                .value_block_key_max = index_value_keys_used(index_block, .key_max)[i],
             } else null;
         }
 

--- a/src/lsm/table.zig
+++ b/src/lsm/table.zig
@@ -545,49 +545,24 @@ pub fn TableType(
 
         pub fn verify_value_block(
             value_block: BlockPtrConst,
-            index_block: BlockPtrConst,
             tree_id: u16,
+            key_min: Key,
+            key_max: Key,
         ) void {
             data.assert_matching_block_schema(value_block, tree_id);
 
-            const index_block_addresses = index.value_addresses_used(index_block);
-            const index_block_keys_min = index_value_keys_used(index_block, .key_min);
-            const index_block_keys_max = index_value_keys_used(index_block, .key_max);
-
-            assert(index_block_addresses.len > 0);
-            assert(index_block_keys_min.len == index_block_keys_max.len);
-            assert(index_block_keys_min.len == index_block_addresses.len);
-
-            const value_block_address = block_address(value_block);
-            const value_block_index = std.mem.indexOfScalar(
-                u64,
-                index_block_addresses,
-                value_block_address,
-            ).?;
-
-            const values = value_block_values_used(value_block);
+            const values = Table.value_block_values_used(value_block);
             assert(values.len > 0);
             assert(values.len <= data.value_count_max);
 
-            const index_key_min = index_block_keys_min[0];
-            const index_key_max = index_block_keys_max[index_block_keys_max.len - 1];
             const value_key_min = key_from_value(&values[0]);
             const value_key_max = key_from_value(&values[values.len - 1]);
 
-            assert(index_key_min <= value_key_min);
-            assert(index_key_max >= value_key_max);
-            if (values.len > 1) {
-                assert(value_key_min < value_key_max);
-                assert(index_key_min < value_key_max);
-                assert(index_key_max > value_key_min);
-            }
-            if (value_block_index > 0 and value_block_index < index_block_addresses.len - 1) {
-                assert(index_key_min < value_key_min);
-                assert(index_key_max > value_key_max);
-            }
-            if (value_block_index == 0) assert(index_key_min == value_key_min);
-            if (value_block_index == index_block_addresses.len - 1)
-                assert(index_key_max == value_key_max);
+            assert(value_key_min <= value_key_max);
+            if (values.len > 1) assert(value_key_min < value_key_max);
+
+            assert(value_key_min == key_min);
+            assert(value_key_max == key_max);
 
             if (constants.verify) {
                 for (values[0 .. values.len - 1], values[1..]) |*a, *b| {
@@ -647,7 +622,12 @@ pub fn TableType(
                 assert(value_block_header.address == value_block_address);
                 assert(value_block_header.checksum == value_block_checksum.value);
 
-                Table.verify_value_block(value_block, index_block, tree_id);
+                Table.verify_value_block(
+                    value_block,
+                    tree_id,
+                    Table.index_value_keys_used(index_block, .key_min)[value_block_index],
+                    Table.index_value_keys_used(index_block, .key_max)[value_block_index],
+                );
 
                 const values = value_block_values_used(value_block);
                 if (values.len > 0) {

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -348,6 +348,8 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             var index_block_count: u8 = 0;
             var index_block_addresses: [constants.lsm_levels]u64 = undefined;
             var index_block_checksums: [constants.lsm_levels]u128 = undefined;
+            var index_block_keys_min: [constants.lsm_levels]Key = undefined;
+            var index_block_keys_max: [constants.lsm_levels]Key = undefined;
             {
                 var it = tree.manifest.lookup(
                     parameters.snapshot,
@@ -361,6 +363,8 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
 
                     index_block_addresses[index_block_count] = table.address;
                     index_block_checksums[index_block_count] = table.checksum;
+                    index_block_keys_min[index_block_count] = table.key_min;
+                    index_block_keys_max[index_block_count] = table.key_max;
                 }
             }
 
@@ -376,6 +380,8 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 .index_block_count = index_block_count,
                 .index_block_addresses = index_block_addresses,
                 .index_block_checksums = index_block_checksums,
+                .index_block_keys_min = index_block_keys_min,
+                .index_block_keys_max = index_block_keys_max,
                 .callback = parameters.callback,
             };
 
@@ -395,6 +401,8 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             index_block_count: u8,
             index_block_addresses: [constants.lsm_levels]u64,
             index_block_checksums: [constants.lsm_levels]u128,
+            index_block_keys_min: [constants.lsm_levels]Key,
+            index_block_keys_max: [constants.lsm_levels]Key,
 
             value_block: ?struct {
                 address: u64,
@@ -426,6 +434,13 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 assert(context.index_block_count <= constants.lsm_levels);
                 assert(Table.index.block_metadata(index_block).tree_id == context.tree.config.id);
 
+                const keys_min = Table.index_value_keys_used(index_block, .key_min);
+                const keys_max = Table.index_value_keys_used(index_block, .key_max);
+
+                assert(keys_min[0] == context.index_block_keys_min[context.index_block]);
+                assert(keys_max[keys_max.len - 1] ==
+                    context.index_block_keys_max[context.index_block]);
+
                 const blocks = Table.index_blocks_for_key(index_block, context.key) orelse {
                     // The key is not present in this table, check the next level.
                     context.advance_to_next_level();
@@ -452,7 +467,13 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 assert(context.index_block < context.index_block_count);
                 assert(context.index_block_count > 0);
                 assert(context.index_block_count <= constants.lsm_levels);
-                assert(Table.data.block_metadata(value_block).tree_id == context.tree.config.id);
+                Table.data.assert_matching_block_schema(value_block, context.tree.config.id);
+
+                const values = Table.value_block_values_used(value_block);
+                assert(Table.key_from_value(&values[0]) >=
+                    context.index_block_keys_min[context.index_block]);
+                assert(Table.key_from_value(&values[values.len - 1]) <=
+                    context.index_block_keys_max[context.index_block]);
 
                 if (Table.value_block_search(value_block, context.key)) |value| {
                     context.callback(context, unwrap_tombstone(value));

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -540,7 +540,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             tree.compaction_op = tree.grid.superblock.working.vsr_state.checkpoint.header.op;
             tree.key_range = tree.manifest.key_range();
 
-            tree.manifest.verify(snapshot_latest);
+            tree.manifest.verify(snapshot_latest, tree.config.id);
             assert(tree.compaction_op.? == 0 or
                 (tree.compaction_op.? + 1) % constants.lsm_compaction_ops == 0);
             maybe(tree.key_range == null);

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -407,6 +407,8 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
             value_block: ?struct {
                 address: u64,
                 checksum: u128,
+                key_min: Key,
+                key_max: Key,
             } = null,
 
             callback: *const fn (*Tree.LookupContext, ?*const Value) void,
@@ -451,6 +453,8 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 context.value_block = .{
                     .address = blocks.value_block_address,
                     .checksum = blocks.value_block_checksum,
+                    .key_min = blocks.value_block_key_min,
+                    .key_max = blocks.value_block_key_max,
                 };
 
                 context.tree.grid.read_block(
@@ -471,10 +475,12 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 Table.data.assert_matching_block_schema(value_block, context.tree.config.id);
 
                 const values = Table.value_block_values_used(value_block);
-                assert(Table.key_from_value(&values[0]) >=
-                    context.index_block_keys_min[context.index_block]);
-                assert(Table.key_from_value(&values[values.len - 1]) <=
-                    context.index_block_keys_max[context.index_block]);
+                const values_key_min = Table.key_from_value(&values[0]);
+                const values_key_max = Table.key_from_value(&values[values.len - 1]);
+                assert(values_key_min >= context.index_block_keys_min[context.index_block]);
+                assert(values_key_max <= context.index_block_keys_max[context.index_block]);
+                assert(values_key_min == context.value_block.?.key_min);
+                assert(values_key_max == context.value_block.?.key_max);
 
                 if (Table.value_block_search(value_block, context.key)) |value| {
                     context.callback(context, unwrap_tombstone(value));

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -433,6 +433,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 assert(context.index_block_count > 0);
                 assert(context.index_block_count <= constants.lsm_levels);
                 assert(Table.index.block_metadata(index_block).tree_id == context.tree.config.id);
+                _ = Table.index.from_block(index_block, context.tree.config.id);
 
                 const keys_min = Table.index_value_keys_used(index_block, .key_min);
                 const keys_max = Table.index_value_keys_used(index_block, .key_max);

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -434,8 +434,7 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
                 assert(context.index_block < context.index_block_count);
                 assert(context.index_block_count > 0);
                 assert(context.index_block_count <= constants.lsm_levels);
-                assert(Table.index.block_metadata(index_block).tree_id == context.tree.config.id);
-                _ = Table.index.from_block(index_block, context.tree.config.id);
+                _ = Table.index.from_block_with_schema(index_block, context.tree.config.id);
 
                 const keys_min = Table.index_value_keys_used(index_block, .key_min);
                 const keys_max = Table.index_value_keys_used(index_block, .key_max);

--- a/src/tigerbeetle/inspect.zig
+++ b/src/tigerbeetle/inspect.zig
@@ -1454,7 +1454,7 @@ fn print_block(writer: std.io.AnyWriter, block: BlockPtrConst) !void {
             }
         },
         .index => {
-            const index = schema.TableIndex.from(block);
+            const index = schema.TableIndex.from_block_without_schema(block);
             for (
                 index.value_addresses_used(block),
                 index.value_checksums_used(block),

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -1579,7 +1579,7 @@ pub fn GridType(comptime Storage: type) type {
                     break :blk grid.superblock.storage.grid_block(index_address).?;
                 }
             };
-            const index_schema = schema.TableIndex.from(index_block);
+            const index_schema = schema.TableIndex.from_block_without_schema(index_block);
             const index_block_header = schema.header_from_block(index_block);
 
             assert(index_block_header.address == index_address);

--- a/src/vsr/grid_blocks_missing.zig
+++ b/src/vsr/grid_blocks_missing.zig
@@ -488,7 +488,7 @@ pub const GridBlocksMissing = struct {
         assert(table.table_blocks_written == 0);
         assert(table.value_blocks_received.count() == 0);
 
-        const index_schema = schema.TableIndex.from(index_block);
+        const index_schema = schema.TableIndex.from_block_without_schema(index_block);
         const index_block_header = schema.header_from_block(index_block);
         assert(index_block_header.address == table.table_info.address);
         assert(index_block_header.checksum == table.table_info.checksum);

--- a/src/vsr/grid_scrubber.zig
+++ b/src/vsr/grid_scrubber.zig
@@ -416,7 +416,7 @@ pub fn GridScrubberType(comptime Forest: type, grid_scrubber_reads_max: comptime
                     };
                 };
 
-                const index_schema = schema.TableIndex.from(index_block);
+                const index_schema = schema.TableIndex.from_block_without_schema(index_block);
                 const value_block_index = tour.table_value.value_block_index;
                 if (value_block_index <
                     index_schema.value_blocks_used(scrubber.tour_index_block))


### PR DESCRIPTION
We want to detect changes in the schema and inconsistent data and crash as early as possible, i.e., before writing new data.
This PR introduces assertions around this in compaction, lookups, scans, and manfiest.verify.

It also verifies that the tree_id has not changed. Much of the runtime schema data is computed from comparatively little metadata stored in the blocks. This means we can assert that the metadata has not changed, but we cannot currently assert that the derived data (e.g., the computation itself) has not changed.

I patched tigerbeetle v0.17.5 with these asserts and tried to read a v0.17.4 file with a different schema, which successfully hits one of these asserts when reading data:
```
thread 81686 panic: reached unreachable code
/tmp/tb-0.17.5-asserts/zig/lib/std/debug.zig:550:14: 0x1336bed in assert (tigerbeetle)
    if (!ok) unreachable; // assertion failure
             ^
/tmp/tb-0.17.5-asserts/src/lsm/schema.zig:194:15: 0x1a30103 in from_block (tigerbeetle)
        assert(header_metadata.key_size == schema.key_size);
```