### PR TITLE
fix(go): make assert.Empty/Greater safe

### DIFF
--- a/src/clients/go/assert/assert.go
+++ b/src/clients/go/assert/assert.go
@@ -12,11 +12,16 @@ func isEmpty(obj interface{}) bool {
 	}
 
 	value := reflect.ValueOf(obj)
-	if value.IsNil() {
-		return true
-	}
 	switch value.Kind() {
-	case reflect.Chan, reflect.Map, reflect.Slice:
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		if value.IsNil() {
+			return true
+		}
+		if value.Kind() == reflect.Chan || value.Kind() == reflect.Map || value.Kind() == reflect.Slice {
+			return value.Len() == 0
+		}
+		return false
+	case reflect.Array, reflect.String:
 		return value.Len() == 0
 	default:
 		return false
@@ -99,9 +104,30 @@ func NotEqual(t *testing.T, a, b interface{}) {
 }
 
 func isGreater(a, b interface{}) bool {
-	a64, okA := a.(uint64)
-	b64, okB := b.(uint64)
-	return okA && okB && (a64 > b64)
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if !av.IsValid() || !bv.IsValid() {
+		return false
+	}
+
+	switch av.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		switch bv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return av.Int() > bv.Int()
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		switch bv.Kind() {
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			return av.Uint() > bv.Uint()
+		}
+	case reflect.Float32, reflect.Float64:
+		switch bv.Kind() {
+		case reflect.Float32, reflect.Float64:
+			return av.Float() > bv.Float()
+		}
+	}
+	return false
 }
 
 func Greater(t *testing.T, a, b interface{}) {

--- a/src/clients/go/assert/assert_test.go
+++ b/src/clients/go/assert/assert_test.go
@@ -1,0 +1,42 @@
+package assert
+
+import "testing"
+
+func TestEmpty(t *testing.T) {
+	Empty(t, nil)
+	Empty(t, []int{})
+	Empty(t, [0]int{})
+	Empty(t, "")
+	Empty(t, map[string]int{})
+
+	if isEmpty([]int{1}) {
+		t.Fatalf("expected non-empty slice to be non-empty")
+	}
+	if isEmpty([1]int{1}) {
+		t.Fatalf("expected non-empty array to be non-empty")
+	}
+	if isEmpty("x") {
+		t.Fatalf("expected non-empty string to be non-empty")
+	}
+}
+
+func TestGreater(t *testing.T) {
+	if !isGreater(uint64(3), uint64(2)) {
+		t.Fatalf("uint64 3 > 2")
+	}
+	if !isGreater(3, 2) {
+		t.Fatalf("int 3 > 2")
+	}
+	if !isGreater(int64(5), int64(1)) {
+		t.Fatalf("int64 5 > 1")
+	}
+	if isGreater(2, 3) {
+		t.Fatalf("2 should not be greater than 3")
+	}
+	if isGreater(3, 3) {
+		t.Fatalf("equal values should not be greater")
+	}
+	if isGreater("a", "b") {
+		t.Fatalf("non-numeric Greater should be false")
+	}
+}


### PR DESCRIPTION
## Summary
Fixes real bugs in the Go client's tiny `assert` helper (#2704):

- **`Empty` / `isEmpty`:** stopped calling `reflect.Value.IsNil()` on kinds that panic (e.g. arrays). Nillable kinds still use `IsNil`; arrays/strings use length.
- **`Greater` / `isGreater`:** compare ordered numeric kinds (int/uint/float families) instead of only succeeding for exact `uint64` type-assert pairs — so `assert.Greater(t, 3, 2)` works.

Added `assert/assert_test.go` for empty-array safety and int/`uint64` greater cases.

## Test plan
- [x] `cd src/clients/go && go test ./assert/ -count=1`

Closes #2704

AI-assisted; human-reviewed.
