### PR TITLE
Move Bench into stdx

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -170,7 +170,19 @@ pub fn build(b: *std.Build) !void {
         (build_options.config_release_client_min == null));
 
     const target = try resolve_target(b, build_options.target);
+
+    const test_options = b.addOptions();
+    // Benchmark run in two modes.
+    // - ./zig/zig build test
+    // - ./zig/zig build -Drelease test -- "benchmark: name"
+    // The former uses small parameter values and is silent.
+    // The latter is the real benchmark, which prints the output.
+    test_options.addOption(bool, "benchmark", for (b.args orelse &.{}) |arg| {
+        if (std.mem.indexOf(u8, arg, "benchmark") != null) break true;
+    } else false);
+
     const stdx_module = b.addModule("stdx", .{ .root_source_file = b.path("src/stdx/stdx.zig") });
+    stdx_module.addOptions("test_options", test_options);
 
     assert(build_options.git_commit.len == 40);
     const vsr_options, const vsr_module = build_vsr_module(b, .{
@@ -300,6 +312,7 @@ pub fn build(b: *std.Build) !void {
         .vsr_options_test = vsr_options_test,
         .tigerbeetle_test = tigerbeetle_test,
         .vortex_options = vortex_options,
+        .test_options = test_options,
     });
 
     // zig build test:jni
@@ -873,18 +886,9 @@ fn build_test(
         vsr_options_test: *std.Build.Step.Options,
         tigerbeetle_test: std.Build.LazyPath,
         vortex_options: *std.Build.Step.Options,
+        test_options: *std.Build.Step.Options,
     },
 ) !void {
-    const test_options = b.addOptions();
-    // Benchmark run in two modes.
-    // - ./zig/zig build test
-    // - ./zig/zig build -Drelease test -- "benchmark: name"
-    // The former uses small parameter values and is silent.
-    // The latter is the real benchmark, which prints the output.
-    test_options.addOption(bool, "benchmark", for (b.args orelse &.{}) |arg| {
-        if (std.mem.indexOf(u8, arg, "benchmark") != null) break true;
-    } else false);
-
     const stdx_unit_tests = b.addTest(.{
         .name = "test-stdx",
         .root_module = b.createModule(.{
@@ -894,7 +898,8 @@ fn build_test(
         }),
         .filters = b.args orelse &.{},
     });
-    stdx_unit_tests.root_module.addOptions("test_options", test_options);
+    stdx_unit_tests.root_module.addOptions("test_options", options.test_options);
+
     const unit_tests = b.addTest(.{
         .name = "test-unit",
         .root_module = b.createModule(.{
@@ -906,7 +911,7 @@ fn build_test(
     });
     unit_tests.root_module.addImport("stdx", options.stdx_module);
     unit_tests.root_module.addOptions("vsr_options", options.vsr_options_test);
-    unit_tests.root_module.addOptions("test_options", test_options);
+    unit_tests.root_module.addOptions("test_options", options.test_options);
 
     steps.test_unit_build.dependOn(&b.addInstallArtifact(stdx_unit_tests, .{}).step);
     steps.test_unit_build.dependOn(&b.addInstallArtifact(unit_tests, .{}).step);

--- a/build.zig
+++ b/build.zig
@@ -894,6 +894,7 @@ fn build_test(
         }),
         .filters = b.args orelse &.{},
     });
+    stdx_unit_tests.root_module.addOptions("test_options", test_options);
     const unit_tests = b.addTest(.{
         .name = "test-unit",
         .root_module = b.createModule(.{

--- a/src/lsm/binary_search_benchmark.zig
+++ b/src/lsm/binary_search_benchmark.zig
@@ -7,7 +7,7 @@ const KiB = stdx.KiB;
 const MiB = stdx.MiB;
 const GiB = stdx.GiB;
 
-const Bench = @import("../testing/bench.zig");
+const Bench = stdx.Bench;
 
 const binary_search_values_upsert_index =
     @import("./binary_search.zig").binary_search_values_upsert_index;

--- a/src/lsm/k_way_merge_benchmark.zig
+++ b/src/lsm/k_way_merge_benchmark.zig
@@ -2,8 +2,8 @@ const std = @import("std");
 const assert = std.debug.assert;
 
 const stdx = @import("stdx");
+const Bench = stdx.Bench;
 
-const Bench = @import("../testing/bench.zig");
 const Pending = error{Pending};
 const KWayMergeIteratorType = @import("k_way_merge.zig").KWayMergeIteratorType;
 

--- a/src/stdx/radix_benchmark.zig
+++ b/src/stdx/radix_benchmark.zig
@@ -21,6 +21,7 @@ test "benchmark: radix sort" {
 
     var arena_instance = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena_instance.deinit();
+
     const arena = arena_instance.allocator();
 
     var prng = stdx.PRNG.from_seed(bench.seed);

--- a/src/stdx/radix_benchmark.zig
+++ b/src/stdx/radix_benchmark.zig
@@ -1,0 +1,101 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+const stdx = @import("stdx.zig");
+const Bench = stdx.Bench;
+const radix = @import("radix.zig");
+
+const repetitions: usize = 32;
+const layouts = .{
+    .{ .Key = u64, .value_bytes = 16 },
+    .{ .Key = u128, .value_bytes = 32 },
+    .{ .Key = u256, .value_bytes = 128 },
+    .{ .Key = u64, .value_bytes = 128 },
+};
+
+test "benchmark: radix sort" {
+    var bench: Bench = .init();
+    defer bench.deinit();
+
+    const values_count: usize = @intCast(bench.parameter("values_count", 64, 1 << 20));
+
+    var arena_instance = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_instance.deinit();
+    const arena = arena_instance.allocator();
+
+    var prng = stdx.PRNG.from_seed(bench.seed);
+    var checksum: u64 = 0;
+    inline for (layouts) |layout| {
+        checksum +%= try run(
+            &bench,
+            layout.Key,
+            layout.value_bytes,
+            values_count,
+            arena,
+            &prng,
+        );
+    }
+    bench.report("checksum={}", .{checksum});
+}
+
+fn run(
+    bench: *Bench,
+    comptime Key: type,
+    comptime value_bytes: usize,
+    values_count: usize,
+    arena: std.mem.Allocator,
+    prng: *stdx.PRNG,
+) !u64 {
+    const Value = ValueType(Key, value_bytes);
+    const values_original = try arena.alignedAlloc(Value, 64, values_count);
+    const values = try arena.alignedAlloc(Value, 64, values_count);
+    const values_scratch = try arena.alignedAlloc(Value, 64, values_count);
+
+    for (values_original) |*value| value.key = prng.int(Key);
+
+    var duration_samples: [repetitions]stdx.Duration = undefined;
+    var checksum: u64 = 0;
+    for (&duration_samples) |*duration| {
+        stdx.copy_disjoint(.exact, Value, values, values_original);
+
+        bench.start();
+        radix.sort(Key, Value, Value.key_from_value, values, values_scratch);
+        duration.* = bench.stop();
+
+        assert(std.sort.isSorted(Value, values, {}, Value.less_than));
+        checksum +%= @truncate(values[values.len / 2].key);
+    }
+
+    const duration_overall = bench.estimate(&duration_samples);
+    const duration_element: stdx.Duration = .{ .ns = duration_overall.ns / values_count };
+    const duration_key_byte: stdx.Duration = .{ .ns = duration_element.ns / @sizeOf(Key) };
+    bench.report("K={:_>2}B V={:_>3}B: {d:.0}, {} per element, {} per key byte", .{
+        @sizeOf(Key),
+        @sizeOf(Value),
+        duration_overall,
+        duration_element,
+        duration_key_byte,
+    });
+    return checksum;
+}
+
+fn ValueType(comptime Key: type, comptime value_bytes: usize) type {
+    return struct {
+        const Value = @This();
+
+        key: Key,
+        body: [value_bytes - @sizeOf(Key)]u8 = @splat(0),
+
+        comptime {
+            assert(@sizeOf(Value) == value_bytes);
+        }
+
+        inline fn key_from_value(value: *const Value) Key {
+            return value.key;
+        }
+
+        fn less_than(_: void, a: Value, b: Value) bool {
+            return a.key < b.key;
+        }
+    };
+}

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -13,6 +13,7 @@ pub const IOPSType = @import("iops.zig").IOPSType;
 pub const BoundedArrayType = @import("bounded_array.zig").BoundedArrayType;
 pub const PRNG = @import("prng.zig");
 pub const RingBufferType = @import("ring_buffer.zig").RingBufferType;
+pub const Bench = @import("testing/bench.zig");
 pub const Snap = @import("testing/snaptest.zig").Snap;
 pub const ZipfianGenerator = @import("zipfian.zig").ZipfianGenerator;
 pub const ZipfianShuffled = @import("zipfian.zig").ZipfianShuffled;
@@ -1254,6 +1255,7 @@ comptime {
     _ = @import("shell.zig");
     _ = @import("sort_test.zig");
     _ = @import("stdx.zig");
+    _ = @import("testing/bench.zig");
     _ = @import("testing/snaptest.zig");
     _ = @import("time_units.zig");
     _ = @import("unshare.zig");

--- a/src/stdx/stdx.zig
+++ b/src/stdx/stdx.zig
@@ -1251,6 +1251,7 @@ comptime {
     _ = @import("net.zig");
     _ = @import("prng.zig");
     _ = @import("radix.zig");
+    _ = @import("radix_benchmark.zig");
     _ = @import("ring_buffer.zig");
     _ = @import("shell.zig");
     _ = @import("sort_test.zig");

--- a/src/stdx/testing/bench.zig
+++ b/src/stdx/testing/bench.zig
@@ -53,7 +53,7 @@ test "benchmark: API tutorial" { // `benchmark:` in the name is important!
 
 const std = @import("std");
 const assert = std.debug.assert;
-const stdx = @import("stdx");
+const stdx = @import("../stdx.zig");
 const Duration = stdx.Duration;
 const Instant = stdx.Instant;
 const TimeOS = @import("../time.zig").TimeOS;
@@ -115,14 +115,14 @@ pub fn start(bench: *Bench) void {
     assert(bench.timer == null);
     defer assert(bench.timer != null);
 
-    bench.timer = bench.time.time().monotonic();
+    bench.timer = bench.time.monotonic();
 }
 
 pub fn stop(bench: *Bench) Duration {
     assert(bench.timer != null);
     defer assert(bench.timer == null);
 
-    const instant_stop = bench.time.time().monotonic();
+    const instant_stop = bench.time.monotonic();
     const elapsed = bench.timer.?.elapsed(instant_stop);
     bench.timer = null;
     return elapsed;

--- a/src/stdx/testing/bench.zig
+++ b/src/stdx/testing/bench.zig
@@ -56,7 +56,7 @@ const assert = std.debug.assert;
 const stdx = @import("../stdx.zig");
 const Duration = stdx.Duration;
 const Instant = stdx.Instant;
-const TimeOS = @import("../time.zig").TimeOS;
+const Time = @import("./time.zig");
 
 const seed_benchmark: u64 = 42;
 
@@ -65,7 +65,7 @@ const mode: enum { smoke, benchmark } =
     if (@import("test_options").benchmark) .benchmark else .smoke;
 
 seed: u64,
-time: TimeOS = .{},
+time: Time = .{},
 timer: ?Instant = null,
 
 const Bench = @This();
@@ -114,15 +114,13 @@ fn parameter_fallible(
 pub fn start(bench: *Bench) void {
     assert(bench.timer == null);
     defer assert(bench.timer != null);
-
-    bench.timer = bench.time.monotonic();
+    bench.timer = bench.time.benchmark_monotonic();
 }
 
 pub fn stop(bench: *Bench) Duration {
     assert(bench.timer != null);
     defer assert(bench.timer == null);
-
-    const instant_stop = bench.time.monotonic();
+    const instant_stop = bench.time.benchmark_monotonic();
     const elapsed = bench.timer.?.elapsed(instant_stop);
     bench.timer = null;
     return elapsed;

--- a/src/stdx/testing/bench.zig
+++ b/src/stdx/testing/bench.zig
@@ -114,12 +114,14 @@ fn parameter_fallible(
 pub fn start(bench: *Bench) void {
     assert(bench.timer == null);
     defer assert(bench.timer != null);
+
     bench.timer = bench.time.benchmark_monotonic();
 }
 
 pub fn stop(bench: *Bench) Duration {
     assert(bench.timer != null);
     defer assert(bench.timer == null);
+
     const instant_stop = bench.time.benchmark_monotonic();
     const elapsed = bench.timer.?.elapsed(instant_stop);
     bench.timer = null;

--- a/src/stdx/testing/time.zig
+++ b/src/stdx/testing/time.zig
@@ -58,20 +58,20 @@ fn benchmark_monotonic_windows() u64 {
     //
     // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ntddk/ns-ntddk-kuser_shared_data
     // https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/api/ntexapi_x/kuser_shared_data/index.htm
-    const qpc = os.windows.QueryPerformanceCounter();
-    const qpf = os.windows.QueryPerformanceFrequency();
+    const counter = os.windows.QueryPerformanceCounter();
+    const frequency = os.windows.QueryPerformanceFrequency();
 
     // 10Mhz (1 qpc tick every 100ns) is a common QPF on modern systems.
     // We can optimize towards this by converting to ns via a single multiply.
     //
     // https://github.com/microsoft/STL/blob/785143a0c73f030238ef618890fd4d6ae2b3a3a0/stl/inc/chrono#L694-L701
-    const common_qpf = 10_000_000;
-    if (qpf == common_qpf) return qpc * (std.time.ns_per_s / common_qpf);
+    const common_frequency = 10_000_000;
+    if (frequency == common_frequency) return counter * (std.time.ns_per_s / common_frequency);
 
     // Convert qpc to nanos using fixed point to avoid expensive extra divs and
     // overflow.
-    const scale = (std.time.ns_per_s << 32) / qpf;
-    return @as(u64, @truncate((@as(u96, qpc) * scale) >> 32));
+    const scale = (std.time.ns_per_s << 32) / frequency;
+    return @as(u64, @truncate((@as(u96, counter) * scale) >> 32));
 }
 
 fn benchmark_monotonic_darwin() u64 {

--- a/src/stdx/testing/time.zig
+++ b/src/stdx/testing/time.zig
@@ -19,7 +19,7 @@ const is_windows = builtin.target.os.tag == .windows;
 const is_linux = builtin.target.os.tag == .linux;
 const Instant = stdx.Instant;
 
-const BenchmarkTimer = @This();
+const BenchmarkTime = @This();
 
 // BenchmarkTime is used to test algorithm runtime and is not critical for safety.
 // We still guard against non-monotonicity bugs in OS time sources

--- a/src/stdx/testing/timer.zig
+++ b/src/stdx/testing/timer.zig
@@ -1,0 +1,106 @@
+/// In microbenchmarks, we often measure both time and other performance counters
+/// such as how many cycles were used, how many branch misses were incurred, and more.
+/// These only count cycles in the current process, and not, for exampole, sleep time.
+/// The closest matching clock implementation semantics are provided by CLOCK_MONOTONIC,
+/// which is what we use here. To distinguish towards vsr.time.Time.monotonic(),
+/// we call this `benchmark_monotonic()`
+/// https://github.com/ziglang/zig/pull/933#discussion_r656021295.
+const std = @import("std");
+const builtin = @import("builtin");
+
+const stdx = @import("../stdx.zig");
+
+const os = std.os;
+const posix = std.posix;
+const system = posix.system;
+const assert = std.debug.assert;
+const is_darwin = builtin.target.os.tag.isDarwin();
+const is_windows = builtin.target.os.tag == .windows;
+const is_linux = builtin.target.os.tag == .linux;
+const Instant = stdx.Instant;
+
+const BenchmarkTimer = @This();
+
+// BenchmarkTime is used to test algorithm runtime and is not critical for safety.
+// We still guard against non-monotonicity bugs in OS time sources
+// to fail fast and keep our sanity when debugging test outputs.
+monotonic_guard: u64 = 0,
+
+// TODO use different name to differentiate to vsr time
+pub fn benchmark_monotonic(self: *BenchmarkTime) Instant {
+    // Since we do not currently optimize for macOS and windows,
+    // (especially the I/O interface), one could also argue for
+    // failing early here and only allowing measurements on linux.
+    const monotonic_timestamp = blk: {
+        if (is_windows) break :blk benchmark_monotonic_windows();
+        if (is_darwin) break :blk benchmark_monotonic_darwin();
+        if (is_linux) break :blk benchmark_monotonic_linux();
+        @compileError("unsupported OS");
+    };
+
+    // "Oops!...I Did It Again"
+    if (monotonic_timestamp < self.monotonic_guard) {
+        @panic("a hardware/kernel bug regressed the monotonic clock");
+    }
+    self.monotonic_guard = monotonic_timestamp;
+    return .{ .ns = monotonic_timestamp };
+}
+
+fn benchmark_monotonic_windows() u64 {
+    assert(is_windows);
+    // Uses QueryPerformanceCounter() on windows due to it being the highest precision timer
+    // available while also accounting for time spent suspended by default:
+    //
+    // https://docs.microsoft.com/en-us/windows/win32/api/realtimeapiset/nf-realtimeapiset-queryunbiasedinterrupttime#remarks
+
+    // QPF need not be globally cached either as it ends up being a load from read-only memory
+    // mapped to all processed by the kernel called KUSER_SHARED_DATA (See "QpcFrequency")
+    //
+    // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ntddk/ns-ntddk-kuser_shared_data
+    // https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/api/ntexapi_x/kuser_shared_data/index.htm
+    const qpc = os.windows.QueryPerformanceCounter();
+    const qpf = os.windows.QueryPerformanceFrequency();
+
+    // 10Mhz (1 qpc tick every 100ns) is a common QPF on modern systems.
+    // We can optimize towards this by converting to ns via a single multiply.
+    //
+    // https://github.com/microsoft/STL/blob/785143a0c73f030238ef618890fd4d6ae2b3a3a0/stl/inc/chrono#L694-L701
+    const common_qpf = 10_000_000;
+    if (qpf == common_qpf) return qpc * (std.time.ns_per_s / common_qpf);
+
+    // Convert qpc to nanos using fixed point to avoid expensive extra divs and
+    // overflow.
+    const scale = (std.time.ns_per_s << 32) / qpf;
+    return @as(u64, @truncate((@as(u96, qpc) * scale) >> 32));
+}
+
+fn benchmark_monotonic_darwin() u64 {
+    assert(is_darwin);
+    // Uses mach_absolute_time() instead of mach_continuous_time() because
+    // we do *NOT* want to count while suspended here.
+    //
+    // https://developer.apple.com/documentation/kernel/1646199-mach_continuous_time
+    // https://opensource.apple.com/source/Libc/Libc-1158.1.2/gen/clock_gettime.c.auto.html
+    const darwin = struct {
+        const mach_timebase_info_t = system.mach_timebase_info_data;
+        extern "c" fn mach_timebase_info(info: *mach_timebase_info_t) system.kern_return_t;
+        extern "c" fn mach_absolute_time() u64;
+    };
+
+    // mach_timebase_info() called through libc already does global caching for us
+    //
+    // https://opensource.apple.com/source/xnu/xnu-7195.81.3/libsyscall/wrappers/mach_timebase_info.c.auto.html
+    var info: darwin.mach_timebase_info_t = undefined;
+    if (darwin.mach_timebase_info(&info) != 0) @panic("mach_timebase_info() failed");
+
+    const now = darwin.mach_absolute_time();
+    return (now * info.numer) / info.denom;
+}
+
+fn benchmark_monotonic_linux() u64 {
+    assert(is_linux);
+    const ts: posix.timespec = posix.clock_gettime(posix.CLOCK.MONOTONIC) catch {
+        @panic("CLOCK_BOOTTIME required");
+    };
+    return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+}

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -42,7 +42,6 @@ comptime {
     _ = @import("state_machine.zig");
     _ = @import("state_machine_fuzz.zig");
     _ = @import("state_machine_tests.zig");
-    _ = @import("testing/bench.zig");
     _ = @import("testing/exhaustigen.zig");
     _ = @import("testing/id.zig");
     _ = @import("testing/marks.zig");

--- a/src/vsr/checksum_benchmark.zig
+++ b/src/vsr/checksum_benchmark.zig
@@ -8,7 +8,7 @@ const stdx = @import("stdx");
 const KiB = stdx.KiB;
 const MiB = stdx.MiB;
 
-const Bench = @import("../testing/bench.zig");
+const Bench = stdx.Bench;
 
 const repetitions = 35;
 


### PR DESCRIPTION
We should be able to benchmark things in `stdx`. This PR therefore moves `Bench` into `stdx`, and adds a small benchmark for `stdx.radix_sort`.
Since `stdx` doesn't have `time`, and we don't want to use `std.time`, it also adds timing derived off of `vsr.time`.