### PR TITLE
Revert "Merge pull request #3828 from tigerbeetle/cbb/vsr_use_full_journal

### DIFF
--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -1649,10 +1649,11 @@ pub const Checkpoint = struct {
 
     pub fn prepare_max_for_checkpoint(checkpoint: u64) ?u64 {
         assert(valid(checkpoint));
-        if (checkpoint == 0) {
-            return null;
+
+        if (trigger_for_checkpoint(checkpoint)) |trigger| {
+            return trigger + (2 * constants.pipeline_prepare_queue_max);
         } else {
-            return checkpoint + constants.journal_slot_count - constants.vsr_checkpoint_ops;
+            return null;
         }
     }
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -2159,12 +2159,12 @@ pub fn ReplicaType(
                 assert(vsr.Checkpoint.durable(self.op_checkpoint_next(), self.commit_max));
                 if (message.header.op > @min(
                     // Committed ops can be safely overwritten.
-                    self.commit_min,
+                    self.commit_min + constants.journal_slot_count,
                     // Except op_checkpoint_next to op_checkpoint_next_trigger, which are required
                     // during upgrade (see `release_for_next_checkpoint`) and checkpoint (see
                     // `commit_checkpoint_superblock`), and can't be overwritten.
-                    self.op_checkpoint_next() - 1,
-                ) + constants.journal_slot_count) {
+                    self.op_checkpoint_next() + constants.journal_slot_count - 1,
+                )) {
                     log.warn("{}: on_prepare: ignoring prepare.op={} " ++
                         "(too far ahead, commit_min={} op={} commit_max={} prepare_max={})", .{
                         self.log_prefix(),


### PR DESCRIPTION
This reverts commit a052b2c18a0efaf0f8dae5f7242238753f77a697, reversing changes made to 83528614252a7860f595b9931a063493d0cc1ded.

With [#3828](https://github.com/tigerbeetle/tigerbeetle/pull/3828), we changed our `prepare_max` from `trigger + 2 * pipeline` → `trigger + compaction_ops`. The motivation was to use our journal up till the very end (not wasting the last 16 ops in the journal), but turns out this subtly changes some behaviour in the View message flow between a primary on a new version and backup on an old version.

Specifically, with the constants below from `tigerbeetle inspect`, imagine:
* Primary on new version, checkpoint=960, prepare max=1984
* Backup on old version, checkpoint=0, prepare_max=1008
* Primary sends View to the backup.
* Primary's View includes _two old_ [prepare max headers](https://github.com/tigerbeetle/tigerbeetle/blob/0.17.7/src/vsr/replica.zig#L5872-L5880)  so that a lagging backup can leapfrog its op to the prepare_max. So, it sends 1024 and 64.
* Backup receives View, finds 1024 > its prepare_max 1008, so it tries to _regress_ it's op to 64. :boom: 

```
prepare_queue                   8
compaction_ops                  32
checkpoint_ops                  960
journal_slot_count              1024
```
