### PR TITLE
inspect: validate post-checkpoint WAL prepare IDs in integrity check

### DIFF
--- a/src/tigerbeetle/cli.zig
+++ b/src/tigerbeetle/cli.zig
@@ -299,8 +299,7 @@ const CLIArgs = union(enum) {
             \\        Example tree names: "transfers" (object table), "transfers.amount" (index table).
             \\
             \\  integrity
-            \\        Scans the data file and checks all internal checksums to verify internal
-            \\        integrity.
+            \\        Scans the data file and checks internal checksums and invariants.
             \\
         ;
     };

--- a/src/tigerbeetle/inspect_integrity.zig
+++ b/src/tigerbeetle/inspect_integrity.zig
@@ -344,6 +344,16 @@ fn check_wal(integrity: *Integrity) !u64 {
         assert(wal_header.valid_checksum());
         assert(wal_prepare_body_valid);
         assert(wal_header.checksum == wal_prepare.checksum);
+        if (!integrity.superblock.working.vsr_state.checkpoint.prepare_checkpoint_id_valid(
+            wal_header,
+        )) {
+            log.err("invalid checkpoint id: slot={} op={} operation={}", .{
+                slot,
+                wal_header.op,
+                wal_header.operation,
+            });
+            assert(false);
+        }
         checked_bytes += bytes_read;
     }
 

