### PR TITLE
chore(dotnet): point PackageProjectUrl at client subdirectory

### DIFF
--- a/src/clients/dotnet/TigerBeetle/TigerBeetle.props
+++ b/src/clients/dotnet/TigerBeetle/TigerBeetle.props
@@ -6,7 +6,7 @@
       <NeutralLanguage>en-US</NeutralLanguage>
       <PackageId>tigerbeetle</PackageId>
       <PackageTags>TigerBeetle</PackageTags>
-      <PackageProjectUrl>https://github.com/tigerbeetle/tigerbeetle</PackageProjectUrl>
+      <PackageProjectUrl>https://github.com/tigerbeetle/tigerbeetle/tree/main/src/clients/dotnet</PackageProjectUrl>
       <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
       <PublishRepositoryUrl>true</PublishRepositoryUrl>
     </PropertyGroup>


### PR DESCRIPTION
## Summary
Updates the .NET client PackageProjectUrl so NuGet / IDE project-site links open src/clients/dotnet instead of the monorepo root.

Matches the Node repository.directory convention and sibling packaging hygiene PRs.

## Verification
- Single-line change in TigerBeetle.props
- No runtime impact

AI-assisted; human-reviewed.
