### PR TITLE
docs: list Ruby and Rust clients on start and coding TOC

### DIFF
--- a/docs/coding/README.md
+++ b/docs/coding/README.md
@@ -18,7 +18,7 @@ as a series of loosely connected guides which can be read in any order.
 - [Recipes](./recipes/) is a library of ready-made solutions for common business requirements such
   as a currency exchange.
 - [Clients](./clients/) shows how to use TigerBeetle from the comfort of .NET, Go, Java, Node.js,
-  or Python.
+  Python, Ruby, or Rust.
 - [API Changes](./api-changes.md) describes changes introduced in the TigerBeetle Client libraries.
   <br>
   Subscribe to the [tracking issue #2231](https://github.com/tigerbeetle/tigerbeetle/issues/2231)

--- a/docs/start.md
+++ b/docs/start.md
@@ -72,8 +72,7 @@ the storage misbehaves.
 ## Connecting to a Cluster
 
 Now that the cluster is running, we can connect to it using a client. TigerBeetle has
-clients for several popular programming languages, including [Python](https://docs.tigerbeetle.com/coding/clients/python/), [Java](https://docs.tigerbeetle.com/coding/clients/java/), [Node.js](https://docs.tigerbeetle.com/coding/clients/node/), [.Net](https://docs.tigerbeetle.com/coding/clients/dotnet/), and [Go](https://docs.tigerbeetle.com/coding/clients/go/), and more
-are coming; see the [Coding](./coding) section for details. For this tutorial, we'll keep it simple
+clients for several popular programming languages, including [Python](https://docs.tigerbeetle.com/coding/clients/python/), [Java](https://docs.tigerbeetle.com/coding/clients/java/), [Node.js](https://docs.tigerbeetle.com/coding/clients/node/), [.NET](https://docs.tigerbeetle.com/coding/clients/dotnet/), [Go](https://docs.tigerbeetle.com/coding/clients/go/), [Ruby](https://docs.tigerbeetle.com/coding/clients/ruby/), and [Rust](https://docs.tigerbeetle.com/coding/clients/rust/); see the [Coding](./coding) section for details. For this tutorial, we'll keep it simple
 and connect to the cluster using the built-in CLI client. In a separate terminal, start a REPL with:
 
 ```console


### PR DESCRIPTION
## What
Update the quick-start and coding section indices so they mention the same official client set already documented under `docs/coding/clients/README.md` (including Ruby and Rust).

## Why
New readers begin at `docs/start.md`. That page still lists only five languages and says more clients “are coming,” even though Ruby and Rust have first-class packages. Same omission on the Coding TOC Clients bullet.

## Details
- `docs/start.md`: add Ruby + Rust links; spell `.NET` correctly; drop the stale “and more are coming” clause for the listed set.
- `docs/coding/README.md`: Clients bullet includes Python, Ruby, and Rust.
- Orthogonal to #3870 (installing.md client blurb only).

## Checked
- Paths match `src/clients/{ruby,rust}/` and clients README list.
- Docs-only; no runtime change.