### PR TITLE
chore(java): point scm.url at client subdirectory

### DIFF
--- a/src/clients/java/pom.xml
+++ b/src/clients/java/pom.xml
@@ -20,7 +20,7 @@
   </organization>
   <url>https://www.tigerbeetle.com</url>
   <scm>
-    <url>https://github.com/tigerbeetle/tigerbeetle</url>
+    <url>https://github.com/tigerbeetle/tigerbeetle/tree/main/src/clients/java</url>
   </scm>
 
   <licenses>


### PR DESCRIPTION
## Context

Java `pom.xml` already points branding URLs at tigerbeetle.com. The SCM block, however, still lists the bare monorepo root:

```xml
<scm>
  <url>https://github.com/tigerbeetle/tigerbeetle</url>
</scm>
```

## Change

Anchor `scm.url` at `…/tree/main/src/clients/java` so Maven Central / IDE “source” links open the Java client directory (sibling idea to Node’s `repository.directory`).

No Java source, samples, or version bump.

AI-assisted; human-reviewed packaging-only patch.