### PR TITLE
stdx: Add `log_errors` to `HttpOptions`

### DIFF
--- a/src/scripts/release.zig
+++ b/src/scripts/release.zig
@@ -1057,6 +1057,7 @@ fn publish_ruby_trusted_publishing_token(shell: *Shell) ![]const u8 {
         .{
             .content_type = .json,
             .expected_response_code = .created,
+            .log_errors = false,
         },
     );
     const rubygems = try std.json.parseFromSliceLeaky(

--- a/src/stdx/shell.zig
+++ b/src/stdx/shell.zig
@@ -966,6 +966,7 @@ pub const HttpOptions = struct {
 
     response_body_size_max: u32 = 512 * stdx.KiB,
     expected_response_code: std.http.Status = .ok,
+    log_errors: bool = true,
 };
 
 pub fn http_get(shell: *Shell, url: []const u8, options: HttpOptions) ![]const u8 {
@@ -1057,7 +1058,9 @@ fn http_request(
     }
 
     if (request.response.status != options.expected_response_code) {
-        log.err("response: {s}", .{response_body});
+        if (options.log_errors) {
+            log.err("response: {s}", .{response_body});
+        }
         return error.ResponseWrongStatus;
     }
 


### PR DESCRIPTION
This one may need a bit of backstory. So far, I only mentioned it to @matklad on a call.

When working on adding trusted publishing for Ruby (see #3787), I tested the custom Zig code on one of my own Ruby gems first. At that point, the HTTP client in `stdx` was hardcoded to only accept `200 OK` responses. For any other response code, it would log an error message:

```zig
log.err("response: {s}", .{response_body});
```

Unfortunately, the Rubygems.org API returns the new token with a `201 Created` response code, so even though the request was technically successful, it ended up dumping a short-lived auth token into my CI logs, which is less than ideal from a supply-chain security perspective.

This is what led me to add the `expected_response_code` option to `HttpOptions` in the above-mentioned PR. However, it always felt like a partial solution because the [RubyGems API docs](https://guides.rubygems.org/rubygems-org-api/#misc-methods) do not specify HTTP status codes for their responses. So if the `POST /api/v1/oidc/trusted_publisher/exchange_token` endpoint ever gets changed to another success code — unlikely as that may be — we'd run the risk of exposing the token. And the same may be true for other requests we're making. So it may not always be safe to assume that the expected error code does not change and that such a change would not potentially expose something we'd rather not expose.


