### PR TITLE
docs(go): note cgo/C toolchain prerequisite

### DIFF
--- a/src/clients/go/README.md
+++ b/src/clients/go/README.md
@@ -13,6 +13,10 @@ this repo and subdirectory.
 Linux >= 5.6 is the only production environment we
 support. But for ease of development we also support macOS and Windows.
 * Go >= 1.21
+* A C toolchain for [cgo](https://pkg.go.dev/cmd/cgo) (the module links
+  native `libtb_client`). On macOS install Xcode Command Line Tools; on
+  Linux ensure `gcc` or `clang` is on `PATH`. Minimal / NixOS images
+  often fail import with missing `gcc` until a C compiler is installed.
 
 **Additionally on Windows**: you must install [Zig
 0.14.1](https://ziglang.org/download/#release-0.14.1) and set the

--- a/src/clients/go/docs.zig
+++ b/src/clients/go/docs.zig
@@ -21,6 +21,10 @@ pub const GoDocs = Docs{
 
     .prerequisites =
     \\* Go >= 1.21
+    \\* A C toolchain for [cgo](https://pkg.go.dev/cmd/cgo) (the module links
+    \\  native `libtb_client`). On macOS install Xcode Command Line Tools; on
+    \\  Linux ensure `gcc` or `clang` is on `PATH`. Minimal / NixOS images
+    \\  often fail import with missing `gcc` until a C compiler is installed.
     \\
     \\**Additionally on Windows**: you must install [Zig
     \\0.14.1](https://ziglang.org/download/#release-0.14.1) and set the


### PR DESCRIPTION
## Summary

Document that **tigerbeetle-go** needs a C toolchain for cgo (it links native `libtb_client`), which is easy to miss on minimal / NixOS images.

## Motivation

Closes #1641. Users without `gcc`/`clang` on `PATH` hit opaque import failures. Prerequisites already cover Go ≥ 1.21 and the Windows Zig-as-CC note; they did not mention cgo’s C compiler requirement.

## Change

- `src/clients/go/docs.zig` — prerequisites bullet
- `src/clients/go/README.md` — same text for GitHub before regen

Does not change Windows Zig instructions or go.mod baseline (#3885).

## Verification

- Prerequisites section now mentions cgo + Xcode CLT / gcc / clang + NixOS failure mode
- Orthogonal to Uint128 link fix in #3888 (different hunk in the same generator files)

AI-assisted; human-reviewed.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h