### PR TITLE
salvage: chore(ruby) gemspec homepage → client subdir (credit @jcoleman #3868)

### DIFF
--- a/src/clients/ruby/tigerbeetle.gemspec
+++ b/src/clients/ruby/tigerbeetle.gemspec
@@ -6,10 +6,10 @@ Gem::Specification.new do |spec|
   spec.summary     = "The TigerBeetle client for Ruby."
   spec.authors     = ["TigerBeetle, Inc"]
   spec.license     = "Apache-2.0"
-  spec.homepage    = "https://github.com/tigerbeetle/tigerbeetle"
+  spec.homepage    = "https://github.com/tigerbeetle/tigerbeetle/tree/main/src/clients/ruby"
 
   spec.metadata = {
-    "source_code_uri" => "https://github.com/tigerbeetle/tigerbeetle",
+    "source_code_uri" => "https://github.com/tigerbeetle/tigerbeetle/tree/main/src/clients/ruby",
     "bug_tracker_uri" => "https://github.com/tigerbeetle/tigerbeetle/issues",
   }
 


### PR DESCRIPTION
### What

RubyGems `homepage` / `source_code_uri` currently open the monorepo root. Package consumers get no breadcrumb that the Ruby client lives under `src/clients/ruby`.

This PR points both fields at `…/tree/main/src/clients/ruby`, matching the Node client’s `repository.directory` posture.

### Credit

**salvage of #3868** by [@jcoleman](https://github.com/jcoleman) — same intent and diff shape. Rebased as a single conventional commit on current `main`, with `Co-authored-by: James Coleman`. When this lands, #3868 can close as superseded (happy to attribute either way).

### Why not just n-a-c on #3868?

Fork PR keeps maintainer merge mechanics simple if they prefer Bartok9 / convention-aligned subjects; still fully credits the original author.

### Scope

- File: `src/clients/ruby/tigerbeetle.gemspec` only
- No Ruby runtime change

AI-assisted drafting of commit framing; human-reviewed line value.