### PR TITLE
Correct array len assertion

### DIFF
--- a/src/vsr/replica.zig
+++ b/src/vsr/replica.zig
@@ -11847,7 +11847,7 @@ const JVQuorum = struct {
 
                 const headers = message_body_as_view_headers(jv.base_const());
                 const header_index = jv.header.op - op;
-                assert(header_index <= headers.slice.len);
+                assert(header_index < headers.slice.len);
 
                 const header = &headers.slice[header_index];
                 assert(header.op == op);


### PR DESCRIPTION
Is this a typo? I guess normally it would be < the len? I saw header_index >= headers.slice.len in other parts of the code, so I'm guessing the inverse is the intent?