### PR TITLE
docs: list Ruby and Rust clients on installing page

### DIFF
--- a/docs/operating/installing.md
+++ b/docs/operating/installing.md
@@ -64,5 +64,5 @@ compilation instructions.
 
 ## Client Libraries
 
-Client libraries for .NET, Go, Java, Node.js, and Python are published to the respective package
-repositories, see [Clients](../coding/clients/).
+Client libraries for .NET, Go, Java, Node.js, Python, Ruby, and Rust are published to the respective
+package repositories, see [Clients](../coding/clients/).


### PR DESCRIPTION
## Summary
- Update the **Client Libraries** blurb in `docs/operating/installing.md` so it lists **Ruby** and **Rust** alongside .NET, Go, Java, Node.js, and Python.
- Aligns install docs with the canonical list in `docs/coding/clients/README.md` (RubyGems + crates.io clients already documented there).

## Motivation
Readers of the install guide could miss that Ruby and Rust clients are first-class official libraries.

## Verification
- Compared against `docs/coding/clients/README.md` client list.
- Docs-only; link target `../coding/clients/` unchanged.

## Notes
No runtime change.