### PR TITLE
salvage: refactor(go) drop redundant asymmetric reply checks (credit @paulyeo21 #3843)

### DIFF
--- a/src/clients/c/tb_client/context.zig
+++ b/src/clients/c/tb_client/context.zig
@@ -885,6 +885,9 @@ pub fn ContextType(
 
             if (!operation.is_multi_batch()) {
                 assert(packet_list.multi_batch_next == null);
+                // Replies must contain a whole number of results, matching the
+                // `@divExact` invariant enforced on the multi-batch path below.
+                assert(reply.len % operation.result_size() == 0);
                 return self.notify_completion(packet_list, .{
                     .timestamp = timestamp,
                     .reply = reply,

--- a/src/clients/go/tb_client.go
+++ b/src/clients/go/tb_client.go
@@ -145,31 +145,6 @@ func getEventSize(op C.TB_OPERATION) uintptr {
 	}
 }
 
-func getResultSize(op C.TB_OPERATION) uintptr {
-	switch op {
-	case C.TB_OPERATION_CREATE_ACCOUNTS:
-		return unsafe.Sizeof(CreateAccountResult{})
-	case C.TB_OPERATION_CREATE_TRANSFERS:
-		return unsafe.Sizeof(CreateTransferResult{})
-	case C.TB_OPERATION_LOOKUP_ACCOUNTS:
-		return unsafe.Sizeof(Account{})
-	case C.TB_OPERATION_LOOKUP_TRANSFERS:
-		return unsafe.Sizeof(Transfer{})
-	case C.TB_OPERATION_GET_ACCOUNT_TRANSFERS:
-		return unsafe.Sizeof(Transfer{})
-	case C.TB_OPERATION_GET_ACCOUNT_BALANCES:
-		return unsafe.Sizeof(AccountBalance{})
-	case C.TB_OPERATION_QUERY_ACCOUNTS:
-		return unsafe.Sizeof(Account{})
-	case C.TB_OPERATION_QUERY_TRANSFERS:
-		return unsafe.Sizeof(Transfer{})
-	case C.TB_OPERATION_GET_CHANGE_EVENTS:
-		return unsafe.Sizeof(ChangeEvent{})
-	default:
-		return 0
-	}
-}
-
 func (c *c_client) doRequest(
 	op C.TB_OPERATION,
 	count int,
@@ -248,28 +223,8 @@ func onGoPacketCompletion(
 	req := (*request)(unsafe.Pointer(packet.user_data))
 	var reply []uint8 = nil
 	if result_size > 0 && result != nil {
-		op := C.TB_OPERATION(packet.operation)
-
-		// Make sure the completion handler is giving us valid data.
-		resultSize := C.uint32_t(getResultSize(op))
-		if result_size%resultSize != 0 {
-			panic("invalid result_size:  misaligned for the event")
-		}
-
-		//TODO(batiati): Refine the way we handle events with asymmetric results.
-		if op != C.TB_OPERATION_GET_ACCOUNT_TRANSFERS &&
-			op != C.TB_OPERATION_GET_ACCOUNT_BALANCES &&
-			op != C.TB_OPERATION_QUERY_ACCOUNTS &&
-			op != C.TB_OPERATION_QUERY_TRANSFERS &&
-			op != C.TB_OPERATION_GET_CHANGE_EVENTS {
-			// Make sure the amount of results at least matches the amount of requests.
-			count := packet.data_size / C.uint32_t(getEventSize(op))
-			if count*resultSize < result_size {
-				panic("invalid result_size: implied multiple results per event")
-			}
-		}
-
-		// Copy the result data into a new buffer.
+		// Copy the result data into a new buffer. The reply's size, alignment, and
+		// result count are validated by the C client; see `tb_client/context.zig`.
 		reply = make([]uint8, result_size)
 		C.memcpy(unsafe.Pointer(&reply[0]), unsafe.Pointer(result), C.size_t(result_size))
 	}


### PR DESCRIPTION
## Salvage
Credit **@paulyeo21** — original PR https://github.com/tigerbeetle/tigerbeetle/pull/3843 was **APPROVED** but **behind main**. This branch rebases that change onto current `main` so it can land cleanly.

## What
- Remove Go completion-handler re-validation of reply alignment / asymmetric result ops (`getResultSize` + hand-maintained exclusion list / `TODO(batiati)`).
- Rely on C `tb_client` invariants (already enforced for other language clients).
- Add alignment assert on the non-multi-batch reply path in `context.zig` so every path is checked on the Zig side.

No intended behavior change for successful replies—only removal of duplicate panic-path checks and dead helpers.

## Credit
Original author and review thread: #3843.  
`Co-authored-by: Paul Yeo` on the rebased commit.

Closes nothing automatically—maintainers may close #3843 in favor of this if preferred.