### PR TITLE
fix(go): return error on invalid QueryFilter

### DIFF
--- a/src/clients/go/errors.go
+++ b/src/clients/go/errors.go
@@ -15,4 +15,5 @@ var (
 	ErrClientClosed         = errors.New("client was closed")
 	ErrInvalidOperation     = errors.New("internal operation provided was invalid")
 	ErrTooMuchData          = errors.New("too much data was sent or requested in this batch")
+	ErrInvalidQueryFilter   = errors.New("invalid query filter")
 )

--- a/src/clients/go/query_filter_validate_test.go
+++ b/src/clients/go/query_filter_validate_test.go
@@ -1,0 +1,35 @@
+package tigerbeetle_go
+
+import (
+	"errors"
+	"math"
+	"testing"
+)
+
+func TestValidateQueryFilter(t *testing.T) {
+	t.Parallel()
+
+	ok := QueryFilter{Limit: 10}
+	if err := validateQueryFilter(ok); err != nil {
+		t.Fatalf("valid filter: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		filter QueryFilter
+	}{
+		{"zero limit", QueryFilter{Ledger: 1}},
+		{"timestamp min max", QueryFilter{Limit: 10, TimestampMin: math.MaxUint64}},
+		{"timestamp max max", QueryFilter{Limit: 10, TimestampMax: math.MaxUint64}},
+		{"min greater max", QueryFilter{Limit: 10, TimestampMin: 2, TimestampMax: 1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateQueryFilter(tc.filter)
+			if !errors.Is(err, ErrInvalidQueryFilter) {
+				t.Fatalf("got %v want ErrInvalidQueryFilter", err)
+			}
+		})
+	}
+}

--- a/src/clients/go/tb_client.go
+++ b/src/clients/go/tb_client.go
@@ -29,6 +29,7 @@ extern __declspec(dllexport) void onGoPacketCompletion(
 import "C"
 import (
 	e "errors"
+	"math"
 	"runtime"
 	"strings"
 	"unsafe"
@@ -430,7 +431,31 @@ func (c *c_client) GetAccountBalances(filter AccountFilter) ([]AccountBalance, e
 	return results, nil
 }
 
+// validateQueryFilter mirrors state_machine QueryFilter acceptance so Go callers
+// get an error instead of an empty result for zero-limit / impossible timestamps
+// (see https://github.com/tigerbeetle/tigerbeetle/issues/3092).
+func validateQueryFilter(filter QueryFilter) error {
+	// timestamp id 2^64-1 is never a valid event timestamp (TimestampRange.valid).
+	if filter.TimestampMin != 0 && filter.TimestampMin == math.MaxUint64 {
+		return ErrInvalidQueryFilter
+	}
+	if filter.TimestampMax != 0 && filter.TimestampMax == math.MaxUint64 {
+		return ErrInvalidQueryFilter
+	}
+	if filter.TimestampMax != 0 && filter.TimestampMin > filter.TimestampMax {
+		return ErrInvalidQueryFilter
+	}
+	if filter.Limit == 0 {
+		return ErrInvalidQueryFilter
+	}
+	return nil
+}
+
 func (c *c_client) QueryAccounts(filter QueryFilter) ([]Account, error) {
+	if err := validateQueryFilter(filter); err != nil {
+		return nil, err
+	}
+
 	reply, err := c.doRequest(
 		C.TB_OPERATION_QUERY_ACCOUNTS,
 		1,
@@ -451,6 +476,10 @@ func (c *c_client) QueryAccounts(filter QueryFilter) ([]Account, error) {
 }
 
 func (c *c_client) QueryTransfers(filter QueryFilter) ([]Transfer, error) {
+	if err := validateQueryFilter(filter); err != nil {
+		return nil, err
+	}
+
 	reply, err := c.doRequest(
 		C.TB_OPERATION_QUERY_TRANSFERS,
 		1,


### PR DESCRIPTION
QueryAccounts/QueryTransfers with Limit 0 looked like empty success. Validate filter client-side and return ErrInvalidQueryFilter. Refs #3092.

AI-assisted; human-reviewed.