--- a/src/tigerbeetle/inspect_integrity.zig
+++ b/src/tigerbeetle/inspect_integrity.zig
@@ -344,16 +344,14 @@ fn check_wal(integrity: *Integrity) !u64 {
         assert(wal_header.valid_checksum());
         assert(wal_prepare_body_valid);
         assert(wal_header.checksum == wal_prepare.checksum);
-        if (!integrity.superblock.working.vsr_state.checkpoint.prepare_checkpoint_id_valid(
-            wal_header,
-        )) {
-            log.err("invalid checkpoint id: slot={} op={} operation={}", .{
-                slot,
-                wal_header.op,
-                wal_header.operation,
-            });
-            assert(false);
+
+        if (wal_header.operation != .reserved) {
+            const checkpoint = &integrity.superblock.working.vsr_state.checkpoint;
+            if (checkpoint.checkpoint_id_for_op(wal_header.op)) |checkpoint_id_expected| {
+                assert(wal_header.checkpoint_id == checkpoint_id_expected);
+            }
         }
+
         checked_bytes += bytes_read;
     }
 

--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -7146,37 +7146,11 @@ pub fn ReplicaType(
         /// Returns `null` for ops which are too far in the past/future to know their checkpoint
         /// ids.
         fn checkpoint_id_for_op(self: *const Replica, op: u64) ?u128 {
-            const checkpoint_now = self.op_checkpoint_sync();
-            const checkpoint_next_1 = vsr.Checkpoint.checkpoint_after(checkpoint_now);
-            const checkpoint_next_2 = vsr.Checkpoint.checkpoint_after(checkpoint_next_1);
-
             const checkpoint: *const vsr.CheckpointState = if (self.syncing == .updating_checkpoint)
                 &self.syncing.updating_checkpoint
             else
                 &self.superblock.working.vsr_state.checkpoint;
-
-            if (op + constants.vsr_checkpoint_ops <= checkpoint_now) {
-                // Case 1: op is from a too distant past for us to know its checkpoint id.
-                return null;
-            }
-
-            if (op <= checkpoint_now) {
-                // Case 2: op is from the previous checkpoint whose id we still remember.
-                return checkpoint.grandparent_checkpoint_id;
-            }
-
-            if (op <= checkpoint_next_1) {
-                // Case 3: op is in the current checkpoint.
-                return checkpoint.parent_checkpoint_id;
-            }
-
-            if (op <= checkpoint_next_2) {
-                // Case 4: op is in the next checkpoint (which we have not checkpointed).
-                return vsr.checksum(std.mem.asBytes(checkpoint));
-            }
-
-            // Case 5: op is from the too far future for us to know anything!
-            return null;
+            return checkpoint.checkpoint_id_for_op(op);
         }
 
         /// Returns the oldest op that the replica must/(is permitted to) repair.

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -389,6 +389,47 @@ pub const SuperBlockHeader = extern struct {
 
         reserved: [408]u8 = @splat(0),
 
+        /// Returns the checkpoint id associated with `op`, or `null` when `op` is outside the
+        /// checkpoint history retained in this state.
+        pub fn checkpoint_id_for_op(checkpoint: *const CheckpointState, op: u64) ?u128 {
+            const checkpoint_now = checkpoint.header.op;
+            const checkpoint_next_1 = vsr.Checkpoint.checkpoint_after(checkpoint_now);
+            const checkpoint_next_2 = vsr.Checkpoint.checkpoint_after(checkpoint_next_1);
+
+            if (op + constants.vsr_checkpoint_ops <= checkpoint_now) {
+                // Case 1: op is from a too distant past for us to know its checkpoint id.
+                return null;
+            }
+
+            if (op <= checkpoint_now) {
+                // Case 2: op is from the previous checkpoint whose id we still remember.
+                return checkpoint.grandparent_checkpoint_id;
+            }
+
+            if (op <= checkpoint_next_1) {
+                // Case 3: op is in the current checkpoint.
+                return checkpoint.parent_checkpoint_id;
+            }
+
+            if (op <= checkpoint_next_2) {
+                // Case 4: op is in the next checkpoint (which we have not checkpointed).
+                return vsr.checksum(std.mem.asBytes(checkpoint));
+            }
+
+            // Case 5: op is from the too far future for us to know anything!
+            return null;
+        }
+
+        pub fn prepare_checkpoint_id_valid(
+            checkpoint: *const CheckpointState,
+            prepare: *const vsr.Header.Prepare,
+        ) bool {
+            if (prepare.operation == .reserved or prepare.op <= checkpoint.header.op) return true;
+            const checkpoint_id_expected =
+                checkpoint.checkpoint_id_for_op(prepare.op) orelse return true;
+            return prepare.checkpoint_id == checkpoint_id_expected;
+        }
+
         comptime {
             assert(@sizeOf(CheckpointState) % @sizeOf(u128) == 0);
             assert(@sizeOf(CheckpointState) == 1024);
@@ -1583,6 +1624,44 @@ pub const Caller = enum {
         };
     }
 };
+
+test "CheckpointState.checkpoint_id_for_op" {
+    const checkpoint_1 = vsr.Checkpoint.checkpoint_after(0);
+    const checkpoint_2 = vsr.Checkpoint.checkpoint_after(checkpoint_1);
+    const checkpoint_3 = vsr.Checkpoint.checkpoint_after(checkpoint_2);
+    const checkpoint_4 = vsr.Checkpoint.checkpoint_after(checkpoint_3);
+
+    var checkpoint = std.mem.zeroes(SuperBlockHeader.CheckpointState);
+    checkpoint.header.op = checkpoint_2;
+    checkpoint.parent_checkpoint_id = 1;
+    checkpoint.grandparent_checkpoint_id = 2;
+    const checkpoint_id = vsr.checksum(std.mem.asBytes(&checkpoint));
+
+    try std.testing.expectEqual(null, checkpoint.checkpoint_id_for_op(checkpoint_1));
+    try std.testing.expectEqual(2, checkpoint.checkpoint_id_for_op(checkpoint_1 + 1));
+    try std.testing.expectEqual(2, checkpoint.checkpoint_id_for_op(checkpoint_2));
+    try std.testing.expectEqual(1, checkpoint.checkpoint_id_for_op(checkpoint_2 + 1));
+    try std.testing.expectEqual(1, checkpoint.checkpoint_id_for_op(checkpoint_3));
+    try std.testing.expectEqual(checkpoint_id, checkpoint.checkpoint_id_for_op(checkpoint_3 + 1));
+    try std.testing.expectEqual(checkpoint_id, checkpoint.checkpoint_id_for_op(checkpoint_4));
+    try std.testing.expectEqual(null, checkpoint.checkpoint_id_for_op(checkpoint_4 + 1));
+
+    var prepare = std.mem.zeroes(vsr.Header.Prepare);
+    prepare.operation = .pulse;
+    prepare.op = checkpoint_2 + 1;
+    prepare.checkpoint_id = checkpoint.parent_checkpoint_id;
+    try std.testing.expect(checkpoint.prepare_checkpoint_id_valid(&prepare));
+
+    prepare.checkpoint_id += 1;
+    try std.testing.expect(!checkpoint.prepare_checkpoint_id_valid(&prepare));
+
+    prepare.op = checkpoint_2;
+    try std.testing.expect(checkpoint.prepare_checkpoint_id_valid(&prepare));
+
+    prepare.operation = .reserved;
+    prepare.op = checkpoint_2 + 1;
+    try std.testing.expect(checkpoint.prepare_checkpoint_id_valid(&prepare));
+}
 
 test "SuperBlockHeader" {
     const expect = std.testing.expect;

--- a/src/vsr/superblock.zig
+++ b/src/vsr/superblock.zig
@@ -420,16 +420,6 @@ pub const SuperBlockHeader = extern struct {
             return null;
         }
 
-        pub fn prepare_checkpoint_id_valid(
-            checkpoint: *const CheckpointState,
-            prepare: *const vsr.Header.Prepare,
-        ) bool {
-            if (prepare.operation == .reserved or prepare.op <= checkpoint.header.op) return true;
-            const checkpoint_id_expected =
-                checkpoint.checkpoint_id_for_op(prepare.op) orelse return true;
-            return prepare.checkpoint_id == checkpoint_id_expected;
-        }
-
         comptime {
             assert(@sizeOf(CheckpointState) % @sizeOf(u128) == 0);
             assert(@sizeOf(CheckpointState) == 1024);
@@ -1645,22 +1635,6 @@ test "CheckpointState.checkpoint_id_for_op" {
     try std.testing.expectEqual(checkpoint_id, checkpoint.checkpoint_id_for_op(checkpoint_3 + 1));
     try std.testing.expectEqual(checkpoint_id, checkpoint.checkpoint_id_for_op(checkpoint_4));
     try std.testing.expectEqual(null, checkpoint.checkpoint_id_for_op(checkpoint_4 + 1));
-
-    var prepare = std.mem.zeroes(vsr.Header.Prepare);
-    prepare.operation = .pulse;
-    prepare.op = checkpoint_2 + 1;
-    prepare.checkpoint_id = checkpoint.parent_checkpoint_id;
-    try std.testing.expect(checkpoint.prepare_checkpoint_id_valid(&prepare));
-
-    prepare.checkpoint_id += 1;
-    try std.testing.expect(!checkpoint.prepare_checkpoint_id_valid(&prepare));
-
-    prepare.op = checkpoint_2;
-    try std.testing.expect(checkpoint.prepare_checkpoint_id_valid(&prepare));
-
-    prepare.operation = .reserved;
-    prepare.op = checkpoint_2 + 1;
-    try std.testing.expect(checkpoint.prepare_checkpoint_id_valid(&prepare));
 }
 
 test "SuperBlockHeader" {


### PR DESCRIPTION
We were doing some internal benchmarking and synthetically created datafiles for testing using a custom tool. We checked them using `tigerbeetle inspect integrity` but found that the check missed an issue where prepares had incorrect checkpoint IDs. The prepares had valid checksums, so the existing integrity check failed to catch the inconsistency.

Not sure if upstream is interested in this change, but I thought the integrity checker should check this since it's easy to do and fast. I reused `checkpoint_id_for_op()` to validate relevant WAL prepares against the superblock checkpoint state without additional I/O, and added tests for it.