### PR TITLE
docs(java): point package-info Source @see at monorepo path

### DIFF
--- a/src/clients/java/src/main/java/com/tigerbeetle/package-info.java
+++ b/src/clients/java/src/main/java/com/tigerbeetle/package-info.java
@@ -2,6 +2,6 @@
  * TigerBeetle client for Java.
  *
  * @see <a href="https://docs.tigerbeetle.com">TigerBeetle Docs</a>
- * @see <a href="https://github.com/tigerbeetle/tigerbeetle-java">Source code</a>
+ * @see <a href="https://github.com/tigerbeetle/tigerbeetle/tree/main/src/clients/java">Source code</a>
  */
 package com.tigerbeetle;


### PR DESCRIPTION
## Summary
Javadoc `package com.tigerbeetle` `@see Source code` linked to the old standalone `tigerbeetle-java` repo name. The client lives in this monorepo under `src/clients/java`.

Updates the href to `.../tree/main/src/clients/java` so Source lands on the real tree (same idea as Node `repository.directory` and the open Python/Ruby packaging URL fixes).

## Scope
- Single line in `package-info.java`
- Leaves `pom.xml` `<scm>` alone (orthogonal to #3877)

## Notes
Tiny docs metadata fix; AI-assisted, human-reviewed.