### PR TITLE
chore(node): add homepage and bugs metadata to package.json

### DIFF
--- a/src/clients/node/package.json
+++ b/src/clients/node/package.json
@@ -9,6 +9,10 @@
     "url": "git+https://github.com/tigerbeetle/tigerbeetle.git",
     "directory": "src/clients/node"
   },
+  "homepage": "https://github.com/tigerbeetle/tigerbeetle/tree/main/src/clients/node",
+  "bugs": {
+    "url": "https://github.com/tigerbeetle/tigerbeetle/issues"
+  },
   "preferUnplugged": true,
   "files": [
     "LICENSE",


### PR DESCRIPTION
`tigerbeetle-node` already declares `repository.directory = src/clients/node`. This adds the usual npm companions:

- **homepage** → monorepo client tree
- **bugs.url** → main issue tracker

No runtime or lockfile churn—metadata only for registry / IDE consumers.