### PR TITLE
docs: document bounded client request queue (#1072)

### DIFF
--- a/docs/coding/requests.md
+++ b/docs/coding/requests.md
@@ -83,6 +83,11 @@ it automatically groups together batches of small sizes into one request. Since 
 can have [**at most one in-flight request**](../reference/sessions.md), the client
 accumulates smaller batches together while waiting for a reply to the last request.
 
+The client retains only a **bounded** number of outstanding requests (in flight plus backlog;
+see [Client Sessions](../reference/sessions.md)). Exceeding that bound does not block forever and
+does not expand memory indefinitely — submit fails with a client-side error. Prefer deeper
+[event batches](#batching-events) over a large fan-out of concurrent tiny requests on one session.
+
 †: For queries (e.g. `get_account_transfers`, etc) TigerBeetle clients use the query `limit` to
 automatically batch queries of the same type together into requests when it knows for sure that all
 of their results will fit in a single reply.

--- a/docs/reference/sessions.md
+++ b/docs/reference/sessions.md
@@ -9,6 +9,14 @@ to statically guarantee capacity in its incoming message queue. Additional reque
 application are queued by the client, to be dequeued and sent when their preceding request receives
 a reply.
 
+That client-side queue is **bounded**. By default a session may hold only a small number of
+requests at once (the in-flight request plus a short backlog —
+`constants.client_request_queue_max`, 2 by default). Multithreaded or highly concurrent apps should
+still share **one** client and batch events, but they must not assume unlimited request buffering:
+when the queue is full, further submits fail rather than growing without bound (language bindings
+surface this as an error/exception such as Java's `ConcurrencyMaxExceeded` path). This limit is
+independent of cluster [session eviction](#eviction) (`clients_max`).
+
 Similar to other databases, TigerBeetle has a [hard limit](#eviction) on the number of concurrent
 client sessions. To maximize throughput, users are encouraged to minimize the number of concurrent
 clients and [batch](../coding/requests.md#batching-events) as many events as possible per request.


### PR DESCRIPTION
## Summary
Document the **bounded per-client request queue** (in-flight request + short backlog, `constants.client_request_queue_max`, default 2) and contrast it with **cluster session eviction** (`clients_max`).

Updates:
- `docs/reference/sessions.md` — queue bound + Java `ConcurrencyMaxExceeded` signal as an example binding surface
- `docs/coding/requests.md` — automatic-batching section points at the same limit

## Motivation
#1072 asked for docs on the client concurrency/queue limit when creating/using a client and the failure mode when it is exceeded. Sessions already covered one-in-flight + eviction but not the submit backlog bound in `src/constants.zig` (`client_request_queue_max`).

## Verification
- [x] Default `client_request_queue_max = 2` from `src/config.zig`
- [x] Comment in `src/constants.zig` matches “including the in-flight request”
- [x] Java bindings expose `PacketAcquireStatus.ConcurrencyMaxExceeded`
- [x] Docs-only; did not edit generated client READMEs

References #1072

AI-assisted; human-reviewed.
