### PR TITLE
docs(clients): fix python README link and list ruby/rust Docs

### DIFF
--- a/src/clients/README.md
+++ b/src/clients/README.md
@@ -17,7 +17,9 @@ Existing `Docs` struct implementations are in:
 * [go/docs.zig](./go/docs.zig), which generates [go/README.md](./go/README.md)
 * [java/docs.zig](./java/docs.zig), which generates [java/README.md](./java/README.md)
 * [node/docs.zig](./node/docs.zig), which generates [node/README.md](./node/README.md)
-* [python/docs.zig](./python/docs.zig), which generates [python/README.md](./node/README.md)
+* [python/docs.zig](./python/docs.zig), which generates [python/README.md](./python/README.md)
+* [ruby/docs.zig](./ruby/docs.zig), which generates [ruby/README.md](./ruby/README.md)
+* [rust/docs.zig](./rust/docs.zig), which generates [rust/README.md](./rust/README.md)
 
 ### Run
 


### PR DESCRIPTION
## Summary
`src/clients/README.md` linked the Python client’s generated README to `./node/README.md`. This corrects that path to `./python/README.md` and documents the existing Ruby and Rust `docs.zig` generators in the same list.

## Motivation
Broken relative links fail the “works on GitHub markdown” bar called out in the docs internals guide. Ruby/Rust already ship client docs generators but were omitted from the index after they landed as first-class clients.

## Verification
- Manual path review: `src/clients/python/README.md`, `ruby/README.md`, `rust/README.md` exist
- Diff is README-only (+3/−1)

## Notes
AI-assisted; human-reviewed. Docs index only — no runtime change.