### PR TITLE
state machine: prefetch imported events in mixed sub-batches

### DIFF
--- a/src/state_machine.zig
+++ b/src/state_machine.zig
@@ -1277,6 +1277,27 @@ pub fn StateMachineType(comptime Storage: type) type {
                 Account,
                 self.prefetch_input.?,
             );
+            // Multi-batch prefetch flattens independently validated batches. A later imported
+            // account batch still needs its transfer timestamp keys prefetched.
+            if (accounts.len > 1 and !accounts[0].flags.imported) {
+                var imported_batch = false;
+                for (accounts[1..]) |*a| {
+                    if (a.flags.imported) {
+                        imported_batch = true;
+                        self.forest.grooves.transfers.prefetch_enqueue(.{
+                            .timestamp = a.timestamp,
+                        });
+                    }
+                }
+                if (imported_batch) {
+                    self.forest.grooves.transfers.prefetch(
+                        prefetch_create_accounts_transfers_callback,
+                        self.prefetch_context.get(.transfers),
+                    );
+                    return;
+                }
+            }
+
             if (accounts.len > 0 and
                 accounts[0].flags.imported)
             {
@@ -1368,6 +1389,18 @@ pub fn StateMachineType(comptime Storage: type) type {
                 } else {
                     self.forest.grooves.accounts.prefetch_enqueue(.{ .id = t.debit_account_id });
                     self.forest.grooves.accounts.prefetch_enqueue(.{ .id = t.credit_account_id });
+                }
+            }
+
+            // Multi-batch prefetch flattens independently validated batches. Enqueue account
+            // timestamp keys for imported transfers even when the first batch is ordinary.
+            if (transfers.len > 1 and !transfers[0].flags.imported) {
+                for (transfers[1..]) |*t| {
+                    if (t.flags.imported) {
+                        self.forest.grooves.accounts.prefetch_enqueue(.{
+                            .timestamp = t.timestamp,
+                        });
+                    }
                 }
             }
 

--- a/src/state_machine_tests.zig
+++ b/src/state_machine_tests.zig
@@ -290,6 +290,13 @@ pub const TestContext = struct {
             .not_found => null,
         };
     }
