### PR TITLE
docs: fix broken relative links for GitHub rendering

### DIFF
--- a/docs/coding/api-changes.md
+++ b/docs/coding/api-changes.md
@@ -416,7 +416,7 @@ try {
 ```
 
 For more details, please refer to the
-[Java client reference page](./clients/java).
+[Java client reference page](/src/clients/java/).
 
 </details><br><!--Java-->
 
@@ -500,7 +500,7 @@ for (const result of transferResults) {
 ```
 
 For more details, please refer to the
-[Node.js client reference page](./clients/node).
+[Node.js client reference page](/src/clients/node/).
 
 </details><br><!--Node.js-->
 
@@ -584,7 +584,7 @@ for result in transfer_results:
 ```
 
 For more details, please refer to the
-[Python client reference page](./clients/python).
+[Python client reference page](/src/clients/python/).
 
 </details><br><!--Python-->
 
@@ -597,7 +597,7 @@ However, the Rust client is not yet publicly available on Crates.io at the time 
 so they are not considered breaking changes.
 
 For more details, please refer to the
-[Rust client reference page](./clients/rust).
+[Rust client reference page](/src/clients/rust/).
 
 </details><!--Rust-->
 

--- a/docs/internals/docs.md
+++ b/docs/internals/docs.md
@@ -26,7 +26,7 @@ User docs roughly follow the Django-style organization. Specifically, they come 
   the basics, and what to get a specific thing done. Unlike tutorials, guides should _always_
   explain the why. Every page under [coding](/docs/coding/) and [operating](/docs/operating) is a
   guide.
-- Reference ([reference](/docs/reference>)) is the API-docs level documentation. It specifies
+- Reference ([reference](/docs/reference/)) is the API-docs level documentation. It specifies
   behaviors with maximum level of precision. A reference is not good for reading start to finish, it
   is a random-access document.
 

--- a/docs/internals/vsr.md
+++ b/docs/internals/vsr.md
@@ -242,8 +242,8 @@ In response to a `get_reply`:
 
 See also:
 
-- [Integration: Client Session Lifecycle](../../reference/sessions.md#lifecycle)
-- [Integration: Client Session Eviction](../../reference/sessions.md#eviction)
+- [Integration: Client Session Lifecycle](../reference/sessions.md#lifecycle)
+- [Integration: Client Session Eviction](../reference/sessions.md#eviction)
 
 ### Protocol: Repair Grid
 

--- a/docs/reference/sessions.md
+++ b/docs/reference/sessions.md
@@ -1,6 +1,6 @@
 # Client Sessions
 
-A _client session_ is a sequence of [requests](../coding/requests/README.md) and replies sent between a
+A _client session_ is a sequence of [requests](../coding/requests.md) and replies sent between a
 client and a cluster.
 
 A client session may have **at most one in-flight request** — i.e. at most one unique request on the
@@ -49,7 +49,7 @@ to self-terminate, bubbling up to the application as an `session evicted` error.
 
 If active clients are terminating with `session evicted` errors, it most likely indicates that the
 application is trying to run too many concurrent clients. For performance reasons, it is recommended
-to [batch](../coding/requests/README.md#batching-events) as many events as possible into each request sent
+to [batch](../coding/requests.md#batching-events) as many events as possible into each request sent
 by each client.
 
 ## Retries
@@ -73,7 +73,7 @@ would be misleading. An error would imply that a request did not execute, when t
 
 ## Guarantees
 
-- A client session may have at most one in-flight [request](../coding/requests/README.md).
+- A client session may have at most one in-flight [request](../coding/requests.md).
 - A client session [reads its own writes](https://jepsen.io/consistency/models/read-your-writes),
   meaning that read operations that happen after a given write operation will observe the effects of
   the write.


### PR DESCRIPTION
## Summary
- Fix relative markdown links that 404 when viewing docs on GitHub (docs must work for the site, GH, and local editors — see `docs/internals/docs.md`).
- `docs/internals/vsr.md`: client-session integration links pointed one directory too high (`../../reference` → `../reference`).
- `docs/reference/sessions.md`: `coding/requests` is a single `requests.md` file, not a `requests/` directory.
- `docs/internals/docs.md`: typo in the reference path (`/docs/reference>` → `/docs/reference/`).
- `docs/coding/api-changes.md`: client “reference page” footers pointed at non-existent `docs/coding/clients/{java,node,python,rust}`; align with `/src/clients/…/` like `docs/coding/clients/README.md`.

## Motivation
Broken GH navigation for sessions/VSR/API-changes docs; tiny docs-only hygiene matching recent external typo merges.

## Verification
- Relative-link existence check on the four touched files (skip `http(s)` and absolute `/…` site links).
- Confirmed `## Batching Events` heading for `#batching-events` on `docs/coding/requests.md`.

## Notes
Docs-only; no runtime/behavior change.