### PR TITLE
Increase maximum manifest memory size

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -681,14 +681,18 @@ pub const lsm_table_value_blocks_max = table_blocks_max: {
 /// The default size in bytes of the NodePool used for the LSM forest's manifests.
 pub const lsm_manifest_memory_size_default = lsm_manifest_memory: {
     // TODO Tune this better.
-    const lsm_forest_node_count: u32 = 8192;
+    const lsm_forest_node_count: u38 = 8192;
     break :lsm_manifest_memory lsm_forest_node_count * lsm_manifest_node_size;
 };
 
 /// The maximum size in bytes of the NodePool used for the LSM forest's manifests.
 pub const lsm_manifest_memory_size_max =
-    @divFloor(std.math.maxInt(u32), lsm_manifest_memory_size_multiplier) *
+    @divFloor(std.math.maxInt(u38), lsm_manifest_memory_size_multiplier) *
     lsm_manifest_memory_size_multiplier;
+
+comptime {
+    assert(lsm_manifest_memory_size_max == 256 * stdx.GiB - lsm_manifest_memory_size_multiplier);
+}
 
 /// The minimum size in bytes of the NodePool used for the LSM forest's manifests.
 pub const lsm_manifest_memory_size_min = lsm_manifest_memory_size_multiplier;

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -681,18 +681,13 @@ pub const lsm_table_value_blocks_max = table_blocks_max: {
 /// The default size in bytes of the NodePool used for the LSM forest's manifests.
 pub const lsm_manifest_memory_size_default = lsm_manifest_memory: {
     // TODO Tune this better.
-    const lsm_forest_node_count: u38 = 8192;
+    const lsm_forest_node_count: u64 = 8192;
     break :lsm_manifest_memory lsm_forest_node_count * lsm_manifest_node_size;
 };
 
 /// The maximum size in bytes of the NodePool used for the LSM forest's manifests.
-pub const lsm_manifest_memory_size_max =
-    @divFloor(std.math.maxInt(u38), lsm_manifest_memory_size_multiplier) *
-    lsm_manifest_memory_size_multiplier;
-
-comptime {
-    assert(lsm_manifest_memory_size_max == 256 * stdx.GiB - lsm_manifest_memory_size_multiplier);
-}
+/// Loading the manifest into memory impacts recovery time, so we explicitly bound it.
+pub const lsm_manifest_memory_size_max = 16 * stdx.GiB;
 
 /// The minimum size in bytes of the NodePool used for the LSM forest's manifests.
 pub const lsm_manifest_memory_size_min = lsm_manifest_memory_size_multiplier;

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -167,6 +167,12 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         }
     }
 
+    // Comptime scale is limited by LSM size, not manifest memory size.
+    comptime assert(@divFloor(
+        constants.lsm_manifest_memory_size_max,
+        @sizeOf(schema.ManifestNode.TableInfo),
+    ) > table_count_max * _tree_infos.len);
+
     const Grid = GridType(_Storage);
     const ScanBufferPool = ScanBufferPoolType(Grid);
 

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -167,12 +167,6 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         }
     }
 
-    // Comptime scale is limited by LSM size, not manifest memory size.
-    comptime assert(@divFloor(
-        constants.lsm_manifest_memory_size_max,
-        @sizeOf(schema.ManifestNode.TableInfo),
-    ) > table_count_max * _tree_infos.len);
-
     const Grid = GridType(_Storage);
     const ScanBufferPool = ScanBufferPoolType(Grid);
 


### PR DESCRIPTION
Our 4GiB (u32) manifest memory limit is not enough for some scale tests.
A rough bound calculation based on the largest value size puts the limit at around 332 billion values across the LSM forest.

This PR increases the manifest memory limit to ~256 GiB (u38)~ 16 GiB, which should cover roughly 1.3 Trillion values across the forest based on the current average table size estimate.

~We now also assert that the maximum number of Tables supported is bound by the LSM levels, not the manifest, so that we don't get surprises there if we increase the level count.~