### PR TITLE
chore(python): point Source URL at client subdirectory

### DIFF
--- a/src/clients/python/pyproject.toml
+++ b/src/clients/python/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://github.com/tigerbeetle/tigerbeetle"
+Source = "https://github.com/tigerbeetle/tigerbeetle/tree/main/src/clients/python"
 Issues = "https://github.com/tigerbeetle/tigerbeetle/issues"
 
 


### PR DESCRIPTION
Python package metadata currently sets Homepage and Issues to the monorepo root. Node already records `repository.directory = src/clients/node`, which lands package consumers on the client tree instead of an undifferentiated monorepo homepage.

This adds a Source project URL for the same reason:

```toml
Source = "https://github.com/tigerbeetle/tigerbeetle/tree/main/src/clients/python"
```

Packaging-only; no client runtime change. Related spirit to the Ruby gemspec subdirectory cleanup in #3868 (different language / file).