### PR TITLE
Move some imports to the top

### DIFF
--- a/src/aof.zig
+++ b/src/aof.zig
@@ -790,7 +790,7 @@ pub fn AOFType(comptime IO: type) type {
 const testing = std.testing;
 
 test "aof write / read" {
-    const IO = @import("io.zig").IO;
+    const IO = vsr.io.IO;
     const AOF = AOFType(IO);
     const AOFIterator = AOF.Iterator;
 
@@ -944,7 +944,7 @@ pub fn main() !void {
     const target = try gpa.create(AOFEntry);
     defer gpa.destroy(target);
 
-    const IO = @import("io.zig").IO;
+    const IO = vsr.io.IO;
     var io = try IO.init(32, 0);
     defer io.deinit();
 

--- a/src/cdc/amqp/protocol.zig
+++ b/src/cdc/amqp/protocol.zig
@@ -49,6 +49,7 @@ const maybe = stdx.maybe;
 const KiB = stdx.KiB;
 
 const spec = @import("spec.zig");
+const vsr = @import("../../vsr.zig");
 
 pub const frame_min_size = spec.FRAME_MIN_SIZE;
 pub const tcp_port_default = 5672;
@@ -796,7 +797,6 @@ pub fn fatal(comptime format: []const u8, args: anytype) noreturn {
     const log = std.log.scoped(.amqp);
     log.err(format, args);
 
-    const vsr = @import("../../vsr.zig");
     const status = vsr.FatalReason.cli.exit_status();
     assert(status != 0);
     std.process.exit(status);

--- a/src/clients/c/tb_client.zig
+++ b/src/clients/c/tb_client.zig
@@ -3,7 +3,8 @@ const std = @import("std");
 pub const vsr = @import("../../vsr.zig");
 pub const exports = @import("tb_client_exports.zig");
 
-const MessageBus = @import("../../message_bus.zig").MessageBusType(@import("../../io.zig").IO);
+const MessageBusType = @import("../../message_bus.zig").MessageBusType;
+const MessageBus = MessageBusType(vsr.io.IO);
 
 pub const InitError = @import("tb_client/context.zig").InitError;
 pub const InitParameters = @import("tb_client/context.zig").InitParameters;

--- a/src/ewah.zig
+++ b/src/ewah.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;
@@ -45,7 +46,7 @@ pub fn ewah(comptime Word: type) type {
         };
 
         comptime {
-            assert(@import("builtin").target.cpu.arch.endian() == std.builtin.Endian.little);
+            assert(builtin.target.cpu.arch.endian() == std.builtin.Endian.little);
             assert(@typeInfo(Word).int.signedness == .unsigned);
             assert(word_bits % 8 == 0); // A multiple of a byte, so that words can be cast to bytes.
             assert(@bitSizeOf(Marker) == word_bits);

--- a/src/lsm/composite_key.zig
+++ b/src/lsm/composite_key.zig
@@ -3,6 +3,7 @@ const assert = std.debug.assert;
 const math = std.math;
 
 const stdx = @import("stdx");
+const UniqueKeyType = @import("unique_key.zig").UniqueKeyType;
 
 /// Combines a field (the key prefix) with a timestamp (the primary key).
 /// - To keep alignment, it supports either `u64` or `u128` prefixes (which can be truncated
@@ -113,7 +114,6 @@ comptime {
     assert(is_composite_key(CompositeKeyType(u64)));
     assert(is_composite_key(CompositeKeyType(u128)));
 
-    const UniqueKeyType = @import("unique_key.zig").UniqueKeyType;
     assert(!is_composite_key(UniqueKeyType(u64)));
     assert(!is_composite_key(UniqueKeyType(u128)));
 

--- a/src/lsm/forest.zig
+++ b/src/lsm/forest.zig
@@ -21,6 +21,7 @@ const snapshot_min_for_table_output = @import("compaction.zig").snapshot_min_for
 const compaction_op_min = @import("compaction.zig").compaction_op_min;
 const compaction_block_count_beat_min = @import("compaction.zig").compaction_block_count_beat_min;
 const compaction_input_tables_max = @import("compaction.zig").compaction_tables_input_max;
+const ForestTableIteratorType = @import("./forest_table_iterator.zig").ForestTableIteratorType;
 
 /// The maximum number of tables for the forest as a whole. This is set a bit backwards due to how
 /// the code is structured: a single tree should be able to use all the tables in the forest, so the
@@ -961,8 +962,6 @@ pub fn ForestType(comptime _Storage: type, comptime groove_cfg: anytype) type {
         ///
         /// (Invoked immediately after open() or checkpoint()).
         fn verify_tables_recovered(forest: *const Forest) void {
-            const ForestTableIteratorType =
-                @import("./forest_table_iterator.zig").ForestTableIteratorType;
             const ForestTableIterator = ForestTableIteratorType(Forest);
 
             assert(forest.grid.superblock.opened);

--- a/src/lsm/manifest_level_fuzz.zig
+++ b/src/lsm/manifest_level_fuzz.zig
@@ -31,6 +31,10 @@ const log = std.log.scoped(.lsm_manifest_level_fuzz);
 const fuzz = @import("../testing/fuzz.zig");
 const binary_search = @import("binary_search.zig");
 const lsm = @import("tree.zig");
+const TableType = @import("table.zig").TableType;
+const NodePoolType = @import("node_pool.zig").NodePoolType;
+const ManifestLevelType = @import("manifest_level.zig").ManifestLevelType;
+const TreeTableInfoType = @import("manifest.zig").TreeTableInfoType;
 
 const Key = u64;
 const Value = packed struct(u128) {
@@ -51,7 +55,7 @@ inline fn tombstone(value: *const Value) bool {
     return value.tombstone;
 }
 
-const Table = @import("table.zig").TableType(
+const Table = TableType(
     Key,
     Value,
     key_from_value,
@@ -222,14 +226,15 @@ pub fn EnvironmentType(comptime table_count_max_tree: u32, comptime node_size: u
         const Environment = @This();
 
         const TableBuffer = std.ArrayList(TableInfo);
-        const NodePool = @import("node_pool.zig").NodePoolType(node_size, @alignOf(TableInfo));
-        pub const ManifestLevel = @import("manifest_level.zig").ManifestLevelType(
+        const NodePool = NodePoolType(node_size, @alignOf(TableInfo));
+        pub const ManifestLevel = ManifestLevelType(
             NodePool,
             Key,
             TableInfo,
             table_count_max_tree,
         );
-        pub const TableInfo = @import("manifest.zig").TreeTableInfoType(Table);
+        pub const TableInfo = TreeTableInfoType(Table);
+
         pool: NodePool,
         level: ManifestLevel,
         buffer: TableBuffer,

--- a/src/lsm/tree.zig
+++ b/src/lsm/tree.zig
@@ -13,6 +13,10 @@ const NodePool = @import("node_pool.zig").NodePoolType(constants.lsm_manifest_no
 const GridType = @import("../vsr/grid.zig").GridType;
 const BlockPtrConst = @import("../vsr/grid.zig").BlockPtrConst;
 const ScratchMemory = @import("scratch_memory.zig").ScratchMemory;
+const TableMemoryType = @import("table_memory.zig").TableMemoryType;
+const ManifestType = @import("manifest.zig").ManifestType;
+const ManifestLogType = @import("manifest_log.zig").ManifestLogType;
+const CompactionType = @import("compaction.zig").CompactionType;
 
 pub const ScopeCloseMode = enum { persist, discard };
 
@@ -46,14 +50,13 @@ pub fn TreeType(comptime TreeTable: type, comptime Storage: type) type {
         pub const Table = TreeTable;
         pub const Value = Table.Value;
 
-        pub const TableMemory = @import("table_memory.zig").TableMemoryType(Table);
-        pub const Manifest = @import("manifest.zig").ManifestType(Table, Storage);
+        pub const TableMemory = TableMemoryType(Table);
+        pub const Manifest = ManifestType(Table, Storage);
 
         const Grid = GridType(Storage);
-        const ManifestLog = @import("manifest_log.zig").ManifestLogType(Storage);
+        const ManifestLog = ManifestLogType(Storage);
         const KeyRange = Manifest.KeyRange;
 
-        const CompactionType = @import("compaction.zig").CompactionType;
         pub const Compaction = CompactionType(Tree, Storage);
 
         pub const LookupMemoryResult = union(enum) {

--- a/src/message_bus_fuzz.zig
+++ b/src/message_bus_fuzz.zig
@@ -416,7 +416,7 @@ const IO = struct {
     // We can't specify io/linux.zig since it won't compile on windows, which means that we are
     // potentially using different error sets for different OS's, which means that fuzzer seeds are
     // only reproducible on the same OS.
-    const RealIO = @import("io.zig").IO;
+    const RealIO = vsr.io.IO;
     pub const AcceptError = RealIO.AcceptError;
     pub const CloseError = RealIO.CloseError;
     pub const ConnectError = RealIO.ConnectError;

--- a/src/scripts/devhub.zig
+++ b/src/scripts/devhub.zig
@@ -35,6 +35,7 @@ const stdx = @import("stdx");
 const Shell = stdx.Shell;
 const changelog = @import("./changelog.zig");
 const Release = @import("../multiversion.zig").Release;
+const Header = @import("../vsr/message_header.zig").Header;
 
 const MiB = stdx.MiB;
 
@@ -265,8 +266,6 @@ fn devhub_metrics(shell: *Shell, cli_args: CLIArgs) !void {
         // use the benchmark or repl via CLI.
         //
         // Use Header directly with a blocking TCP connection here, to avoid pulling in half of TB.
-        const Header = @import("../vsr/message_header.zig").Header;
-
         var ping = Header.PingClient{
             .command = .ping_client,
             .cluster = 0,

--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -30,6 +30,7 @@ const ci_java = @import("../clients/java/ci.zig");
 const ci_node = @import("../clients/node/ci.zig");
 const ci_python = @import("../clients/python/ci.zig");
 const ci_rust = @import("../clients/rust/ci.zig");
+const vsr_options = @import("vsr_options");
 
 const MiB = stdx.MiB;
 
@@ -128,7 +129,7 @@ pub fn main(shell: *Shell, gpa: std.mem.Allocator, cli_args: CLIArgs) !void {
 
     const version_info = VersionInfo{
         .release_triple = try shell.fmt("{[major]}.{[minor]}.{[patch]}", release.triple()),
-        .release_triple_client_min = @import("vsr_options").release_client_min,
+        .release_triple_client_min = vsr_options.release_client_min,
         .tag = try shell.fmt(
             "{[major]}.{[minor]}.{[patch]}",
             release.triple(),

--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -18,6 +18,10 @@ const GrooveType = @import("lsm/groove.zig").GrooveType;
 const ForestType = @import("lsm/forest.zig").ForestType;
 const ScanBufferType = @import("lsm/scan_buffer.zig").ScanBufferType;
 const ScanLookupType = @import("lsm/scan_lookup.zig").ScanLookupType;
+const ScanLookupStatus = @import("lsm/scan_lookup.zig").ScanLookupStatus;
+const ScanRangeType = @import("lsm/scan_range.zig").ScanRangeType;
+const EvaluateNext = @import("lsm/scan_range.zig").EvaluateNext;
+const ScanTreeType = @import("lsm/scan_tree.zig").ScanTreeType;
 
 const MultiBatchEncoder = vsr.multi_batch.MultiBatchEncoder;
 const MultiBatchDecoder = vsr.multi_batch.MultiBatchDecoder;
@@ -4878,10 +4882,6 @@ fn ExpirePendingTransfersType(
 ) type {
     return struct {
         const ExpirePendingTransfers = @This();
-        const ScanRangeType = @import("lsm/scan_range.zig").ScanRangeType;
-        const EvaluateNext = @import("lsm/scan_range.zig").EvaluateNext;
-        const ScanLookupStatus = @import("lsm/scan_lookup.zig").ScanLookupStatus;
-
         const Tree = @FieldType(TransfersGroove.IndexTrees, "expires_at");
         const Value = Tree.Table.Value;
         const ScanBuffer = ScanBufferType(GridType(Storage));
@@ -5035,7 +5035,6 @@ fn ChangeEventsScanLookupType(
     comptime AccountEventsGroove: type,
     comptime Storage: type,
 ) type {
-    const ScanTreeType = @import("lsm/scan_tree.zig").ScanTreeType;
     const ScanBuffer = ScanBufferType(GridType(Storage));
 
     return struct {

--- a/src/state_machine_tests.zig
+++ b/src/state_machine_tests.zig
@@ -14,6 +14,13 @@ const MultiBatchEncoder = vsr.multi_batch.MultiBatchEncoder;
 const MultiBatchDecoder = vsr.multi_batch.MultiBatchDecoder;
 
 const TimestampRange = @import("lsm/timestamp_range.zig").TimestampRange;
+const TimeSimType = @import("testing/time.zig").TimeSim;
+const TestStorage = @import("testing/storage.zig").Storage;
+const data_file_size_min = @import("vsr/superblock.zig").data_file_size_min;
+const SuperBlockType = @import("vsr/superblock.zig").SuperBlockType;
+const GridType = @import("vsr/grid.zig").GridType;
+const fixtures = @import("testing/fixtures.zig");
+const parse_table = @import("testing/table.zig").parse;
 
 const Account = tb.Account;
 const AccountBalance = tb.AccountBalance;
@@ -35,13 +42,11 @@ const StateMachineType = @import("state_machine.zig").StateMachineType;
 const testing = std.testing;
 
 pub const TestContext = struct {
-    const TimeSim = @import("testing/time.zig").TimeSim;
-    const Storage = @import("testing/storage.zig").Storage;
+    const TimeSim = TimeSimType;
+    const Storage = TestStorage;
     const Tracer = Storage.Tracer;
-    const data_file_size_min = @import("vsr/superblock.zig").data_file_size_min;
-    const SuperBlock = @import("vsr/superblock.zig").SuperBlockType(Storage);
-    const Grid = @import("vsr/grid.zig").GridType(Storage);
-    const fixtures = @import("testing/fixtures.zig");
+    const SuperBlock = SuperBlockType(Storage);
+    const Grid = GridType(Storage);
 
     pub const StateMachine = StateMachineType(Storage);
 
@@ -605,7 +610,6 @@ const TestQueryAccounts = TestQueryFilter;
 const TestQueryTransfers = TestQueryFilter;
 
 fn check(test_table: []const u8) !void {
-    const parse_table = @import("testing/table.zig").parse;
     const test_actions = parse_table(TestAction, test_table);
 
     // Runs the same test for each variation of supported operations,

--- a/src/stdx/prng.zig
+++ b/src/stdx/prng.zig
@@ -125,7 +125,7 @@ pub fn from_seed(seed: u64) PRNG {
 }
 
 pub fn from_seed_testing() PRNG {
-    comptime assert(@import("builtin").is_test);
+    comptime assert(builtin.is_test);
     return .from_seed(std.testing.random_seed);
 }
 

--- a/src/testing/cluster.zig
+++ b/src/testing/cluster.zig
@@ -24,6 +24,11 @@ const StorageChecker = @import("cluster/storage_checker.zig").StorageChecker;
 const GridChecker = @import("cluster/grid_checker.zig").GridChecker;
 const ManifestCheckerType = @import("cluster/manifest_checker.zig").ManifestCheckerType;
 const JournalCheckerType = @import("cluster/journal_checker.zig").JournalCheckerType;
+const TestingNetwork = @import("cluster/network.zig").Network;
+const TestingNetworkOptions = @import("cluster/network.zig").NetworkOptions;
+const TestingStorage = @import("storage.zig").Storage;
+const ClusterFaultAtlas = @import("storage.zig").ClusterFaultAtlas;
+const ClusterMessageBus = @import("cluster/message_bus.zig").ClusterMessageBus;
 
 const vsr = @import("../vsr.zig");
 const format_writes_max = @import("../vsr/replica_format.zig").writes_max;
@@ -59,13 +64,13 @@ pub fn ClusterType(comptime StateMachineType: anytype) type {
     return struct {
         const Cluster = @This();
 
-        pub const Network = @import("cluster/network.zig").Network;
-        pub const NetworkOptions = @import("cluster/network.zig").NetworkOptions;
-        pub const Storage = @import("storage.zig").Storage;
-        pub const StorageFaultAtlas = @import("storage.zig").ClusterFaultAtlas;
+        pub const Network = TestingNetwork;
+        pub const NetworkOptions = TestingNetworkOptions;
+        pub const Storage = TestingStorage;
+        pub const StorageFaultAtlas = ClusterFaultAtlas;
         pub const Tracer = Storage.Tracer;
         pub const SuperBlock = vsr.SuperBlockType(Storage);
-        pub const MessageBus = @import("cluster/message_bus.zig").MessageBus;
+        pub const MessageBus = ClusterMessageBus;
         pub const StateMachine = StateMachineType(Storage);
         pub const Replica = vsr.ReplicaType(StateMachine, MessageBus, Storage, AOF);
         pub const ReplicaReformat =

--- a/src/testing/state_machine.zig
+++ b/src/testing/state_machine.zig
@@ -6,11 +6,12 @@ const vsr = @import("../vsr.zig");
 const constants = @import("../constants.zig");
 const GrooveType = @import("../lsm/groove.zig").GrooveType;
 const ForestType = @import("../lsm/forest.zig").ForestType;
+const GridType = @import("../vsr/grid.zig").GridType;
 
 pub fn StateMachineType(comptime Storage: type) type {
     return struct {
         const StateMachine = @This();
-        const Grid = @import("../vsr/grid.zig").GridType(Storage);
+        const Grid = GridType(Storage);
 
         pub const Workload = WorkloadType(StateMachine);
 

--- a/src/testing/vortex/supervisor.zig
+++ b/src/testing/vortex/supervisor.zig
@@ -49,6 +49,9 @@ const assert = std.debug.assert;
 const maybe = stdx.maybe;
 const log = std.log.scoped(.supervisor);
 const Release = @import("../../multiversion.zig").Release;
+const Model = @import("./workload.zig").Model;
+const Generator = @import("./workload.zig").Generator;
+const Command = @import("./workload.zig").Command;
 
 const dependencies_path: []const u8 = @import("vortex_options").dependencies_path;
 const dependencies_count: u32 = @import("vortex_options").dependencies_count;
@@ -802,10 +805,6 @@ const Replica = struct {
 };
 
 const Workload = struct {
-    const Model = @import("./workload.zig").Model;
-    const Generator = @import("./workload.zig").Generator;
-    const Command = @import("./workload.zig").Command;
-
     const RequestInfo = struct {
         timestamp_start_micros: u64,
         timestamp_end_micros: u64,

--- a/src/trace/event.zig
+++ b/src/trace/event.zig
@@ -10,6 +10,7 @@ const Peer = vsr.Peer;
 const Zone = vsr.Zone;
 const CommitStage = @import("../vsr/replica.zig").CommitStage;
 const tigerbeetle = @import("../tigerbeetle.zig");
+const tree_ids = @import("../state_machine.zig").tree_ids;
 const Duration = stdx.Duration;
 
 const Operation = operation_enum: {
@@ -37,7 +38,6 @@ const Operation = operation_enum: {
 };
 
 const TreeEnum = tree_enum: {
-    const tree_ids = @import("../state_machine.zig").tree_ids;
     var tree_fields: []const std.builtin.Type.EnumField = &[_]std.builtin.Type.EnumField{};
 
     for (std.meta.declarations(tree_ids)) |groove_field| {
@@ -59,7 +59,6 @@ const TreeEnum = tree_enum: {
 };
 
 const GrooveEnum = groove_enum: {
-    const tree_ids = @import("../state_machine.zig").tree_ids;
     var groove_fields: []const std.builtin.Type.EnumField = &[_]std.builtin.Type.EnumField{};
 
     for (std.meta.declarations(tree_ids)) |groove_field| {

--- a/src/vsr/grid.zig
+++ b/src/vsr/grid.zig
@@ -17,6 +17,7 @@ const GridBlocksMissing = @import("./grid_blocks_missing.zig").GridBlocksMissing
 const Tracer = vsr.trace.Tracer;
 
 const FreeSet = @import("./free_set.zig").FreeSet;
+const FreeSetReservation = @import("./free_set.zig").Reservation;
 
 const log = stdx.log.scoped(.grid);
 
@@ -40,7 +41,7 @@ pub fn GridType(comptime Storage: type) type {
 
         pub const RepairTable = GridBlocksMissing.RepairTable;
         pub const RepairTableResult = GridBlocksMissing.RepairTableResult;
-        pub const Reservation = @import("./free_set.zig").Reservation;
+        pub const Reservation = FreeSetReservation;
 
         // Grid just reuses the Storage's NextTick abstraction for simplicity.
         pub const NextTick = Storage.NextTick;


### PR DESCRIPTION
I noticed that some Zig files keep `@import(...)` declarations near their use sites instead of grouping them at the top. Some cases make sense to me, especially test/fuzz-only imports, local comptime checks, or places where lazy compilation/local context matters. But for a few others, especially in the state machine, the imports looked like they could live at the top.

This PR moves the imports that seemed safe to the top of the files. The code compiles with several build commands: check, fmt, vortex, and tests.

Is there any reason not to move these imports to the top?