### PR TITLE
docs(clients): fix python README link target

### DIFF
--- a/src/clients/README.md
+++ b/src/clients/README.md
@@ -17,7 +17,7 @@ Existing `Docs` struct implementations are in:
 * [go/docs.zig](./go/docs.zig), which generates [go/README.md](./go/README.md)
 * [java/docs.zig](./java/docs.zig), which generates [java/README.md](./java/README.md)
 * [node/docs.zig](./node/docs.zig), which generates [node/README.md](./node/README.md)
-* [python/docs.zig](./python/docs.zig), which generates [python/README.md](./node/README.md)
+* [python/docs.zig](./python/docs.zig), which generates [python/README.md](./python/README.md)
 
 ### Run
 


### PR DESCRIPTION
## Summary
Fixes a copy-paste error in `src/clients/README.md`: the python docs.zig bullet linked to `./node/README.md` instead of `./python/README.md`.

## Verification
- Markdown href now matches the link text and sibling client bullets

AI-assisted; human-reviewed.