+
+    fn get_transfer_from_cache(context: *TestContext, id: u128) ?Transfer {
+        return switch (context.state_machine.forest.grooves.transfers.get(id)) {
+            .found_object => |object| object,
+            .found_orphaned, .not_found => null,
+        };
+    }
 };
 
 const TestAction = union(enum) {
@@ -1997,6 +2004,128 @@ test "imported events: imported batch" {
         \\ transfer   T4 A1 A2    3   _  _  _  _    _ L1 C2   _   _   _   _   _   _  IMP _  _ _ 0 imported_event_not_expected
         \\ commit create_transfers
     );
+}
+
+test "imported events: ordinary then imported create multi-batch prefetch" {
+    const allocator = testing.allocator;
+    const input = try allocator.alignedAlloc(
+        u8,
+        constants.cache_line_size,
+        constants.message_body_size_max,
+    );
+    defer allocator.free(input);
+
+    var output: [constants.message_body_size_max]u8 align(constants.cache_line_size) = undefined;
+    var context: TestContext = undefined;
+    try context.init(allocator);
+    defer context.deinit(allocator);
+
+    const ordinary = TestCreateAccount.event(.{
+        .id = 1,
+        .ledger = 1,
+        .code = 1,
+        .status = .created,
+    });
+    stdx.copy_disjoint(.exact, u8, input[0..@sizeOf(Account)], mem.asBytes(&ordinary));
+    _ = context.submit(
+        .create_accounts,
+        input,
+        @sizeOf(Account),
+        &output,
+    );
+
+    const ordinary_created = context.get_account_from_cache(ordinary.id).?;
+    var imported = TestCreateAccount.event(.{
+        .id = 2,
+        .ledger = 1,
+        .code = 1,
+        .flags_imported = .IMP,
+        .timestamp = ordinary_created.timestamp + 1,
+        .status = .created,
+    });
+
+    var body_encoder = MultiBatchEncoder.init(input, .{
+        .element_size = @sizeOf(Account),
+    });
+    stdx.copy_disjoint(
+        .exact,
+        u8,
+        body_encoder.writable().?[0..@sizeOf(Account)],
+        mem.asBytes(&ordinary),
+    );
+    body_encoder.add(@sizeOf(Account));
+    stdx.copy_disjoint(
+        .exact,
+        u8,
+        body_encoder.writable().?[0..@sizeOf(Account)],
+        mem.asBytes(&imported),
+    );
+    body_encoder.add(@sizeOf(Account));
+    const body_size = body_encoder.finish();
+    const body: []align(constants.cache_line_size) const u8 = input[0..body_size];
+
+    context.prepare(.create_accounts, body);
+    _ = context.execute(context.op, .create_accounts, body, &output);
+    try testing.expect(context.get_account_from_cache(imported.id) != null);
+
+    const ordinary_transfer = TestCreateTransfer.event(.{
+        .id = 1,
+        .debit_account_id = ordinary.id,
+        .credit_account_id = imported.id,
+        .amount = 1,
+        .ledger = 1,
+        .code = 1,
+        .status = .created,
+    });
+    stdx.copy_disjoint(
+        .exact,
+        u8,
+        input[0..@sizeOf(Transfer)],
+        mem.asBytes(&ordinary_transfer),
+    );
+    _ = context.submit(
+        .create_transfers,
+        input,
+        @sizeOf(Transfer),
+        &output,
+    );
+
+    const ordinary_transfer_created = context.get_transfer_from_cache(ordinary_transfer.id).?;
+    var imported_transfer = TestCreateTransfer.event(.{
+        .id = 2,
+        .debit_account_id = ordinary.id,
+        .credit_account_id = imported.id,
+        .amount = 1,
+        .ledger = 1,
+        .code = 1,
+        .flags_imported = .IMP,
+        .timestamp = ordinary_transfer_created.timestamp + 1,
+        .status = .created,
+    });
+
+    body_encoder = MultiBatchEncoder.init(input, .{
+        .element_size = @sizeOf(Transfer),
+    });
+    stdx.copy_disjoint(
+        .exact,
+        u8,
+        body_encoder.writable().?[0..@sizeOf(Transfer)],
+        mem.asBytes(&ordinary_transfer),
+    );
+    body_encoder.add(@sizeOf(Transfer));
+    stdx.copy_disjoint(
+        .exact,
+        u8,
+        body_encoder.writable().?[0..@sizeOf(Transfer)],
+        mem.asBytes(&imported_transfer),
+    );
+    body_encoder.add(@sizeOf(Transfer));
+    const transfer_body_size = body_encoder.finish();
+    const transfer_body: []align(constants.cache_line_size) const u8 = input[0..transfer_body_size];
+
+    context.prepare(.create_transfers, transfer_body);
+    _ = context.execute(context.op, .create_transfers, transfer_body, &output);
+    try testing.expect(context.get_transfer_from_cache(imported_transfer.id) != null);
 }
 
 test "imported events: timestamp" {


### PR DESCRIPTION
There seems to be an edge case when an ordinary create sub-batch followed by an imported one can cause a panic and bring down a cluster. The problem is that prefetch uses only the first event in the flattened multi-batch to decide whether imported timestamp keys are required.

We have a test here which reproduces the issue using `create_accounts` and `create_transfers` retries. The retries return `exists` without mutating state, which allows execution to reach the timestamp lookup (which fails due to the missing prefetch).

If this were to happen in production, it's possible for the operation to be replicated in the log. You'd then end up with a cluster that would neither advance nor resolve the issue without a new, updated binary (with the fix here, or similar). So this seems pretty serious.