### PR TITLE
ScanBuilder

### DIFF
--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -312,13 +312,16 @@ const Environment = struct {
 
             fn prefetch_start(getter: *@This()) void {
                 const groove = getter._groove;
-                groove.prefetch_setup(getter._snapshot);
+                groove.prefetch_begin(getter._snapshot);
                 groove.prefetch_enqueue(getter._key);
                 groove.prefetch(@This().prefetch_callback, &getter.prefetch_context);
             }
 
             fn prefetch_callback(prefetch_context: *GrooveTransfers.PrefetchContext) void {
                 const context: *@This() = @fieldParentPtr("prefetch_context", prefetch_context);
+                const groove = context._groove;
+                groove.prefetch_finish();
+
                 assert(!context.finished);
                 context.finished = true;
             }

--- a/src/lsm/forest_fuzz.zig
+++ b/src/lsm/forest_fuzz.zig
@@ -800,7 +800,7 @@ const Environment = struct {
                     const prefix_current: u128 = switch (params.index) {
                         .expires_at => index: {
                             assert(object.timeout != 0);
-                            const value = object.timeout_ns();
+                            const value = object.timestamp + object.timeout_ns();
                             assert(value >= params.min and value <= params.max);
                             break :index value;
                         },

--- a/src/lsm/groove.zig
+++ b/src/lsm/groove.zig
@@ -18,8 +18,6 @@ const NodePool = @import("node_pool.zig").NodePoolType(constants.lsm_manifest_no
 const CacheMapType = @import("cache_map.zig").CacheMapType;
 const ScopeCloseMode = @import("tree.zig").ScopeCloseMode;
 const ManifestLogType = @import("manifest_log.zig").ManifestLogType;
-const ScanBuilderType = @import("scan_builder.zig").ScanBuilderType;
-
 const ScratchMemory = @import("scratch_memory.zig").ScratchMemory;
 
 const snapshot_latest = @import("tree.zig").snapshot_latest;
@@ -437,8 +435,6 @@ pub fn GrooveType(
         },
     });
 
-    const has_scan = index_fields.len > 0;
-
     // Verify groove index count:
     const indexes_count_actual = std.meta.fields(_IndexTrees).len;
     const indexes_count_expect = std.meta.fields(Object).len +
@@ -695,8 +691,6 @@ pub fn GrooveType(
             not_found,
         };
 
-        pub const ScanBuilder = if (has_scan) ScanBuilderType(Groove, Storage) else void;
-
         grid: *Grid,
         objects: ObjectTree,
         indexes: IndexTrees,
@@ -726,8 +720,6 @@ pub fn GrooveType(
         /// table, it _must_ exist in our object cache.
         /// Otherwise, the ObjectsCache is of type void.
         objects_cache: ObjectsCache,
-
-        scan_builder: ScanBuilder,
 
         pub const IndexTreeOptions = _IndexTreeOptions;
 
@@ -761,7 +753,6 @@ pub fn GrooveType(
                 .indexes = undefined,
                 .prefetch_keys = undefined,
                 .objects_cache = if (ObjectsCache != void) undefined else {},
-                .scan_builder = undefined,
             };
 
             groove.objects_cache = if (ObjectsCache != void) try ObjectsCache.init(allocator, .{
@@ -838,9 +829,6 @@ pub fn GrooveType(
                 options.prefetch_entries_for_read_max + options.prefetch_entries_for_update_max,
             );
             errdefer groove.prefetch_keys.deinit(allocator);
-
-            if (has_scan) try groove.scan_builder.init(allocator);
-            errdefer if (has_scan) groove.scan_builder.deinit(allocator);
         }
 
         pub fn deinit(groove: *Groove, allocator: mem.Allocator) void {
@@ -853,7 +841,6 @@ pub fn GrooveType(
             groove.prefetch_keys.deinit(allocator);
 
             if (ObjectsCache != void) groove.objects_cache.deinit(allocator);
-            if (has_scan) groove.scan_builder.deinit(allocator);
 
             groove.* = undefined;
         }
@@ -868,8 +855,6 @@ pub fn GrooveType(
 
             if (ObjectsCache != void) groove.objects_cache.reset();
 
-            if (has_scan) groove.scan_builder.reset();
-
             groove.* = .{
                 .grid = groove.grid,
                 .objects = groove.objects,
@@ -877,7 +862,6 @@ pub fn GrooveType(
                 .prefetch_keys = groove.prefetch_keys,
                 .prefetch_snapshot = null,
                 .objects_cache = groove.objects_cache,
-                .scan_builder = groove.scan_builder,
             };
         }
 
@@ -981,11 +965,21 @@ pub fn GrooveType(
         }
 
         /// Must be called directly before the state machine begins queuing ids for prefetch.
-        pub fn prefetch_setup(groove: *Groove, snapshot_target: u64) void {
+        pub fn prefetch_begin(groove: *Groove, snapshot_target: u64) void {
             assert(snapshot_target < snapshot_latest);
+            assert(groove.prefetch_snapshot == null);
+            maybe(groove.prefetch_keys.count() == 0);
 
             groove.prefetch_snapshot = snapshot_target;
             groove.prefetch_keys.clearRetainingCapacity();
+        }
+
+        /// Must be called after the state machine finishes prefetching.
+        pub fn prefetch_finish(groove: *Groove) void {
+            assert(groove.prefetch_snapshot != null);
+            maybe(groove.prefetch_keys.count() == 0);
+
+            groove.prefetch_snapshot = null;
         }
 
         /// This must be called by the state machine for every lookup by unique keys.
@@ -1341,13 +1335,14 @@ pub fn GrooveType(
             callback: *const fn (*PrefetchContext) void,
             context: *PrefetchContext,
         ) void {
+            assert(groove.prefetch_snapshot != null);
+
             context.* = .{
                 .groove = groove,
                 .callback = callback,
                 .snapshot = groove.prefetch_snapshot.?,
                 .key_iterator = groove.prefetch_keys.iterator(),
             };
-            groove.prefetch_snapshot = null;
             context.start_workers();
         }
 

--- a/src/lsm/scan_builder.zig
+++ b/src/lsm/scan_builder.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 const assert = std.debug.assert;
 
-const Allocator = std.mem.Allocator;
-
 const stdx = @import("stdx");
 const constants = @import("../constants.zig");
 const is_unique_key = @import("unique_key.zig").is_unique_key;
@@ -30,70 +28,81 @@ const Error = @import("scan_buffer.zig").Error;
 /// whether a stream has more items or not, and further IO is required.
 const Pending = error{Pending};
 
+/// Multiple `Groove`s can be queried together in the same scan, as long as
+/// related objects share the same `timestamp`.
+/// For example, indexes from the `Transfers`, `TransfersPending`, and
+/// `AccountEvents` Grooves can be used together in the same query, and the
+/// timestamps produced by the scan can be used for lookups in any of those
+/// Grooves.
+pub fn ScanBuilderConfigType(comptime Forest: type) type {
+    const GrooveName = std.meta.FieldEnum(Forest.Grooves);
+    // TODO(zig): Special case for Forests with a single groove,
+    // as the FieldEnum type is zero-sized.
+    // Compiler error "value stored in comptime field does not match
+    // the default value of the field".
+    if (@sizeOf(GrooveName) == 0) return struct {
+        comptime object_groove: GrooveName = @enumFromInt(0),
+        comptime index_grooves: []const GrooveName = &.{@enumFromInt(0)},
+    };
+
+    return struct {
+        /// Indicates which Groove the ObjectTree comes from.
+        /// Used for queries by `timestamp`.
+        object_groove: GrooveName,
+
+        /// Array of GrooveNames whose secondary indexes can be queried together,
+        /// meaning the `timestamp` of related objects is the same across all Grooves.
+        /// Index names must not conflict.
+        /// There is no support for aliasing or fully qualified names.
+        index_grooves: []const GrooveName,
+    };
+}
+
 /// ScanBuilder is a helper to create and combine scans using
 /// any of the Groove's indexes.
 pub fn ScanBuilderType(
-    // TODO: Instead of a single Groove per ScanType, introduce the concept of Orthogonal Grooves.
-    // For example, indexes from the Grooves `Transfers` and `PendingTransfers` can be
-    // used together in the same query, and the timestamp they produce can be used for
-    // lookups in either Grooves:
-    // ```
-    // SELECT Transfers WHERE Transfers.code=1 AND Transfers.pending_status=posted.
-    // ```
-    //
-    // Although the relation between orthogonal grooves is always 1:1 by the timestamp,
-    // when looking up an object in the Groove `A` by a timestamp found in the Groove `B`, it will
-    // require additional information to correctly assert if `B` "must have" or "may have" a
-    // corresponding match in `A`.
-    // E.g.: Every AccountBalance **must have** a corresponding Account, however the opposite
-    // isn't true.
-    // ```
-    // SELECT AccountBalances WHERE Accounts.user_data_32=100
-    // ```
-    comptime Groove: type,
     comptime Storage: type,
+    comptime Forest: type,
+    /// `Groove`s can be joined in the same scan, as long they produce
+    /// `timestamps` for the same objects.
+    /// For example, indexes from the Grooves `Transfers` and `TransfersPending` can be
+    /// used together in the same query, and the timestamp they produce can be used for
+    /// lookups in either Grooves:
+    ///
+    /// ```
+    /// SELECT Transfers WHERE Transfers.code=1 AND TransfersPending.status=posted
+    /// ```
+    /// or
+    /// ```
+    /// SELECT TransfersPending WHERE Transfers.user_data_32=1234
+    /// ```
+    comptime scan_config: ScanBuilderConfigType(Forest),
 ) type {
     return struct {
-        const ScanBuilder = @This();
-
-        const ScanBuffer = ScanBufferType(GridType(Storage));
-        pub const Scan = ScanType(Groove, Storage);
-
         /// Each `ScanTree` consumes memory and I/O, so they are limited by `lsm_scans_max`.
-        scans: *[constants.lsm_scans_max]Scan,
-        scan_count: u32 = 0,
+        forest: *Forest,
+        scans: [constants.lsm_scans_max]Scan,
+        scan_count: u32,
 
         /// Merging `ScanTree`s does not require additional resources, so `ScanMerge`s are stored
         /// in a separate buffer limited to `lsm_scans_max - 1`.
         /// If `lsm_scans_max = 4`, we can have at most 4 scans and 3 merge operations:
         /// M₁(M₂(S₁, S₂), M₃(S₃, S₄)).
-        merges: *[constants.lsm_scans_max - 1]Scan,
-        merge_count: u32 = 0,
+        merges: [constants.lsm_scans_max - 1]Scan,
+        merge_count: u32,
 
-        pub fn init(self: *ScanBuilder, allocator: Allocator) !void {
-            self.* = .{
+        const ScanBuilder = @This();
+        const ScanBuffer = ScanBufferType(GridType(Storage));
+
+        pub const Scan = ScanType(Storage, Forest, scan_config);
+
+        pub fn init(forest: *Forest) ScanBuilder {
+            return .{
+                .forest = forest,
                 .scans = undefined,
+                .scan_count = 0,
                 .merges = undefined,
-            };
-
-            self.scans = try allocator.create([constants.lsm_scans_max]Scan);
-            errdefer allocator.destroy(self.scans);
-
-            self.merges = try allocator.create([constants.lsm_scans_max - 1]Scan);
-            errdefer allocator.destroy(self.merges);
-        }
-
-        pub fn deinit(self: *ScanBuilder, allocator: Allocator) void {
-            allocator.destroy(self.scans);
-            allocator.destroy(self.merges);
-
-            self.* = undefined;
-        }
-
-        pub fn reset(self: *ScanBuilder) void {
-            self.* = .{
-                .scans = self.scans,
-                .merges = self.merges,
+                .merge_count = 0,
             };
         }
 
@@ -103,7 +112,7 @@ pub fn ScanBuilderType(
         /// Results are ordered by `timestamp`.
         pub fn scan_prefix(
             self: *ScanBuilder,
-            comptime index: std.meta.FieldEnum(Groove.IndexTrees),
+            comptime index: Scan.Indexes,
             buffer: *ScanBuffer,
             snapshot: u64,
             prefix: CompositeKeyPrefixType(index),
@@ -114,7 +123,7 @@ pub fn ScanBuilderType(
             const scan = self.scan_add(field) catch unreachable;
             const scan_impl = &@field(scan.dispatcher, @tagName(field));
             scan_impl.init(
-                &@field(self.groove().indexes, @tagName(index)),
+                self.tree(index),
                 buffer,
                 snapshot,
                 key_from_value(index, prefix, timestamp_range.min),
@@ -129,17 +138,19 @@ pub fn ScanBuilderType(
         /// Results are always unique.
         pub fn scan_unique_key(
             self: *ScanBuilder,
-            comptime index: std.meta.FieldEnum(Groove.IndexTrees),
+            comptime index: Scan.Indexes,
             buffer: *ScanBuffer,
             snapshot: u64,
             value: UniqueKeyType(index),
             direction: Direction,
         ) *Scan {
+            comptime assert(is_unique_key(TableValueType(index)));
+
             const field = comptime std.enums.nameCast(std.meta.FieldEnum(Scan.Dispatcher), index);
             const scan = self.scan_add(field) catch unreachable;
             const scan_impl = &@field(scan.dispatcher, @tagName(field));
             scan_impl.init(
-                &@field(self.groove().indexes, @tagName(index)),
+                self.tree(index),
                 buffer,
                 snapshot,
                 value,
@@ -162,7 +173,7 @@ pub fn ScanBuilderType(
             const scan = self.scan_add(.timestamp) catch unreachable;
             const scan_impl = &@field(scan.dispatcher, "timestamp");
             scan_impl.init(
-                &self.groove().objects,
+                self.tree(.timestamp),
                 buffer,
                 snapshot,
                 timestamp_range.min,
@@ -269,36 +280,48 @@ pub fn ScanBuilderType(
             return scan;
         }
 
-        fn TableValueType(comptime index: std.meta.FieldEnum(Groove.IndexTrees)) type {
-            const IndexTree = @FieldType(Groove.IndexTrees, @tagName(index));
+        fn TableValueType(comptime index: Scan.Indexes) type {
+            const IndexTree = Scan.TreeType(index);
             return IndexTree.Table.Value;
         }
 
-        fn CompositeKeyPrefixType(comptime index: std.meta.FieldEnum(Groove.IndexTrees)) type {
+        fn CompositeKeyPrefixType(comptime index: Scan.Indexes) type {
             const CompositeKey = TableValueType(index);
             comptime assert(is_composite_key(CompositeKey));
             return @FieldType(CompositeKey, "field");
         }
 
-        fn UniqueKeyType(comptime index: std.meta.FieldEnum(Groove.IndexTrees)) type {
+        fn UniqueKeyType(comptime index: Scan.Indexes) type {
             const UniqueKey = TableValueType(index);
             comptime assert(is_unique_key(UniqueKey));
             return @FieldType(UniqueKey, "field");
         }
 
         fn key_from_value(
-            comptime field: std.meta.FieldEnum(Groove.IndexTrees),
-            prefix: CompositeKeyPrefixType(field),
+            comptime index: Scan.Indexes,
+            prefix: CompositeKeyPrefixType(index),
             timestamp: u64,
-        ) TableValueType(field).Key {
-            return TableValueType(field).key_from_value(&.{
+        ) TableValueType(index).Key {
+            return TableValueType(index).key_from_value(&.{
                 .field = prefix,
                 .timestamp = timestamp,
             });
         }
 
-        inline fn groove(self: *ScanBuilder) *Groove {
-            return @alignCast(@fieldParentPtr("scan_builder", self));
+        inline fn tree(
+            self: *ScanBuilder,
+            comptime index: Scan.Indexes,
+        ) *Scan.TreeType(index) {
+            const groove_field = @field(Scan.index_map, @tagName(index));
+            const groove: *Scan.GrooveType(index) = &@field(
+                self.forest.grooves,
+                @tagName(groove_field),
+            );
+
+            return if (index == .timestamp)
+                &groove.objects
+            else
+                &@field(groove.indexes, @tagName(index));
         }
     };
 }
@@ -309,8 +332,9 @@ pub fn ScanBuilderType(
 /// for example `(A₁ ∪ A₂) ∩ B₁` produces the criteria equivalent to
 /// `WHERE (<condition_a1> OR <condition_a2>) AND <condition_b>`.
 pub fn ScanType(
-    comptime Groove: type,
     comptime Storage: type,
+    comptime Forest: type,
+    comptime scan_config: ScanBuilderConfigType(Forest),
 ) type {
     return struct {
         const Scan = @This();
@@ -330,10 +354,65 @@ pub fn ScanType(
             callback: Callback,
         };
 
+        /// Maps the index name -> `Groove` relation.
+        const index_map: T: {
+            const GrooveName = std.meta.FieldEnum(Forest.Grooves);
+            var indexes: []const std.builtin.Type.StructField = &.{};
+
+            // Timestamp from the ObjectTree:
+            indexes = indexes ++ [_]std.builtin.Type.StructField{.{
+                .name = "timestamp",
+                .type = GrooveName,
+                .is_comptime = true,
+                .default_value_ptr = &scan_config.object_groove,
+                .alignment = @alignOf(GrooveName),
+            }};
+
+            // Secondary indexes from joined Grooves' IndexTrees:
+            for (scan_config.index_grooves) |*groove_name| {
+                const Groove = @FieldType(Forest.Grooves, @tagName(groove_name.*));
+                for (std.meta.fields(Groove.IndexTrees)) |field| {
+                    indexes = indexes ++ [_]std.builtin.Type.StructField{.{
+                        .name = field.name,
+                        .type = GrooveName,
+                        .is_comptime = true,
+                        .default_value_ptr = groove_name,
+                        .alignment = @alignOf(GrooveName),
+                    }};
+                }
+            }
+
+            break :T @Type(.{ .@"struct" = .{
+                .layout = .auto,
+                .fields = indexes,
+                .decls = &.{},
+                .is_tuple = false,
+            } });
+        } = .{};
+
+        pub const Indexes = std.meta.FieldEnum(@TypeOf(index_map));
+
+        fn GrooveType(comptime index: Indexes) type {
+            const groove_from_index: std.meta.FieldEnum(Forest.Grooves) = @field(
+                index_map,
+                @tagName(index),
+            );
+            return @FieldType(Forest.Grooves, @tagName(groove_from_index));
+        }
+
+        fn TreeType(comptime index: Indexes) type {
+            const Groove = GrooveType(index);
+            return if (index == .timestamp)
+                Groove.ObjectTree
+            else
+                @FieldType(Groove.IndexTrees, @tagName(index));
+        }
+
         /// Comptime dispatcher for all scan implementations that share the same interface.
         /// Generates a tagged union with an specialized `ScanTreeType` for each queryable field in
-        /// the `Groove` (e.g. `timestamp`, `id` if present, and secondary indexes), plus a
-        /// `ScanMergeType` for each merge operation (e.g. union, intersection, and difference).
+        /// the `Groove` (e.g. `timestamp`, `id` if present, and secondary indexes),
+        /// plus the supported joins, and a `ScanMergeType` for each merge operation
+        /// (e.g. union, intersection, and difference).
         ///
         /// Example:
         /// ```
@@ -350,20 +429,17 @@ pub fn ScanType(
         /// ```
         pub const Dispatcher = T: {
             var type_info = @typeInfo(union(enum) {
-                timestamp: ScanTreeType(*Context, Groove.ObjectTree, Storage),
-
-                merge_union: ScanMergeUnionType(Groove, Storage),
-                merge_intersection: ScanMergeIntersectionType(Groove, Storage),
-                merge_difference: ScanMergeDifferenceType(Groove, Storage),
+                merge_union: ScanMergeUnionType(Storage, Forest, scan_config),
+                merge_intersection: ScanMergeIntersectionType(Storage, Forest, scan_config),
+                merge_difference: ScanMergeDifferenceType(Storage, Forest, scan_config),
             });
 
-            // Union fields for each index tree:
-            for (std.meta.fields(Groove.IndexTrees)) |field| {
-                const IndexTree = field.type;
-                const ScanTree = ScanTreeType(*Context, IndexTree, Storage);
+            for (std.enums.values(Indexes)) |index| {
+                const Tree = TreeType(index);
+                const ScanTree = ScanTreeType(*Context, Tree, Storage);
                 type_info.@"union".fields = type_info.@"union".fields ++
                     [_]std.builtin.Type.UnionField{.{
-                        .name = field.name,
+                        .name = @tagName(index),
                         .type = ScanTree,
                         .alignment = @alignOf(ScanTree),
                     }};
@@ -396,7 +472,7 @@ pub fn ScanType(
         assigned: bool,
 
         pub fn read(scan: *Scan, context: *Context) void {
-            @setEvalBranchQuota(4_000);
+            @setEvalBranchQuota(10_000);
             switch (scan.dispatcher) {
                 inline else => |*scan_impl, tag| {
                     const Impl = @TypeOf(scan_impl.*);
@@ -411,6 +487,7 @@ pub fn ScanType(
         }
 
         pub fn next(scan: *Scan) Pending!?u64 {
+            @setEvalBranchQuota(10_000);
             switch (scan.dispatcher) {
                 inline .merge_union,
                 .merge_intersection,
@@ -425,10 +502,12 @@ pub fn ScanType(
                             continue;
                         }
 
+                        const Groove = GrooveType(comptime std.enums.nameCast(Indexes, index));
                         if (comptime Groove.is_primary_key(index)) {
                             // When iterating over the primary key,
                             // it can return a timestamp zero, which indicates an orphaned id.
                             if (value.timestamp == 0) {
+                                assert(index != .timestamp);
                                 assert(Groove.config.primary_key_orphaned);
                                 continue;
                             }
@@ -461,7 +540,7 @@ pub fn ScanType(
                 .merge_intersection,
                 .merge_difference,
                 => |*scan_impl| scan_impl.probe(timestamp),
-                inline else => |*scan_impl| {
+                inline else => |*scan_impl, index| {
                     const ScanTree = @TypeOf(scan_impl.*);
                     const Value = ScanTree.Tree.Table.Value;
 
@@ -477,6 +556,7 @@ pub fn ScanType(
                             .timestamp = timestamp,
                         }));
                     } else {
+                        const Groove = GrooveType(std.enums.nameCast(Indexes, index));
                         comptime assert(is_unique_key(Value));
                         comptime assert(Groove.config.unique_keys.len > 0);
 
@@ -495,7 +575,7 @@ pub fn ScanType(
                 .merge_intersection,
                 .merge_difference,
                 => |*scan_impl| return scan_impl.direction,
-                inline else => |*scan_impl| {
+                inline else => |*scan_impl, index| {
                     const ScanTree = @TypeOf(scan_impl.*);
                     const Value = ScanTree.Tree.Table.Value;
                     if (comptime is_composite_key(Value)) {
@@ -504,6 +584,7 @@ pub fn ScanType(
                         assert(Value.key_prefix(scan_impl.key_lower) ==
                             Value.key_prefix(scan_impl.key_upper));
                     } else {
+                        const Groove = GrooveType(std.enums.nameCast(Indexes, index));
                         comptime assert(is_unique_key(Value));
                         comptime assert(Groove.config.unique_keys.len > 0);
                         assert(scan_impl.key_lower == scan_impl.key_upper);

--- a/src/lsm/scan_builder.zig
+++ b/src/lsm/scan_builder.zig
@@ -63,7 +63,7 @@ pub fn ScanBuilderConfigType(comptime Forest: type) type {
 pub fn ScanBuilderType(
     comptime Storage: type,
     comptime Forest: type,
-    /// `Groove`s can be joined in the same scan, as long they produce
+    /// `Groove`s can be joined in the same scan, as long as they produce
     /// `timestamps` for the same objects.
     /// For example, indexes from the Grooves `Transfers` and `TransfersPending` can be
     /// used together in the same query, and the timestamp they produce can be used for

--- a/src/lsm/scan_fuzz.zig
+++ b/src/lsm/scan_fuzz.zig
@@ -18,6 +18,7 @@ const GridType = @import("../vsr/grid.zig").GridType;
 const GrooveType = @import("groove.zig").GrooveType;
 const ForestType = @import("forest.zig").ForestType;
 const ScanLookupType = @import("scan_lookup.zig").ScanLookupType;
+const ScanBuilderType = @import("scan_builder.zig").ScanBuilderType;
 const TimestampRange = @import("timestamp_range.zig").TimestampRange;
 const Direction = @import("../direction.zig").Direction;
 
@@ -142,13 +143,17 @@ const Index = enum {
     index_13,
 };
 
+const ScanBuilder = ScanBuilderType(Storage, Forest, .{
+    .object_groove = .things,
+    .index_grooves = &.{.things},
+});
+const Scan = ScanBuilder.Scan;
+
 const ScanLookup = ScanLookupType(
     ThingsGroove,
-    ThingsGroove.ScanBuilder.Scan,
+    Scan,
     Storage,
 );
-
-const Scan = ThingsGroove.ScanBuilder.Scan;
 
 const thing_index_count = std.enums.values(Index).len;
 /// The max number of indexes in a query.
@@ -531,6 +536,7 @@ const Environment = struct {
     op: u64 = 1,
     checkpoint_op: ?u64 = null,
 
+    scan_builder: ScanBuilder = undefined,
     scan_lookup: ScanLookup = undefined,
     scan_lookup_buffer: []Thing,
     scan_lookup_result: ?[]const Thing = null,
@@ -669,7 +675,9 @@ const Environment = struct {
             assert(env.scan_lookup_result == null);
             defer {
                 env.forest.scan_buffer_pool.reset();
-                env.forest.grooves.things.scan_builder.reset();
+                env.scan_lookup = undefined;
+                env.scan_builder = undefined;
+                env.scan_lookup_result = null;
             }
 
             const query_results_max: u32 = env.prng.range_inclusive(
@@ -688,7 +696,6 @@ const Environment = struct {
                 try env.tick_until_state_change(.scanning, .fuzzing);
 
                 const query_results = env.scan_lookup_result.?;
-                env.scan_lookup_result = null;
                 break :results query_results;
             };
 
@@ -836,7 +843,7 @@ const Environment = struct {
 
             fn prefetch_start(getter: *@This()) void {
                 const groove = getter._groove;
-                groove.prefetch_setup(getter._snapshot);
+                groove.prefetch_begin(getter._snapshot);
                 groove.prefetch_enqueue(.{ .id = getter._key });
                 groove.prefetch(@This().prefetch_callback, &getter.prefetch_context);
             }
@@ -844,6 +851,8 @@ const Environment = struct {
             fn prefetch_callback(prefetch_context: *ThingsGroove.PrefetchContext) void {
                 const context: *@This() = @fieldParentPtr("prefetch_context", prefetch_context);
                 assert(!context.finished);
+
+                context._groove.prefetch_finish();
                 context.finished = true;
             }
         };
@@ -944,10 +953,9 @@ const Environment = struct {
         timestamp_last: u64, // exclusive
     ) *Scan {
         const scan_buffer_pool = &env.forest.scan_buffer_pool;
-        const things_groove = &env.forest.grooves.things;
-        const scan_builder: *ThingsGroove.ScanBuilder = &things_groove.scan_builder;
         const snapshot = env.op;
 
+        env.scan_builder = ScanBuilder.init(&env.forest);
         var stack = stdx.BoundedArrayType(*Scan, query_scans_max){};
         for (query_spec.query.const_slice()) |query_part| {
             switch (query_part) {
@@ -961,9 +969,9 @@ const Environment = struct {
                     assert(timestamp_range.min <= timestamp_range.max);
 
                     const scan = switch (field.index) {
-                        inline else => |comptime_index| scan_builder.scan_prefix(
+                        inline else => |comptime_index| env.scan_builder.scan_prefix(
                             comptime std.enums.nameCast(
-                                std.meta.FieldEnum(ThingsGroove.IndexTrees),
+                                Scan.Indexes,
                                 comptime_index,
                             ),
                             scan_buffer_pool.acquire_assume_capacity(),
@@ -981,8 +989,8 @@ const Environment = struct {
                     const scans_to_merge = stack.slice()[stack.count() - merge.operand_count ..];
 
                     const scan = switch (merge.operator) {
-                        .union_set => scan_builder.merge_union(scans_to_merge),
-                        .intersection_set => scan_builder.merge_intersection(scans_to_merge),
+                        .union_set => env.scan_builder.merge_union(scans_to_merge),
+                        .intersection_set => env.scan_builder.merge_intersection(scans_to_merge),
                     };
 
                     stack.truncate(stack.count() - merge.operand_count);

--- a/src/lsm/scan_merge.zig
+++ b/src/lsm/scan_merge.zig
@@ -10,28 +10,57 @@ const Direction = @import("../direction.zig").Direction;
 const KWayMergeIteratorType = @import("k_way_merge.zig").KWayMergeIteratorType;
 const ZigZagMergeIteratorType = @import("zig_zag_merge.zig").ZigZagMergeIteratorType;
 const ScanType = @import("scan_builder.zig").ScanType;
+const ScanBuilderConfigType = @import("scan_builder.zig").ScanBuilderConfigType;
 const Pending = error{Pending};
 
 /// Union ∪ operation over an array of non-specialized `Scan` instances.
 /// At a high level, this is an ordered iterator over the set-union of the timestamps of
 /// each of the component Scans.
-pub fn ScanMergeUnionType(comptime Groove: type, comptime Storage: type) type {
-    return ScanMergeType(Groove, Storage, .merge_union);
+pub fn ScanMergeUnionType(
+    comptime Storage: type,
+    comptime Forest: type,
+    comptime scan_config: ScanBuilderConfigType(Forest),
+) type {
+    return ScanMergeType(
+        Storage,
+        Forest,
+        scan_config,
+        .merge_union,
+    );
 }
 
 /// Intersection ∩ operation over an array of non-specialized `Scan` instances.
-pub fn ScanMergeIntersectionType(comptime Groove: type, comptime Storage: type) type {
-    return ScanMergeType(Groove, Storage, .merge_intersection);
+pub fn ScanMergeIntersectionType(
+    comptime Storage: type,
+    comptime Forest: type,
+    comptime scan_config: ScanBuilderConfigType(Forest),
+) type {
+    return ScanMergeType(
+        Storage,
+        Forest,
+        scan_config,
+        .merge_intersection,
+    );
 }
 
 /// Difference (minus) operation over two non-specialized `Scan` instances.
-pub fn ScanMergeDifferenceType(comptime Groove: type, comptime Storage: type) type {
-    return ScanMergeType(Groove, Storage, .merge_intersection);
+pub fn ScanMergeDifferenceType(
+    comptime Storage: type,
+    comptime Forest: type,
+    comptime scan_config: ScanBuilderConfigType(Forest),
+) type {
+    return ScanMergeType(
+        Storage,
+        Forest,
+        scan_config,
+        .merge_intersection,
+    );
 }
 
 fn ScanMergeType(
-    comptime Groove: type,
     comptime Storage: type,
+    comptime Forest: type,
+    comptime scan_config: ScanBuilderConfigType(Forest),
     comptime merge: enum {
         merge_union,
         merge_intersection,
@@ -40,7 +69,7 @@ fn ScanMergeType(
 ) type {
     return struct {
         const ScanMerge = @This();
-        const Scan = ScanType(Groove, Storage);
+        const Scan = ScanType(Storage, Forest, scan_config);
 
         pub const Callback = *const fn (context: *Scan.Context, self: *ScanMerge) void;
 

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -18,6 +18,7 @@ const GrooveType = @import("lsm/groove.zig").GrooveType;
 const ForestType = @import("lsm/forest.zig").ForestType;
 const ScanBufferType = @import("lsm/scan_buffer.zig").ScanBufferType;
 const ScanLookupType = @import("lsm/scan_lookup.zig").ScanLookupType;
+const ScanBuilderType = @import("lsm/scan_builder.zig").ScanBuilderType;
 
 const MultiBatchEncoder = vsr.multi_batch.MultiBatchEncoder;
 const MultiBatchDecoder = vsr.multi_batch.MultiBatchDecoder;
@@ -236,6 +237,7 @@ pub fn StateMachineType(comptime Storage: type) type {
         prefetch_input: ?[]const u8 = null,
         prefetch_callback: ?*const fn (*StateMachine) void = null,
         prefetch_context: PrefetchContext = .null,
+        scan_builder: ScanBuilders = .null,
 
         scan_lookup: ScanLookup = .null,
         scan_lookup_buffer: []align(constants.cache_line_size) u8,
@@ -243,7 +245,8 @@ pub fn StateMachineType(comptime Storage: type) type {
         scan_lookup_results: std.ArrayListUnmanaged(u32),
         scan_lookup_next_tick: Grid.NextTick = undefined,
 
-        expire_pending_transfers: ExpirePendingTransfers = .{},
+        // TODO: Split the scan from the running state.
+        expire_pending_transfers: ScanBuilders.ExpirePendingTransfers = .{},
 
         open_callback: ?*const fn (*StateMachine) void = null,
         compact_callback: ?*const fn (*StateMachine) void = null,
@@ -476,7 +479,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                 .primary_key = "timestamp",
                 .primary_key_orphaned = false,
                 .unique_keys = &[_][:0]const u8{},
-                .ignored = &[_][:0]const u8{"padding"},
+                .ignored = &[_][]const u8{"padding"},
                 .optional = &[_][:0]const u8{
                     // Index the current status of a pending transfer.
                     // Examples:
@@ -604,27 +607,6 @@ pub fn StateMachineType(comptime Storage: type) type {
             },
         );
 
-        const AccountsScanLookup = ScanLookupType(
-            AccountsGroove,
-            AccountsGroove.ScanBuilder.Scan,
-            Storage,
-        );
-
-        const TransfersScanLookup = ScanLookupType(
-            TransfersGroove,
-            TransfersGroove.ScanBuilder.Scan,
-            Storage,
-        );
-
-        const AccountBalancesScanLookup = ScanLookupType(
-            AccountEventsGroove,
-            // Both Objects use the same timestamp, so we can use the TransfersGroove's indexes.
-            TransfersGroove.ScanBuilder.Scan,
-            Storage,
-        );
-
-        const ChangeEventsScanLookup = ChangeEventsScanLookupType(AccountEventsGroove, Storage);
-
         /// Since prefetch contexts are used one at a time, it's safe to access
         /// the union's fields and reuse the same memory for all context instances.
         const PrefetchContext = union(enum) {
@@ -658,17 +640,96 @@ pub fn StateMachineType(comptime Storage: type) type {
             }
         };
 
-        const ExpirePendingTransfers = ExpirePendingTransfersType(TransfersGroove, Storage);
+        /// Defines a `ScanBuilder` type for each type of query the StateMachine executes.
+        /// Note: `get_change_events` does not use a `ScanBuilder`, since it iterates directly
+        /// over the object tree without filtering by secondary indexes.
+        const ScanBuilders = union(enum) {
+            null,
+            accounts: ScanBuilders.Accounts,
+            transfers: ScanBuilders.Transfers,
 
-        /// Since scan lookups are used one at a time, it's safe to access
-        /// the union's fields and reuse the same memory for all ScanLookup instances.
+            const Tag = std.meta.Tag(@This());
+
+            /// Used by `query_accounts`.
+            const Accounts = ScanBuilderType(Storage, Forest, .{
+                .object_groove = .accounts,
+                .index_grooves = &.{.accounts},
+            });
+
+            /// Used by `query_transfers`, `get_account_transfers` and `get_account_balances`.
+            const Transfers = ScanBuilderType(Storage, Forest, .{
+                .object_groove = .transfers,
+                .index_grooves = &.{ .transfers, .transfers_pending, .account_events },
+            });
+
+            // Used by `expire_pending_transfers`.
+            const ExpirePendingTransfers = ExpirePendingTransfersType(TransfersGroove, Storage);
+
+            pub fn FieldType(comptime field: Tag) type {
+                return @FieldType(ScanBuilders, @tagName(field));
+            }
+
+            pub fn get(self: *ScanBuilders, comptime field: Tag) *FieldType(field) {
+                comptime assert(field != .null);
+                assert(self.* == .null);
+
+                const state_machine: *StateMachine = @alignCast(
+                    @fieldParentPtr("scan_builder", self),
+                );
+                self.* = @unionInit(
+                    ScanBuilders,
+                    @tagName(field),
+                    .init(&state_machine.forest),
+                );
+                return &@field(self, @tagName(field));
+            }
+        };
+
+        /// Defines a `ScanLookup` type for each type of object
+        /// the StateMachine fetches from `ScanBuilder` queries.
+        ///
+        /// `ScanLookup`s and `ScanBuilder`s are composable.
+        /// Think of `ScanLookup` as the SELECT clause, while
+        /// `ScanBuilder`s are the WHERE and ORDER BY clauses.
         const ScanLookup = union(enum) {
             null,
-            transfers: TransfersScanLookup,
-            accounts: AccountsScanLookup,
-            account_balances: AccountBalancesScanLookup,
-            expire_pending_transfers: ExpirePendingTransfers.ScanLookup,
-            change_events: ChangeEventsScanLookup,
+            transfers: ScanLookup.Transfers,
+            accounts: ScanLookup.Accounts,
+            account_balances: ScanLookup.AccountBalances,
+            expire_pending_transfers: ScanLookup.ExpirePendingTransfers,
+            change_events: ScanLookup.ChangeEvents,
+
+            /// Used by `query_accounts`.
+            const Accounts = ScanLookupType(
+                AccountsGroove,
+                ScanBuilders.Accounts.Scan,
+                Storage,
+            );
+
+            /// Used by `query_transfers` and `get_account_transfers`.
+            const Transfers = ScanLookupType(
+                TransfersGroove,
+                ScanBuilders.Transfers.Scan,
+                Storage,
+            );
+
+            /// Used by `get_account_balances`.
+            const AccountBalances = ScanLookupType(
+                AccountEventsGroove,
+                // Both Objects use the same timestamp, so we can use the TransfersGroove's indexes.
+                ScanBuilders.Transfers.Scan,
+                Storage,
+            );
+
+            /// Used by `get_change_events`.
+            const ChangeEvents = ChangeEventsScanLookupType(AccountEventsGroove, Storage);
+
+            /// Used by `expire_pending_transfers`.
+            const ExpirePendingTransfers = ScanLookupType(
+                TransfersGroove,
+                ScanBuilders.ExpirePendingTransfers.Scan,
+                Storage,
+            );
 
             pub const Field = std.meta.FieldEnum(ScanLookup);
             pub fn FieldType(comptime field: Field) type {
@@ -1188,9 +1249,9 @@ pub fn StateMachineType(comptime Storage: type) type {
             self.prefetch_callback = callback;
 
             // TODO(Snapshots) Pass in the target snapshot.
-            self.forest.grooves.accounts.prefetch_setup(snapshot);
-            self.forest.grooves.transfers.prefetch_setup(snapshot);
-            self.forest.grooves.transfers_pending.prefetch_setup(snapshot);
+            self.forest.grooves.accounts.prefetch_begin(snapshot);
+            self.forest.grooves.transfers.prefetch_begin(snapshot);
+            self.forest.grooves.transfers_pending.prefetch_begin(snapshot);
 
             // Prefetch starts timing for an operation.
             self.metrics.timer.reset();
@@ -1237,6 +1298,10 @@ pub fn StateMachineType(comptime Storage: type) type {
             self.prefetch_snapshot = null;
             self.prefetch_operation = null;
             self.prefetch_input = null;
+
+            self.forest.grooves.accounts.prefetch_finish();
+            self.forest.grooves.transfers.prefetch_finish();
+            self.forest.grooves.transfers_pending.prefetch_finish();
 
             callback(self);
         }
@@ -1517,7 +1582,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                 );
 
                 const scan_lookup = self.scan_lookup.get(.transfers);
-                scan_lookup.* = TransfersScanLookup.init(
+                scan_lookup.* = ScanLookup.Transfers.init(
                     &self.forest.grooves.transfers,
                     scan,
                 );
@@ -1545,7 +1610,7 @@ pub fn StateMachineType(comptime Storage: type) type {
         }
 
         fn prefetch_get_account_transfers_scan_callback(
-            scan_lookup: *TransfersScanLookup,
+            scan_lookup: *ScanLookup.Transfers,
             results: []const Transfer,
         ) void {
             const self: *StateMachine = ScanLookup.parent(.transfers, scan_lookup);
@@ -1559,8 +1624,8 @@ pub fn StateMachineType(comptime Storage: type) type {
             self.scan_lookup_results.appendAssumeCapacity(@intCast(results.len));
 
             self.scan_lookup = .null;
+            self.scan_builder = .null;
             self.forest.scan_buffer_pool.reset();
-            self.forest.grooves.transfers.scan_builder.reset();
 
             return self.prefetch_scan_resume();
         }
@@ -1597,6 +1662,8 @@ pub fn StateMachineType(comptime Storage: type) type {
             assert(self.prefetch_operation.? == .get_account_balances or
                 self.prefetch_operation.? == .deprecated_get_account_balances_unbatched);
             assert(self.scan_lookup == .null);
+
+            // It runs before the scan; there must be no ongoing scan lookup.
             assert(self.scan_lookup_buffer_index == 0);
             assert(self.scan_lookup_results.items.len == 0);
 
@@ -1633,7 +1700,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                         );
 
                         const scan_lookup = self.scan_lookup.get(.account_balances);
-                        scan_lookup.* = AccountBalancesScanLookup.init(
+                        scan_lookup.* = ScanLookup.AccountBalances.init(
                             &self.forest.grooves.account_events,
                             scan,
                         );
@@ -1675,7 +1742,7 @@ pub fn StateMachineType(comptime Storage: type) type {
         }
 
         fn prefetch_get_account_balances_scan_callback(
-            scan_lookup: *AccountBalancesScanLookup,
+            scan_lookup: *ScanLookup.AccountBalances,
             results: []const AccountEvent,
         ) void {
             const self: *StateMachine = ScanLookup.parent(.account_balances, scan_lookup);
@@ -1688,9 +1755,9 @@ pub fn StateMachineType(comptime Storage: type) type {
             self.scan_lookup_buffer_index += @intCast(results.len * @sizeOf(AccountEvent));
             self.scan_lookup_results.appendAssumeCapacity(@intCast(results.len));
 
-            self.forest.scan_buffer_pool.reset();
-            self.forest.grooves.transfers.scan_builder.reset();
             self.scan_lookup = .null;
+            self.scan_builder = .null;
+            self.forest.scan_buffer_pool.reset();
 
             return self.prefetch_scan_resume();
         }
@@ -1737,7 +1804,7 @@ pub fn StateMachineType(comptime Storage: type) type {
         fn get_scan_from_account_filter(
             self: *StateMachine,
             filter: *const AccountFilter,
-        ) ?*TransfersGroove.ScanBuilder.Scan {
+        ) ?*ScanBuilders.Transfers.Scan {
             assert(self.forest.scan_buffer_pool.scan_buffer_used == 0);
 
             const filter_valid =
@@ -1752,9 +1819,7 @@ pub fn StateMachineType(comptime Storage: type) type {
 
             if (!filter_valid) return null;
 
-            const transfers_groove: *TransfersGroove = &self.forest.grooves.transfers;
-            const scan_builder: *TransfersGroove.ScanBuilder = &transfers_groove.scan_builder;
-
+            const scan_builder = self.scan_builder.get(.transfers);
             const timestamp_range: TimestampRange = .{
                 .min = if (filter.timestamp_min == 0)
                     TimestampRange.timestamp_min
@@ -1778,7 +1843,8 @@ pub fn StateMachineType(comptime Storage: type) type {
             //     user_data_32=? AND
             //     code=?
             // ```
-            var scan_conditions: stdx.BoundedArrayType(*TransfersGroove.ScanBuilder.Scan, 5) = .{};
+            const Scan = ScanBuilders.Transfers.Scan;
+            var scan_conditions: stdx.BoundedArrayType(*Scan, 5) = .{};
             const direction: Direction = if (filter.flags.reversed) .descending else .ascending;
 
             // Adding the condition for `debit_account_id = $account_id`.
@@ -1817,7 +1883,7 @@ pub fn StateMachineType(comptime Storage: type) type {
             }
 
             // Additional filters with an intersection `AND`.
-            inline for ([_]std.meta.FieldEnum(TransfersGroove.IndexTrees){
+            inline for ([_]std.meta.FieldEnum(Scan.Indexes){
                 .user_data_128, .user_data_64, .user_data_32, .code,
             }) |filter_field| {
                 const filter_value = @field(filter, @tagName(filter_field));
@@ -1865,11 +1931,7 @@ pub fn StateMachineType(comptime Storage: type) type {
             });
 
             assert(self.forest.scan_buffer_pool.scan_buffer_used == 0);
-            if (self.get_scan_from_query_filter(
-                AccountsGroove,
-                &self.forest.grooves.accounts,
-                filter,
-            )) |scan| {
+            if (self.get_scan_from_query_filter(.accounts, filter)) |scan| {
                 assert(self.forest.scan_buffer_pool.scan_buffer_used > 0);
 
                 const scan_buffer = stdx.bytes_as_slice(
@@ -1879,7 +1941,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                 );
 
                 const scan_lookup = self.scan_lookup.get(.accounts);
-                scan_lookup.* = AccountsScanLookup.init(
+                scan_lookup.* = ScanLookup.Accounts.init(
                     &self.forest.grooves.accounts,
                     scan,
                 );
@@ -1907,7 +1969,7 @@ pub fn StateMachineType(comptime Storage: type) type {
         }
 
         fn prefetch_query_accounts_scan_callback(
-            scan_lookup: *AccountsScanLookup,
+            scan_lookup: *ScanLookup.Accounts,
             results: []const Account,
         ) void {
             const self: *StateMachine = ScanLookup.parent(.accounts, scan_lookup);
@@ -1921,8 +1983,8 @@ pub fn StateMachineType(comptime Storage: type) type {
             self.scan_lookup_results.appendAssumeCapacity(@intCast(results.len));
 
             self.scan_lookup = .null;
+            self.scan_builder = .null;
             self.forest.scan_buffer_pool.reset();
-            self.forest.grooves.accounts.scan_builder.reset();
 
             return self.prefetch_scan_resume();
         }
@@ -1952,11 +2014,7 @@ pub fn StateMachineType(comptime Storage: type) type {
             });
 
             assert(self.forest.scan_buffer_pool.scan_buffer_used == 0);
-            if (self.get_scan_from_query_filter(
-                TransfersGroove,
-                &self.forest.grooves.transfers,
-                filter,
-            )) |scan| {
+            if (self.get_scan_from_query_filter(.transfers, filter)) |scan| {
                 assert(self.forest.scan_buffer_pool.scan_buffer_used > 0);
 
                 const scan_buffer = stdx.bytes_as_slice(
@@ -1966,7 +2024,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                 );
 
                 const scan_lookup = self.scan_lookup.get(.transfers);
-                scan_lookup.* = TransfersScanLookup.init(
+                scan_lookup.* = ScanLookup.Transfers.init(
                     &self.forest.grooves.transfers,
                     scan,
                 );
@@ -1994,7 +2052,7 @@ pub fn StateMachineType(comptime Storage: type) type {
         }
 
         fn prefetch_query_transfers_scan_callback(
-            scan_lookup: *TransfersScanLookup,
+            scan_lookup: *ScanLookup.Transfers,
             results: []const Transfer,
         ) void {
             const self: *StateMachine = ScanLookup.parent(.transfers, scan_lookup);
@@ -2008,8 +2066,8 @@ pub fn StateMachineType(comptime Storage: type) type {
             self.scan_lookup_results.appendAssumeCapacity(@intCast(results.len));
 
             self.scan_lookup = .null;
+            self.scan_builder = .null;
             self.forest.scan_buffer_pool.reset();
-            self.forest.grooves.transfers.scan_builder.reset();
 
             return self.prefetch_scan_resume();
         }
@@ -2053,10 +2111,10 @@ pub fn StateMachineType(comptime Storage: type) type {
 
         fn get_scan_from_query_filter(
             self: *StateMachine,
-            comptime Groove: type,
-            groove: *Groove,
+            comptime target: std.meta.Tag(ScanBuilders),
             filter: *const QueryFilter,
-        ) ?*Groove.ScanBuilder.Scan {
+        ) ?*ScanBuilders.FieldType(target).Scan {
+            comptime assert(target == .accounts or target == .transfers);
             assert(self.forest.scan_buffer_pool.scan_buffer_used == 0);
 
             const filter_valid =
@@ -2090,16 +2148,19 @@ pub fn StateMachineType(comptime Storage: type) type {
                 .ledger,
                 .code,
             };
-            comptime assert(indexes.len <= constants.lsm_scans_max);
+            comptime assert(indexes.len < constants.lsm_scans_max);
 
-            var scan_conditions: stdx.BoundedArrayType(*Groove.ScanBuilder.Scan, indexes.len) = .{};
+            const ScanBuilder = ScanBuilders.FieldType(target);
+            const scan_builder: *ScanBuilder = self.scan_builder.get(target);
+            var scan_conditions: stdx.BoundedArrayType(*ScanBuilder.Scan, indexes.len + 1) = .{};
             inline for (indexes) |index| {
-                if (@field(filter, @tagName(index)) != 0) {
-                    scan_conditions.push(groove.scan_builder.scan_prefix(
-                        std.enums.nameCast(std.meta.FieldEnum(Groove.IndexTrees), index),
+                const filter_value = @field(filter, @tagName(index));
+                if (filter_value != 0) {
+                    scan_conditions.push(scan_builder.scan_prefix(
+                        std.enums.nameCast(std.meta.FieldEnum(ScanBuilder.Scan.Indexes), index),
                         self.forest.scan_buffer_pool.acquire_assume_capacity(),
                         self.prefetch_snapshot.?,
-                        @field(filter, @tagName(index)),
+                        filter_value,
                         timestamp_range,
                         direction,
                     ));
@@ -2111,14 +2172,14 @@ pub fn StateMachineType(comptime Storage: type) type {
                 // TODO(batiati): Querying only by timestamp uses the Object groove,
                 // we could skip the lookup step entirely then.
                 // It will be implemented as part of the query executor.
-                groove.scan_builder.scan_timestamp(
+                scan_builder.scan_timestamp(
                     self.forest.scan_buffer_pool.acquire_assume_capacity(),
                     self.prefetch_snapshot.?,
                     timestamp_range,
                     direction,
                 ),
                 1 => scan_conditions.get(0),
-                else => groove.scan_builder.merge_intersection(scan_conditions.const_slice()),
+                else => scan_builder.merge_intersection(scan_conditions.const_slice()),
             };
         }
 
@@ -2127,9 +2188,9 @@ pub fn StateMachineType(comptime Storage: type) type {
             assert(self.prefetch_input != null);
             assert(self.prefetch_operation != null);
             assert(self.scan_lookup == .null);
+            assert(self.forest.scan_buffer_pool.scan_buffer_used == 0);
             maybe(self.scan_lookup_buffer_index > 0);
             maybe(self.scan_lookup_results.items.len > 0);
-            assert(self.forest.scan_buffer_pool.scan_buffer_used == 0);
 
             self.forest.grid.on_next_tick(
                 &prefetch_scan_invalid_filter_callback,
@@ -2288,21 +2349,24 @@ pub fn StateMachineType(comptime Storage: type) type {
         }
 
         fn prefetch_get_change_events_scan_callback(
-            scan_lookup: *ChangeEventsScanLookup,
+            scan_lookup: *ScanLookup.ChangeEvents,
             results: []const AccountEvent,
         ) void {
             const self: *StateMachine = ScanLookup.parent(.change_events, scan_lookup);
             assert(self.prefetch_input != null);
             assert(self.prefetch_operation.? == .get_change_events);
             assert(self.scan_lookup_buffer_index < self.scan_lookup_buffer.len);
+
+            // Operations not encoded as multi-batch
+            // must have only a single filter.
             assert(self.scan_lookup_results.items.len == 0);
 
             self.scan_lookup_buffer_index += @intCast(results.len * @sizeOf(AccountEvent));
             self.scan_lookup_results.appendAssumeCapacity(@intCast(results.len));
 
-            self.forest.scan_buffer_pool.reset();
-            self.forest.grooves.account_events.scan_builder.reset();
             self.scan_lookup = .null;
+            self.scan_builder = .null;
+            self.forest.scan_buffer_pool.reset();
 
             if (results.len == 0) return self.prefetch_finish();
 
@@ -2396,7 +2460,7 @@ pub fn StateMachineType(comptime Storage: type) type {
         fn get_scan_from_change_events_filter(
             self: *StateMachine,
             filter: *const ChangeEventsFilter,
-        ) ?*ChangeEventsScanLookup {
+        ) ?*ScanLookup.ChangeEvents {
             assert(self.forest.scan_buffer_pool.scan_buffer_used == 0);
 
             const filter_valid =
@@ -2422,7 +2486,7 @@ pub fn StateMachineType(comptime Storage: type) type {
             };
             assert(timestamp_range.min <= timestamp_range.max);
 
-            const scan_lookup: *ChangeEventsScanLookup = self.scan_lookup.get(.change_events);
+            const scan_lookup: *ScanLookup.ChangeEvents = self.scan_lookup.get(.change_events);
             scan_lookup.init(
                 &self.forest.grooves.account_events.objects,
                 self.forest.scan_buffer_pool.acquire_assume_capacity(),
@@ -2465,7 +2529,7 @@ pub fn StateMachineType(comptime Storage: type) type {
             );
 
             const scan_lookup = self.scan_lookup.get(.expire_pending_transfers);
-            scan_lookup.* = ExpirePendingTransfers.ScanLookup.init(
+            scan_lookup.* = ScanLookup.ExpirePendingTransfers.init(
                 transfers_groove,
                 scan,
             );
@@ -2476,7 +2540,7 @@ pub fn StateMachineType(comptime Storage: type) type {
         }
 
         fn prefetch_expire_pending_transfers_scan_callback(
-            scan_lookup: *ExpirePendingTransfers.ScanLookup,
+            scan_lookup: *ScanLookup.ExpirePendingTransfers,
             results: []const Transfer,
         ) void {
             const self: *StateMachine = ScanLookup.parent(.expire_pending_transfers, scan_lookup);
@@ -2490,8 +2554,8 @@ pub fn StateMachineType(comptime Storage: type) type {
             self.scan_lookup_results.appendAssumeCapacity(@intCast(results.len));
 
             self.scan_lookup = .null;
+            self.scan_builder = .null;
             self.forest.scan_buffer_pool.reset();
-            self.forest.grooves.transfers.scan_builder.reset();
 
             self.prefetch_expire_pending_transfers_accounts();
         }
@@ -4889,7 +4953,7 @@ fn ExpirePendingTransfersType(
         // TODO(zig) Context should be `*ExpirePendingTransfers`,
         // but its a dependency loop.
         const Context = struct {};
-        const ScanRange = ScanRangeType(
+        const Scan = ScanRangeType(
             Tree,
             Storage,
             *Context,
@@ -4897,17 +4961,11 @@ fn ExpirePendingTransfersType(
             timestamp_from_value,
         );
 
-        pub const ScanLookup = ScanLookupType(
-            TransfersGroove,
-            ScanRange,
-            Storage,
-        );
-
         context: Context = undefined,
         phase: union(enum) {
             idle,
             running: struct {
-                scan: ScanRange,
+                scan: Scan,
                 expires_at_max: u64,
             },
         } = .idle,
@@ -4934,7 +4992,7 @@ fn ExpirePendingTransfersType(
                 /// Will fetch transfers expired before this timestamp (inclusive).
                 expires_at_max: u64,
             },
-        ) *ScanRange {
+        ) *Scan {
             assert(self.phase == .idle);
             assert(TimestampRange.valid(filter.expires_at_max));
             maybe(filter.expires_at_max != TimestampRange.timestamp_min and

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -4201,7 +4201,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                 .expired => {
                     assert(p.timeout > 0);
                     assert(!p.flags.imported);
-                    assert(timestamp_event >= p.timestamp + p.timeout_ns());
+                    assert(p.timestamp + p.timeout_ns() <= timestamp_event);
                     return .pending_transfer_expired;
                 },
             }

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -245,8 +245,7 @@ pub fn StateMachineType(comptime Storage: type) type {
         scan_lookup_results: std.ArrayListUnmanaged(u32),
         scan_lookup_next_tick: Grid.NextTick = undefined,
 
-        // TODO: Split the scan from the running state.
-        expire_pending_transfers: ScanBuilders.ExpirePendingTransfers = .{},
+        pulse: Pulse = .{},
 
         open_callback: ?*const fn (*StateMachine) void = null,
         compact_callback: ?*const fn (*StateMachine) void = null,
@@ -260,6 +259,17 @@ pub fn StateMachineType(comptime Storage: type) type {
 
         const StateMachine = @This();
         const Grid = GridType(Storage);
+
+        const Pulse = struct {
+            /// Different kinds of work can be triggered by the pulse operation.
+            action: enum {
+                idle,
+                no_op,
+                expire_pending_transfers,
+            } = .idle,
+
+            expire_pending_transfers: ExpirePendingTransfersWorkerType(StateMachine) = .{},
+        };
 
         /// Re-exports the `Contract` declarations, so it can be interchangeable
         /// with a concrete state machine type.
@@ -647,6 +657,7 @@ pub fn StateMachineType(comptime Storage: type) type {
             null,
             accounts: ScanBuilders.Accounts,
             transfers: ScanBuilders.Transfers,
+            expire_pending_transfers: ScanBuilders.ExpirePendingTransfers,
 
             const Tag = std.meta.Tag(@This());
 
@@ -663,7 +674,10 @@ pub fn StateMachineType(comptime Storage: type) type {
             });
 
             // Used by `expire_pending_transfers`.
-            const ExpirePendingTransfers = ExpirePendingTransfersType(TransfersGroove, Storage);
+            const ExpirePendingTransfers = ExpirePendingTransfersScanBuilderType(
+                Storage,
+                Forest,
+            );
 
             pub fn FieldType(comptime field: Tag) type {
                 return @FieldType(ScanBuilders, @tagName(field));
@@ -716,12 +730,11 @@ pub fn StateMachineType(comptime Storage: type) type {
             /// Used by `get_account_balances`.
             const AccountBalances = ScanLookupType(
                 AccountEventsGroove,
-                // Both Objects use the same timestamp, so we can use the TransfersGroove's indexes.
                 ScanBuilders.Transfers.Scan,
                 Storage,
             );
 
-            /// Used by `get_change_events`.
+            /// Custom lookup used by `get_change_events`.
             const ChangeEvents = ChangeEventsScanLookupType(AccountEventsGroove, Storage);
 
             /// Used by `expire_pending_transfers`.
@@ -1198,10 +1211,8 @@ pub fn StateMachineType(comptime Storage: type) type {
 
         pub fn pulse_needed(self: *const StateMachine, timestamp: u64) bool {
             assert(!self.aof_recovery);
-            assert(self.expire_pending_transfers.pulse_next_timestamp >=
-                TimestampRange.timestamp_min);
-
-            return self.expire_pending_transfers.pulse_next_timestamp <= timestamp;
+            assert(self.pulse.action == .idle);
+            return self.pulse.expire_pending_transfers.pulse_needed(timestamp);
         }
 
         pub fn prefetch(
@@ -1257,7 +1268,7 @@ pub fn StateMachineType(comptime Storage: type) type {
             self.metrics.timer.reset();
 
             switch (operation) {
-                .pulse => self.prefetch_expire_pending_transfers(),
+                .pulse => self.prefetch_pulse(),
                 .create_accounts => self.prefetch_create_accounts(),
                 .create_transfers => self.prefetch_create_transfers(),
                 .lookup_accounts => self.prefetch_lookup_accounts(),
@@ -2497,131 +2508,41 @@ pub fn StateMachineType(comptime Storage: type) type {
             return scan_lookup;
         }
 
-        fn prefetch_expire_pending_transfers(self: *StateMachine) void {
+        fn prefetch_pulse(self: *StateMachine) void {
             assert(self.prefetch_input != null);
             assert(self.prefetch_operation.? == .pulse);
+            assert(self.pulse.action == .idle);
+            defer assert(self.pulse.action != .idle);
+
             assert(self.scan_lookup_buffer_index == 0);
             assert(self.scan_lookup_results.items.len == 0);
             assert(self.forest.scan_buffer_pool.scan_buffer_used == 0);
             assert(TimestampRange.valid(self.prefetch_timestamp));
 
-            // We must be constrained to the same limit as `create_transfers`.
-            const scan_buffer_size = @max(
-                Operation.create_transfers.event_max(self.batch_size_limit),
-                Operation.deprecated_create_transfers_sparse.event_max(self.batch_size_limit),
-                Operation.deprecated_create_transfers_unbatched.event_max(self.batch_size_limit),
-            ) * @sizeOf(Transfer);
-
-            const scan_lookup_buffer = stdx.bytes_as_slice(
-                .inexact,
-                Transfer,
-                self.scan_lookup_buffer[0..scan_buffer_size],
-            );
-
-            const transfers_groove: *TransfersGroove = &self.forest.grooves.transfers;
-            const scan = self.expire_pending_transfers.scan(
-                &transfers_groove.indexes.expires_at,
-                self.forest.scan_buffer_pool.acquire_assume_capacity(),
-                .{
-                    .snapshot = transfers_groove.prefetch_snapshot.?,
-                    .expires_at_max = self.prefetch_timestamp,
-                },
-            );
-
-            const scan_lookup = self.scan_lookup.get(.expire_pending_transfers);
-            scan_lookup.* = ScanLookup.ExpirePendingTransfers.init(
-                transfers_groove,
-                scan,
-            );
-            scan_lookup.read(
-                scan_lookup_buffer,
-                &prefetch_expire_pending_transfers_scan_callback,
-            );
-        }
-
-        fn prefetch_expire_pending_transfers_scan_callback(
-            scan_lookup: *ScanLookup.ExpirePendingTransfers,
-            results: []const Transfer,
-        ) void {
-            const self: *StateMachine = ScanLookup.parent(.expire_pending_transfers, scan_lookup);
-            assert(self.prefetch_input != null);
-            assert(self.prefetch_operation.? == .pulse);
-            assert(self.scan_lookup_buffer_index < self.scan_lookup_buffer.len);
-            assert(self.scan_lookup_results.items.len == 0);
-
-            self.expire_pending_transfers.finish(scan_lookup.state, results);
-            self.scan_lookup_buffer_index = @intCast(results.len * @sizeOf(Transfer));
-            self.scan_lookup_results.appendAssumeCapacity(@intCast(results.len));
-
-            self.scan_lookup = .null;
-            self.scan_builder = .null;
-            self.forest.scan_buffer_pool.reset();
-
-            self.prefetch_expire_pending_transfers_accounts();
-        }
-
-        fn prefetch_expire_pending_transfers_accounts(self: *StateMachine) void {
-            assert(self.prefetch_input != null);
-            assert(self.prefetch_operation.? == .pulse);
-            assert(self.scan_lookup_results.items.len == 1);
-            maybe(self.scan_lookup_buffer_index == 0);
-
-            const result_count: u32 = self.scan_lookup_results.items[0];
-            if (result_count == 0) return self.prefetch_finish();
-
-            const result_max: u32 = @max(
-                Operation.create_transfers.event_max(self.batch_size_limit),
-                Operation.deprecated_create_transfers_sparse.event_max(self.batch_size_limit),
-                Operation.deprecated_create_transfers_unbatched.event_max(self.batch_size_limit),
-            );
-            assert(result_count <= result_max);
-            assert(self.scan_lookup_buffer_index == result_count * @sizeOf(Transfer));
-            const transfers = stdx.bytes_as_slice(
-                .exact,
-                Transfer,
-                self.scan_lookup_buffer[0..self.scan_lookup_buffer_index],
-            );
-
-            const grooves = &self.forest.grooves;
-            for (transfers) |expired| {
-                assert(expired.flags.pending == true);
-                const expires_at = expired.timestamp + expired.timeout_ns();
-
-                assert(expires_at <= self.prefetch_timestamp);
-
-                grooves.accounts.prefetch_enqueue(.{ .id = expired.debit_account_id });
-                grooves.accounts.prefetch_enqueue(.{ .id = expired.credit_account_id });
-                grooves.transfers_pending.prefetch_enqueue(.{ .timestamp = expired.timestamp });
+            if (self.pulse.expire_pending_transfers.pulse_needed(self.prefetch_timestamp)) {
+                self.pulse.action = .expire_pending_transfers;
+                self.pulse.expire_pending_transfers.prefetch();
+                return;
             }
 
-            self.forest.grooves.accounts.prefetch(
-                prefetch_expire_pending_transfers_callback_accounts,
-                self.prefetch_context.get(.accounts),
+            // No pulse is required.
+            // The primary decides whether to pulse based on its own known (or unknown)
+            // state, but different replicas may have different states.
+            // The state machine fuzzer stresses this path.
+            self.pulse.action = .no_op;
+            self.forest.grid.on_next_tick(
+                &prefetch_pulse_nop_callback,
+                &self.scan_lookup_next_tick,
             );
         }
 
-        fn prefetch_expire_pending_transfers_callback_accounts(
-            completion: *AccountsGroove.PrefetchContext,
-        ) void {
-            const self: *StateMachine = PrefetchContext.parent(.accounts, completion);
-            assert(self.prefetch_input != null);
-            assert(self.prefetch_operation.? == .pulse);
-            self.prefetch_context = .null;
+        fn prefetch_pulse_nop_callback(completion: *Grid.NextTick) void {
+            const self: *StateMachine = @alignCast(@fieldParentPtr(
+                "scan_lookup_next_tick",
+                completion,
+            ));
 
-            self.forest.grooves.transfers_pending.prefetch(
-                prefetch_expire_pending_transfers_callback_transfers_pending,
-                self.prefetch_context.get(.transfers_pending),
-            );
-        }
-
-        fn prefetch_expire_pending_transfers_callback_transfers_pending(
-            completion: *TransfersPendingGroove.PrefetchContext,
-        ) void {
-            const self: *StateMachine = PrefetchContext.parent(.transfers_pending, completion);
-            assert(self.prefetch_input != null);
-            assert(self.prefetch_operation.? == .pulse);
-
-            self.prefetch_context = .null;
+            assert(self.pulse.action == .no_op);
             self.prefetch_finish();
         }
 
@@ -2649,7 +2570,7 @@ pub fn StateMachineType(comptime Storage: type) type {
             }
 
             const result: usize = switch (operation) {
-                .pulse => self.execute_expire_pending_transfers(timestamp),
+                .pulse => self.execute_pulse(timestamp),
                 inline .create_accounts,
                 .create_transfers,
                 .lookup_accounts,
@@ -4040,8 +3961,8 @@ pub fn StateMachineType(comptime Storage: type) type {
                 assert(t.flags.pending);
                 assert(!t.flags.imported);
                 const expires_at = timestamp_actual + t.timeout_ns();
-                if (expires_at < self.expire_pending_transfers.pulse_next_timestamp) {
-                    self.expire_pending_transfers.pulse_next_timestamp = expires_at;
+                if (expires_at < self.pulse.expire_pending_transfers.timestamp_next) {
+                    self.pulse.expire_pending_transfers.timestamp_next = expires_at;
                 }
             }
 
@@ -4288,8 +4209,8 @@ pub fn StateMachineType(comptime Storage: type) type {
 
                 // In case the pending transfer's timeout is exactly the one we are using
                 // as flag, we need to zero the value to run the next `pulse`.
-                if (self.expire_pending_transfers.pulse_next_timestamp == timestamp_expiry) {
-                    self.expire_pending_transfers.pulse_next_timestamp =
+                if (self.pulse.expire_pending_transfers.timestamp_next == timestamp_expiry) {
+                    self.pulse.expire_pending_transfers.timestamp_next =
                         TimestampRange.timestamp_min;
                 }
             }
@@ -4572,119 +4493,16 @@ pub fn StateMachineType(comptime Storage: type) type {
             });
         }
 
-        fn execute_expire_pending_transfers(self: *StateMachine, timestamp: u64) usize {
-            assert(self.scan_lookup_results.items.len == 1); // No multi-batch.
+        fn execute_pulse(self: *StateMachine, timestamp: u64) usize {
             assert(timestamp > self.commit_timestamp or self.aof_recovery);
+            defer self.pulse.action = .idle;
 
-            defer {
-                self.scan_lookup_buffer_index = 0;
-                self.scan_lookup_results.clearRetainingCapacity();
-            }
-
-            const result_count: u32 = self.scan_lookup_results.items[0];
-            if (result_count == 0) return 0;
-
-            const result_max: u32 = @max(
-                Operation.create_transfers.event_max(self.batch_size_limit),
-                Operation.deprecated_create_transfers_sparse.event_max(self.batch_size_limit),
-                Operation.deprecated_create_transfers_unbatched.event_max(self.batch_size_limit),
-            );
-            assert(result_count <= result_max);
-
-            assert(self.scan_lookup_buffer_index > 0);
-            assert(self.scan_lookup_buffer_index == result_count * @sizeOf(Transfer));
-
-            const transfers_pending = stdx.bytes_as_slice(
-                .exact,
-                Transfer,
-                self.scan_lookup_buffer[0..self.scan_lookup_buffer_index],
-            );
-
-            log.debug("expire_pending_transfers: len={}", .{transfers_pending.len});
-
-            for (transfers_pending, 0..) |*p, index| {
-                assert(p.flags.pending);
-                assert(p.timeout > 0);
-
-                const timestamp_event = timestamp - transfers_pending.len + index + 1;
-                assert(TimestampRange.valid(timestamp_event));
-                assert(self.commit_timestamp < timestamp_event);
-                defer self.commit_timestamp = timestamp_event;
-
-                const expires_at = p.timestamp + p.timeout_ns();
-                assert(expires_at <= timestamp_event);
-
-                const dr_account = self.get_account(
-                    p.debit_account_id,
-                ).?;
-                assert(dr_account.debits_pending >= p.amount);
-
-                const cr_account = self.get_account(
-                    p.credit_account_id,
-                ).?;
-                assert(cr_account.credits_pending >= p.amount);
-
-                var dr_account_new = dr_account;
-                var cr_account_new = cr_account;
-                dr_account_new.debits_pending -= p.amount;
-                cr_account_new.credits_pending -= p.amount;
-
-                if (p.flags.closing_debit) {
-                    assert(dr_account_new.flags.closed);
-                    dr_account_new.flags.closed = false;
-                }
-                if (p.flags.closing_credit) {
-                    assert(cr_account_new.flags.closed);
-                    cr_account_new.flags.closed = false;
-                }
-
-                // Pending transfers can expire in closed accounts.
-                maybe(dr_account_new.flags.closed);
-                maybe(cr_account_new.flags.closed);
-
-                const dr_updated = p.amount > 0 or
-                    dr_account_new.flags.closed != dr_account.flags.closed;
-                if (dr_updated) {
-                    self.forest.grooves.accounts.update(.{
-                        .old = &dr_account,
-                        .new = &dr_account_new,
-                    });
-                }
-
-                const cr_updated = p.amount > 0 or
-                    cr_account_new.flags.closed != cr_account.flags.closed;
-                if (cr_updated) {
-                    self.forest.grooves.accounts.update(.{
-                        .old = &cr_account,
-                        .new = &cr_account_new,
-                    });
-                }
-
-                const transfer_pending: TransferPending = self.get_transfer_pending(p.timestamp).?;
-                assert(transfer_pending.timestamp == p.timestamp);
-                assert(transfer_pending.status == .pending);
-                self.transfer_update_pending_status(&transfer_pending, .expired);
-
-                // Removing the `expires_at` index.
-                // Invariant: Unique keys cannot be removed.
-                const IndexHelper = TransfersGroove.IndexHelperType("expires_at");
-                comptime assert(!IndexHelper.is_unique_key);
-                comptime assert(IndexHelper.is_derived);
-                self.forest.grooves.transfers.indexes.expires_at.remove(&.{
-                    .timestamp = p.timestamp,
-                    .field = expires_at,
-                });
-
-                self.account_event(.{
-                    .timestamp_event = timestamp_event,
-                    .dr_account = &dr_account_new,
-                    .cr_account = &cr_account_new,
-                    .transfer_flags = null,
-                    .transfer_pending_status = .expired,
-                    .transfer_pending = p,
-                    .amount_requested = 0,
-                    .amount = p.amount,
-                });
+            switch (self.pulse.action) {
+                .idle => unreachable,
+                .no_op => {},
+                .expire_pending_transfers => self.pulse.expire_pending_transfers.execute(
+                    timestamp,
+                ),
             }
 
             // This operation has no output.
@@ -4936,9 +4754,9 @@ pub fn StateMachineType(comptime Storage: type) type {
 /// UNION
 /// WHERE expires_at > prefetch_timestamp LIMIT 1
 /// ```
-fn ExpirePendingTransfersType(
-    comptime TransfersGroove: type,
+fn ExpirePendingTransfersScanBuilderType(
     comptime Storage: type,
+    comptime Forest: type,
 ) type {
     return struct {
         const ExpirePendingTransfers = @This();
@@ -4946,6 +4764,7 @@ fn ExpirePendingTransfersType(
         const EvaluateNext = @import("lsm/scan_range.zig").EvaluateNext;
         const ScanLookupStatus = @import("lsm/scan_lookup.zig").ScanLookupStatus;
 
+        const TransfersGroove = @FieldType(Forest.Grooves, "transfers");
         const Tree = @FieldType(TransfersGroove.IndexTrees, "expires_at");
         const Value = Tree.Table.Value;
         const ScanBuffer = ScanBufferType(GridType(Storage));
@@ -4961,6 +4780,7 @@ fn ExpirePendingTransfersType(
             timestamp_from_value,
         );
 
+        forest: *Forest,
         context: Context = undefined,
         phase: union(enum) {
             idle,
@@ -4968,24 +4788,19 @@ fn ExpirePendingTransfersType(
                 scan: Scan,
                 expires_at_max: u64,
             },
-        } = .idle,
+        },
+        value_next_expired_at: ?u64,
 
-        /// Used by the state machine to determine "when" it needs to execute the expiration logic:
-        /// - When `== timestamp_min`, there may be pending transfers to expire,
-        ///   but we need to scan to check.
-        /// - When `== timestamp_max`, there are no pending transfers to expire.
-        /// - Otherwise, this is the timestamp of the next pending transfer expiry.
-        pulse_next_timestamp: u64 = TimestampRange.timestamp_min,
-        value_next_expired_at: ?u64 = null,
-
-        fn reset(self: *ExpirePendingTransfers) void {
-            assert(self.phase == .idle);
-            self.* = .{};
+        fn init(forest: *Forest) ExpirePendingTransfers {
+            return .{
+                .forest = forest,
+                .phase = .idle,
+                .value_next_expired_at = null,
+            };
         }
 
         fn scan(
             self: *ExpirePendingTransfers,
-            tree: *Tree,
             buffer: *ScanBuffer,
             filter: struct {
                 snapshot: u64,
@@ -4995,20 +4810,15 @@ fn ExpirePendingTransfersType(
         ) *Scan {
             assert(self.phase == .idle);
             assert(TimestampRange.valid(filter.expires_at_max));
-            maybe(filter.expires_at_max != TimestampRange.timestamp_min and
-                filter.expires_at_max != TimestampRange.timestamp_max and
-                self.pulse_next_timestamp > filter.expires_at_max);
 
-            self.* = .{
-                .pulse_next_timestamp = self.pulse_next_timestamp,
-                .phase = .{ .running = .{
-                    .expires_at_max = filter.expires_at_max,
-                    .scan = undefined,
-                } },
-            };
+            self.phase = .{ .running = .{
+                .expires_at_max = filter.expires_at_max,
+                .scan = undefined,
+            } };
+
             self.phase.running.scan.init(
                 &self.context,
-                tree,
+                &self.forest.grooves.transfers.indexes.expires_at,
                 buffer,
                 filter.snapshot,
                 Tree.Table.key_from_value(&.{
@@ -5024,17 +4834,17 @@ fn ExpirePendingTransfersType(
             return &self.phase.running.scan;
         }
 
-        fn finish(
+        /// Returns the timestamp of the next pending transfer to expire after the
+        /// last result produced.
+        /// Returns `timestamp_max` if there are no more pending transfers to expire.
+        fn expires_at_timestamp_next(
             self: *ExpirePendingTransfers,
             status: ScanLookupStatus,
-            results: []const Transfer,
-        ) void {
+        ) u64 {
             assert(self.phase == .running);
-            if (self.phase.running.expires_at_max != TimestampRange.timestamp_min and
-                self.phase.running.expires_at_max != TimestampRange.timestamp_max and
-                self.pulse_next_timestamp > self.phase.running.expires_at_max)
-            {
-                assert(results.len == 0);
+            defer {
+                self.phase = .idle;
+                self.value_next_expired_at = null;
             }
 
             switch (status) {
@@ -5043,20 +4853,18 @@ fn ExpirePendingTransfersType(
                         self.value_next_expired_at.? <= self.phase.running.expires_at_max)
                     {
                         // There are no more unexpired transfers left to expire in the next pulse.
-                        self.pulse_next_timestamp = TimestampRange.timestamp_max;
+                        return TimestampRange.timestamp_max;
                     } else {
-                        self.pulse_next_timestamp = self.value_next_expired_at.?;
+                        return self.value_next_expired_at.?;
                     }
                 },
                 .buffer_finished => {
                     // There are more transfers to expire than a single batch.
                     assert(self.value_next_expired_at != null);
-                    self.pulse_next_timestamp = self.value_next_expired_at.?;
+                    return self.value_next_expired_at.?;
                 },
                 else => unreachable,
             }
-            self.phase = .idle;
-            self.value_next_expired_at = null;
         }
 
         inline fn value_next(context: *Context, value: *const Value) EvaluateNext {
@@ -5195,6 +5003,334 @@ fn ChangeEventsScanLookupType(
             const results = self.state.scan.buffer[0..self.state.scan.buffer_produced_len];
             self.state = .finished;
             callback(self, results);
+        }
+    };
+}
+
+/// Expires pending transfers during the pulse operation.
+fn ExpirePendingTransfersWorkerType(comptime StateMachine: type) type {
+    return struct {
+        /// Determine "when" it needs to execute the expiration logic:
+        /// - When `== timestamp_min`, there may be pending transfers to expire,
+        ///   but we need to scan to check.
+        /// - When `== timestamp_max`, there are no pending transfers to expire.
+        /// - Otherwise, this is the timestamp of the next pending transfer expiry.
+        timestamp_next: u64 = TimestampRange.timestamp_min,
+
+        const ExpirePendingTransfersWorker = @This();
+        const Operation = StateMachine.Operation;
+        const ScanLookup = StateMachine.ScanLookup;
+        const ScanBuilders = StateMachine.ScanBuilders;
+        const PrefetchContext = StateMachine.PrefetchContext;
+
+        pub fn pulse_needed(worker: *const ExpirePendingTransfersWorker, timestamp: u64) bool {
+            assert(worker.timestamp_next >= TimestampRange.timestamp_min);
+            return worker.timestamp_next <= timestamp;
+        }
+
+        pub fn prefetch(worker: *ExpirePendingTransfersWorker) void {
+            const state_machine: *StateMachine = worker.parent();
+            assert(state_machine.prefetch_input != null);
+            assert(state_machine.prefetch_operation.? == .pulse);
+            assert(state_machine.scan_lookup_buffer_index == 0);
+            assert(state_machine.scan_lookup_results.items.len == 0);
+            assert(state_machine.forest.scan_buffer_pool.scan_buffer_used == 0);
+            assert(TimestampRange.valid(state_machine.prefetch_timestamp));
+
+            // We must be constrained to the same limit as `create_transfers`.
+            const scan_buffer_size = @max(
+                Operation.create_transfers.event_max(state_machine.batch_size_limit),
+                Operation.deprecated_create_transfers_sparse.event_max(
+                    state_machine.batch_size_limit,
+                ),
+                Operation.deprecated_create_transfers_unbatched.event_max(
+                    state_machine.batch_size_limit,
+                ),
+            ) * @sizeOf(Transfer);
+
+            const scan_lookup_buffer: []Transfer = stdx.bytes_as_slice(
+                .inexact,
+                Transfer,
+                state_machine.scan_lookup_buffer[0..scan_buffer_size],
+            );
+
+            assert(worker.timestamp_next <= state_machine.prefetch_timestamp);
+            maybe(worker.timestamp_next == TimestampRange.timestamp_min);
+            const scan_builder = state_machine.scan_builder.get(.expire_pending_transfers);
+            const scan = scan_builder.scan(
+                state_machine.forest.scan_buffer_pool.acquire_assume_capacity(),
+                .{
+                    .snapshot = state_machine.forest.grooves.transfers.prefetch_snapshot.?,
+                    .expires_at_max = state_machine.prefetch_timestamp,
+                },
+            );
+
+            const scan_lookup = state_machine.scan_lookup.get(.expire_pending_transfers);
+            scan_lookup.* = ScanLookup.ExpirePendingTransfers.init(
+                &state_machine.forest.grooves.transfers,
+                scan,
+            );
+            scan_lookup.read(
+                scan_lookup_buffer,
+                &prefetch_scan_callback,
+            );
+        }
+
+        fn prefetch_scan_callback(
+            scan_lookup: *ScanLookup.ExpirePendingTransfers,
+            results: []const Transfer,
+        ) void {
+            const state_machine: *StateMachine = ScanLookup.parent(
+                .expire_pending_transfers,
+                scan_lookup,
+            );
+            assert(state_machine.prefetch_input != null);
+            assert(state_machine.prefetch_operation.? == .pulse);
+            assert(state_machine.scan_lookup_buffer_index < state_machine.scan_lookup_buffer.len);
+            assert(state_machine.scan_lookup_results.items.len == 0);
+
+            assert(state_machine.pulse.action == .expire_pending_transfers);
+            const worker: *ExpirePendingTransfersWorker =
+                &state_machine.pulse.expire_pending_transfers;
+            assert(worker.timestamp_next <= state_machine.prefetch_timestamp);
+            maybe(worker.timestamp_next == TimestampRange.timestamp_min);
+
+            state_machine.scan_lookup_buffer_index = @intCast(results.len * @sizeOf(Transfer));
+            state_machine.scan_lookup_results.appendAssumeCapacity(@intCast(results.len));
+
+            // The custom `ScanBuilder` returns the timestamp of the next pending
+            // transfer to expire after the last result produced.
+            // It will be used to trigger the next pulse operation.
+            assert(state_machine.scan_builder == .expire_pending_transfers);
+            const scan_builder = &state_machine.scan_builder.expire_pending_transfers;
+            const expires_at_timestamp_next: u64 = scan_builder.expires_at_timestamp_next(
+                scan_lookup.state,
+            );
+            assert(worker.timestamp_next < expires_at_timestamp_next);
+            maybe(expires_at_timestamp_next == TimestampRange.timestamp_max);
+            worker.timestamp_next = expires_at_timestamp_next;
+
+            state_machine.scan_lookup = .null;
+            state_machine.scan_builder = .null;
+            state_machine.forest.scan_buffer_pool.reset();
+
+            if (results.len == 0) {
+                // It may not return any results if:
+                // - The state is unknown (`timestamp_min`).
+                // - The pending transfer was manually posted or voided.
+                state_machine.prefetch_finish();
+                return;
+            }
+
+            worker.prefetch_accounts();
+        }
+
+        fn prefetch_accounts(worker: *ExpirePendingTransfersWorker) void {
+            const state_machine: *StateMachine = worker.parent();
+            assert(state_machine.prefetch_input != null);
+            assert(state_machine.prefetch_operation.? == .pulse);
+            assert(state_machine.scan_lookup_results.items.len == 1);
+            maybe(state_machine.scan_lookup_buffer_index == 0);
+
+            const result_count: u32 = state_machine.scan_lookup_results.items[0];
+            assert(result_count > 0);
+
+            const result_max: u32 = @max(
+                Operation.create_transfers.event_max(state_machine.batch_size_limit),
+                Operation.deprecated_create_transfers_sparse.event_max(
+                    state_machine.batch_size_limit,
+                ),
+                Operation.deprecated_create_transfers_unbatched.event_max(
+                    state_machine.batch_size_limit,
+                ),
+            );
+            assert(result_count <= result_max);
+            assert(state_machine.scan_lookup_buffer_index == result_count * @sizeOf(Transfer));
+            const transfers: []const Transfer = stdx.bytes_as_slice(
+                .exact,
+                Transfer,
+                state_machine.scan_lookup_buffer[0..state_machine.scan_lookup_buffer_index],
+            );
+
+            const grooves = &state_machine.forest.grooves;
+            for (transfers) |expired| {
+                assert(expired.flags.pending == true);
+                const expires_at = expired.timestamp + expired.timeout_ns();
+
+                assert(expires_at <= state_machine.prefetch_timestamp);
+
+                grooves.accounts.prefetch_enqueue(.{ .id = expired.debit_account_id });
+                grooves.accounts.prefetch_enqueue(.{ .id = expired.credit_account_id });
+                grooves.transfers_pending.prefetch_enqueue(.{ .timestamp = expired.timestamp });
+            }
+
+            state_machine.forest.grooves.accounts.prefetch(
+                &prefetch_accounts_callback,
+                state_machine.prefetch_context.get(.accounts),
+            );
+        }
+
+        fn prefetch_accounts_callback(
+            completion: *StateMachine.AccountsGroove.PrefetchContext,
+        ) void {
+            const state_machine: *StateMachine = PrefetchContext.parent(.accounts, completion);
+            assert(state_machine.prefetch_input != null);
+            assert(state_machine.prefetch_operation.? == .pulse);
+            assert(state_machine.pulse.action == .expire_pending_transfers);
+
+            state_machine.prefetch_context = .null;
+            state_machine.forest.grooves.transfers_pending.prefetch(
+                &prefetch_transfers_pending_callback,
+                state_machine.prefetch_context.get(.transfers_pending),
+            );
+        }
+
+        fn prefetch_transfers_pending_callback(
+            completion: *StateMachine.TransfersPendingGroove.PrefetchContext,
+        ) void {
+            const state_machine: *StateMachine = PrefetchContext.parent(
+                .transfers_pending,
+                completion,
+            );
+            assert(state_machine.prefetch_input != null);
+            assert(state_machine.prefetch_operation.? == .pulse);
+            assert(state_machine.pulse.action == .expire_pending_transfers);
+
+            state_machine.prefetch_context = .null;
+            state_machine.prefetch_finish();
+        }
+
+        pub fn execute(worker: *ExpirePendingTransfersWorker, timestamp: u64) void {
+            const state_machine: *StateMachine = worker.parent();
+            assert(state_machine.pulse.action == .expire_pending_transfers);
+            assert(state_machine.scan_lookup_results.items.len == 1); // No multi-batch.
+            assert(timestamp > state_machine.commit_timestamp or state_machine.aof_recovery);
+
+            defer {
+                state_machine.scan_lookup_buffer_index = 0;
+                state_machine.scan_lookup_results.clearRetainingCapacity();
+            }
+
+            const result_count: u32 = state_machine.scan_lookup_results.items[0];
+            if (result_count == 0) return;
+            assert(result_count > 0);
+
+            const result_max: u32 = @max(
+                Operation.create_transfers.event_max(state_machine.batch_size_limit),
+                Operation.deprecated_create_transfers_sparse.event_max(
+                    state_machine.batch_size_limit,
+                ),
+                Operation.deprecated_create_transfers_unbatched.event_max(
+                    state_machine.batch_size_limit,
+                ),
+            );
+            assert(result_count <= result_max);
+
+            assert(state_machine.scan_lookup_buffer_index > 0);
+            assert(state_machine.scan_lookup_buffer_index == result_count * @sizeOf(Transfer));
+
+            const transfers_pending: []const Transfer = stdx.bytes_as_slice(
+                .exact,
+                Transfer,
+                state_machine.scan_lookup_buffer[0..state_machine.scan_lookup_buffer_index],
+            );
+            log.debug("expire_pending_transfers: len={}", .{transfers_pending.len});
+
+            for (transfers_pending, 0..) |*p, index| {
+                assert(p.flags.pending);
+                assert(p.timeout > 0);
+
+                const timestamp_event = timestamp - transfers_pending.len + index + 1;
+                assert(TimestampRange.valid(timestamp_event));
+                assert(state_machine.commit_timestamp < timestamp_event);
+                defer state_machine.commit_timestamp = timestamp_event;
+
+                const expires_at = p.timestamp + p.timeout_ns();
+                assert(expires_at <= timestamp_event);
+
+                const dr_account = state_machine.get_account(
+                    p.debit_account_id,
+                ).?;
+                assert(dr_account.debits_pending >= p.amount);
+
+                const cr_account = state_machine.get_account(
+                    p.credit_account_id,
+                ).?;
+                assert(cr_account.credits_pending >= p.amount);
+
+                var dr_account_new = dr_account;
+                var cr_account_new = cr_account;
+                dr_account_new.debits_pending -= p.amount;
+                cr_account_new.credits_pending -= p.amount;
+
+                if (p.flags.closing_debit) {
+                    assert(dr_account_new.flags.closed);
+                    dr_account_new.flags.closed = false;
+                }
+                if (p.flags.closing_credit) {
+                    assert(cr_account_new.flags.closed);
+                    cr_account_new.flags.closed = false;
+                }
+
+                // Pending transfers can expire in closed accounts.
+                maybe(dr_account_new.flags.closed);
+                maybe(cr_account_new.flags.closed);
+
+                const dr_updated = p.amount > 0 or
+                    dr_account_new.flags.closed != dr_account.flags.closed;
+                if (dr_updated) {
+                    state_machine.forest.grooves.accounts.update(.{
+                        .old = &dr_account,
+                        .new = &dr_account_new,
+                    });
+                }
+
+                const cr_updated = p.amount > 0 or
+                    cr_account_new.flags.closed != cr_account.flags.closed;
+                if (cr_updated) {
+                    state_machine.forest.grooves.accounts.update(.{
+                        .old = &cr_account,
+                        .new = &cr_account_new,
+                    });
+                }
+
+                const transfer_pending: TransferPending = state_machine.get_transfer_pending(
+                    p.timestamp,
+                ).?;
+                assert(transfer_pending.timestamp == p.timestamp);
+                assert(transfer_pending.status == .pending);
+                state_machine.transfer_update_pending_status(&transfer_pending, .expired);
+
+                // Removing the `expires_at` index.
+                // Invariant: Unique keys cannot be removed.
+                const IndexHelper = StateMachine.TransfersGroove.IndexHelperType("expires_at");
+                comptime assert(!IndexHelper.is_unique_key);
+                comptime assert(IndexHelper.is_derived);
+                state_machine.forest.grooves.transfers.indexes.expires_at.remove(&.{
+                    .timestamp = p.timestamp,
+                    .field = expires_at,
+                });
+
+                state_machine.account_event(.{
+                    .timestamp_event = timestamp_event,
+                    .dr_account = &dr_account_new,
+                    .cr_account = &cr_account_new,
+                    .transfer_flags = null,
+                    .transfer_pending_status = .expired,
+                    .transfer_pending = p,
+                    .amount_requested = 0,
+                    .amount = p.amount,
+                });
+            }
+        }
+
+        inline fn parent(worker: *ExpirePendingTransfersWorker) *StateMachine {
+            const pulse: *StateMachine.Pulse = @alignCast(@fieldParentPtr(
+                "expire_pending_transfers",
+                worker,
+            ));
+            const state_machine: *StateMachine = @alignCast(@fieldParentPtr("pulse", pulse));
+            return state_machine;
         }
     };
 }

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -5106,9 +5106,29 @@ fn ExpirePendingTransfersWorkerType(comptime StateMachine: type) type {
             const expires_at_timestamp_next: u64 = scan_builder.expires_at_timestamp_next(
                 scan_lookup.state,
             );
-            assert(worker.timestamp_next < expires_at_timestamp_next);
-            maybe(expires_at_timestamp_next == TimestampRange.timestamp_max);
-            worker.timestamp_next = expires_at_timestamp_next;
+            assert(worker.timestamp_next <= expires_at_timestamp_next);
+            if (worker.timestamp_next == expires_at_timestamp_next) {
+                // Transfers that expire at the same timestamp may span multiple batches.
+                assert(expires_at_timestamp_next != TimestampRange.timestamp_max);
+                assert(results.len > 0);
+                if (constants.verify) {
+                    for (results) |*transfer| {
+                        const expires_at: u64 = transfer.timestamp + transfer.timeout_ns();
+                        assert(expires_at == expires_at_timestamp_next);
+                    }
+                }
+            } else {
+                maybe(expires_at_timestamp_next == TimestampRange.timestamp_max);
+                maybe(results.len == 0);
+                if (constants.verify) {
+                    for (results) |*transfer| {
+                        const expires_at: u64 = transfer.timestamp + transfer.timeout_ns();
+                        assert(expires_at <= expires_at_timestamp_next);
+                    }
+                }
+
+                worker.timestamp_next = expires_at_timestamp_next;
+            }
 
             state_machine.scan_lookup = .null;
             state_machine.scan_builder = .null;

--- a/src/state_machine_tests.zig
+++ b/src/state_machine_tests.zig
@@ -145,7 +145,7 @@ pub const TestContext = struct {
             },
         );
         errdefer ctx.state_machine.deinit(allocator);
-        // Usually, `pulse_next_timestamp` starts in an unknown state, signaling that the state
+        // Usually, `expire_pending_transfers` starts in an unknown state, signaling that the state
         // machine needs a `pulse` to scan for pending transfers and correctly determine when to
         // process the next expiry. However, this initial `pulse` unnecessarily bumps time, making
         // unit tests that depend on the `timestamp` harder to reason about.
@@ -153,8 +153,8 @@ pub const TestContext = struct {
         // Since this is a newly created state machine, we can bypass the initial check, ensuring
         // that there will be no `timestamp` bumps between operations unless actual pending
         // transfers get expired.
-        ctx.state_machine.expire_pending_transfers
-            .pulse_next_timestamp = TimestampRange.timestamp_max;
+        ctx.state_machine.pulse.expire_pending_transfers.timestamp_next =
+            TimestampRange.timestamp_max;
 
         ctx.op = 1;
         ctx.busy = false;

--- a/src/state_machine_tests.zig
+++ b/src/state_machine_tests.zig
@@ -1524,6 +1524,102 @@ test "create/lookup expired transfers" {
     );
 }
 
+test "expire_pending_transfers: multiple pulses" {
+    try check(
+        \\ account A1  0  0  0  0  _  _  _ _ L1 C1   _   _   _ _ _ _ _ _ created
+        \\ account A2  0  0  0  0  _  _  _ _ L1 C1   _   _   _ _ _ _ _ _ created
+        \\ commit create_accounts
+
+        // One full batch of pending transfers (30 - 1 events in the testing state machine).
+        \\ transfer   T1 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer   T2 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer   T3 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer   T4 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer   T5 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer   T6 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer   T7 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer   T8 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer   T9 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T10 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T11 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T12 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T13 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T14 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T15 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T16 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T17 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T18 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T19 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T20 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T21 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T22 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T23 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T24 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T25 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T26 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T27 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T28 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T29 A1 A2   10   _  _  _  _    3 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ commit create_transfers
+
+        // Another full batch of pending transfers.
+        // Advance time by almost one second so that the transfers in the second
+        // batch have nearly the same `expires_at` timestamp as those in the first batch.
+
+        \\ tick 999999970 nanoseconds
+        \\ transfer  T30 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T31 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T32 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T33 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T34 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T35 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T36 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T37 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T38 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T39 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T40 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T41 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T42 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T43 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T44 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T45 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T46 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T47 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T48 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T49 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T50 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T51 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T52 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T53 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T54 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T55 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T56 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T57 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ transfer  T58 A1 A2   10   _  _  _  _    2 L1 C1   _ PEN   _   _   _   _  _ _ _ _ _ created
+        \\ commit create_transfers
+
+        // After 1 second, all transfers should still be pending, as the
+        // first batch has a 3s timeout and the second batch a 2s timeout.
+        \\ tick 1 seconds
+        \\ lookup_account A1 580  0    0  0  _
+        \\ lookup_account A2   0  0  580  0  _
+        \\ commit lookup_accounts
+
+        // After one more second, all transfers should have expired.
+        // However, each pulse can expire up to 30 transfers in the testing
+        // state machine, so it requires two pulses to expire both batches.
+        \\ tick 1 seconds
+        \\ lookup_account A1  280  0   0  0  _
+        \\ lookup_account A2    0  0 280  0  _
+        \\ commit lookup_accounts
+        \\
+        \\ tick 1 nanoseconds // To force another pulse.
+        \\ lookup_account A1  0  0  0  0  _
+        \\ lookup_account A2  0  0  0  0  _
+        \\ commit lookup_accounts
+    );
+}
+
 test "create_transfers: empty" {
     try check(
         \\ commit create_transfers

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -200,7 +200,7 @@ pub fn StateMachineType(comptime Storage: type) type {
             state_machine.callback = callback;
 
             // TODO(Snapshots) Pass in the target snapshot.
-            state_machine.forest.grooves.things.prefetch_setup(snapshot);
+            state_machine.forest.grooves.things.prefetch_begin(snapshot);
             state_machine.forest.grooves.things.prefetch_enqueue(.{ .id = op });
             state_machine.forest.grooves.things.prefetch(
                 prefetch_callback,
@@ -213,6 +213,7 @@ pub fn StateMachineType(comptime Storage: type) type {
                 @alignCast(@fieldParentPtr("prefetch_context", completion));
             const callback = state_machine.callback.?;
             state_machine.callback = null;
+            state_machine.forest.grooves.things.prefetch_finish();
 
             callback(state_machine);
         }


### PR DESCRIPTION
This PR contains infrastructure changes related to #3747 and #3848:

- `Groove` no longer defines the `ScanBuilder` type.
  Now, `ScanBuilder`s can combine indexes from multiple Grooves and are defined and owned by the caller (e.g., the `StateMachine`).

- Splits `prefetch_setup` into `prefetch_begin` and `prefetch_finish`, allowing multiple prefetch cycles in the same Groove. For example, the state machine needs to first prefetch the pending transfer, then prefetch again from the `Transfers` Groove the voided/posted transfer. 

- Refactors the `expire_pending_transfer` logic, preparing `pulse`  operations to trigger multiple actions.

Better reviewed by commit.