### PR TITLE
Update tigerbeetle.gemspec to point homepage to proper subdirectory

### DIFF
--- a/src/clients/ruby/tigerbeetle.gemspec
+++ b/src/clients/ruby/tigerbeetle.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.homepage    = "https://github.com/tigerbeetle/tigerbeetle"
 
   spec.metadata = {
-    "source_code_uri" => "https://github.com/tigerbeetle/tigerbeetle",
+    "source_code_uri" => "https://github.com/tigerbeetle/tigerbeetle/tree/main/src/clients/ruby",
     "bug_tracker_uri" => "https://github.com/tigerbeetle/tigerbeetle/issues",
   }
 

--- a/src/clients/ruby/tigerbeetle.gemspec
+++ b/src/clients/ruby/tigerbeetle.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.summary     = "The TigerBeetle client for Ruby."
   spec.authors     = ["TigerBeetle, Inc"]
   spec.license     = "Apache-2.0"
-  spec.homepage    = "https://github.com/tigerbeetle/tigerbeetle"
+  spec.homepage    = "https://github.com/tigerbeetle/tigerbeetle/tree/main/src/clients/ruby"
 
   spec.metadata = {
     "source_code_uri" => "https://github.com/tigerbeetle/tigerbeetle/tree/main/src/clients/ruby",


### PR DESCRIPTION
Seeing the root repo link on RubyGems.org is pretty confusing because there's no indication at all in the root of the repo that there's a Ruby Gem contained there.

It makes more sense to point at the subdirectory containing the Ruby client.