### PR TITLE
clients/python: Fix u128 overflows in lookups

### DIFF
--- a/src/clients/python/python_bindings.zig
+++ b/src/clients/python/python_bindings.zig
@@ -204,16 +204,24 @@ fn emit_struct_ctypes(
 
     inline for (type_info.fields) |field| {
         const field_type_info = @typeInfo(field.type);
+        const field_is_u128 = field_type_info == .int and field_type_info.int.bits == 128;
 
-        // Emit a bounds check for all integer types that aren't using the custom c_uint128 class.
-        // That has an explicit check built in, but the standard Python ctypes ones (eg,
-        // ctypes.c_uint64) don't and will happily overflow otherwise.
+        // Emit a bounds check for all integer types. The standard Python ctypes ones (eg,
+        // ctypes.c_uint64) don't check and will happily overflow, so validate them here.
+        // u128 goes through our custom c_uint128.from_param.
         if (comptime !std.mem.eql(u8, field.name, "reserved") and field_type_info == .int) {
-            buffer.print("        validate_uint(bits={[int_bits]}, name=\"{[field_name]s}\", " ++
-                "number=obj.{[field_name]s})\n", .{
-                .field_name = field.name,
-                .int_bits = field_type_info.int.bits,
-            });
+            if (field_is_u128) {
+                buffer.print("        {[field_name]s}_u128 = c_uint128.from_param(" ++
+                    "obj.{[field_name]s}, name=\"{[field_name]s}\")\n", .{
+                    .field_name = field.name,
+                });
+            } else {
+                buffer.print("        validate_uint(bits={[int_bits]}, " ++
+                    "name=\"{[field_name]s}\", number=obj.{[field_name]s})\n", .{
+                    .field_name = field.name,
+                    .int_bits = field_type_info.int.bits,
+                });
+            }
         }
     }
 
@@ -222,15 +230,15 @@ fn emit_struct_ctypes(
     inline for (type_info.fields) |field| {
         const field_type_info = @typeInfo(field.type);
         const field_is_u128 = field_type_info == .int and field_type_info.int.bits == 128;
-        const convert_prefix = if (field_is_u128) "c_uint128.from_param(" else "";
-        const convert_suffix = if (field_is_u128) ")" else "";
+        const value_prefix = if (field_is_u128) "" else "obj.";
+        const value_suffix = if (field_is_u128) "_u128" else "";
 
         if (comptime !std.mem.eql(u8, field.name, "reserved")) {
-            buffer.print("            {[field_name]s}={[convert_prefix]s}" ++
-                "obj.{[field_name]s}{[convert_suffix]s},\n", .{
+            buffer.print("            {[field_name]s}={[value_prefix]s}" ++
+                "{[field_name]s}{[value_suffix]s},\n", .{
                 .field_name = field.name,
-                .convert_prefix = convert_prefix,
-                .convert_suffix = convert_suffix,
+                .value_prefix = value_prefix,
+                .value_suffix = value_suffix,
             });
         }
     }

--- a/src/clients/python/src/tigerbeetle/bindings.py
+++ b/src/clients/python/src/tigerbeetle/bindings.py
@@ -333,24 +333,24 @@ CClient._fields_ = [ # noqa: SLF001
 class CAccount(ctypes.Structure):
     @classmethod
     def from_param(cls, obj: Any) -> Self:
-        validate_uint(bits=128, name="id", number=obj.id)
-        validate_uint(bits=128, name="debits_pending", number=obj.debits_pending)
-        validate_uint(bits=128, name="debits_posted", number=obj.debits_posted)
-        validate_uint(bits=128, name="credits_pending", number=obj.credits_pending)
-        validate_uint(bits=128, name="credits_posted", number=obj.credits_posted)
-        validate_uint(bits=128, name="user_data_128", number=obj.user_data_128)
+        id_u128 = c_uint128.from_param(obj.id, name="id")
+        debits_pending_u128 = c_uint128.from_param(obj.debits_pending, name="debits_pending")
+        debits_posted_u128 = c_uint128.from_param(obj.debits_posted, name="debits_posted")
+        credits_pending_u128 = c_uint128.from_param(obj.credits_pending, name="credits_pending")
+        credits_posted_u128 = c_uint128.from_param(obj.credits_posted, name="credits_posted")
+        user_data_128_u128 = c_uint128.from_param(obj.user_data_128, name="user_data_128")
         validate_uint(bits=64, name="user_data_64", number=obj.user_data_64)
         validate_uint(bits=32, name="user_data_32", number=obj.user_data_32)
         validate_uint(bits=32, name="ledger", number=obj.ledger)
         validate_uint(bits=16, name="code", number=obj.code)
         validate_uint(bits=64, name="timestamp", number=obj.timestamp)
         return cls(
-            id=c_uint128.from_param(obj.id),
-            debits_pending=c_uint128.from_param(obj.debits_pending),
-            debits_posted=c_uint128.from_param(obj.debits_posted),
-            credits_pending=c_uint128.from_param(obj.credits_pending),
-            credits_posted=c_uint128.from_param(obj.credits_posted),
-            user_data_128=c_uint128.from_param(obj.user_data_128),
+            id=id_u128,
+            debits_pending=debits_pending_u128,
+            debits_posted=debits_posted_u128,
+            credits_pending=credits_pending_u128,
+            credits_posted=credits_posted_u128,
+            user_data_128=user_data_128_u128,
             user_data_64=obj.user_data_64,
             user_data_32=obj.user_data_32,
             ledger=obj.ledger,
@@ -396,12 +396,12 @@ CAccount._fields_ = [ # noqa: SLF001
 class CTransfer(ctypes.Structure):
     @classmethod
     def from_param(cls, obj: Any) -> Self:
-        validate_uint(bits=128, name="id", number=obj.id)
-        validate_uint(bits=128, name="debit_account_id", number=obj.debit_account_id)
-        validate_uint(bits=128, name="credit_account_id", number=obj.credit_account_id)
-        validate_uint(bits=128, name="amount", number=obj.amount)
-        validate_uint(bits=128, name="pending_id", number=obj.pending_id)
-        validate_uint(bits=128, name="user_data_128", number=obj.user_data_128)
+        id_u128 = c_uint128.from_param(obj.id, name="id")
+        debit_account_id_u128 = c_uint128.from_param(obj.debit_account_id, name="debit_account_id")
+        credit_account_id_u128 = c_uint128.from_param(obj.credit_account_id, name="credit_account_id")
+        amount_u128 = c_uint128.from_param(obj.amount, name="amount")
+        pending_id_u128 = c_uint128.from_param(obj.pending_id, name="pending_id")
+        user_data_128_u128 = c_uint128.from_param(obj.user_data_128, name="user_data_128")
         validate_uint(bits=64, name="user_data_64", number=obj.user_data_64)
         validate_uint(bits=32, name="user_data_32", number=obj.user_data_32)
         validate_uint(bits=32, name="timeout", number=obj.timeout)
@@ -409,12 +409,12 @@ class CTransfer(ctypes.Structure):
         validate_uint(bits=16, name="code", number=obj.code)
         validate_uint(bits=64, name="timestamp", number=obj.timestamp)
         return cls(
-            id=c_uint128.from_param(obj.id),
-            debit_account_id=c_uint128.from_param(obj.debit_account_id),
-            credit_account_id=c_uint128.from_param(obj.credit_account_id),
-            amount=c_uint128.from_param(obj.amount),
-            pending_id=c_uint128.from_param(obj.pending_id),
-            user_data_128=c_uint128.from_param(obj.user_data_128),
+            id=id_u128,
+            debit_account_id=debit_account_id_u128,
+            credit_account_id=credit_account_id_u128,
+            amount=amount_u128,
+            pending_id=pending_id_u128,
+            user_data_128=user_data_128_u128,
             user_data_64=obj.user_data_64,
             user_data_32=obj.user_data_32,
             timeout=obj.timeout,
@@ -508,8 +508,8 @@ CCreateTransferResult._fields_ = [ # noqa: SLF001
 class CAccountFilter(ctypes.Structure):
     @classmethod
     def from_param(cls, obj: Any) -> Self:
-        validate_uint(bits=128, name="account_id", number=obj.account_id)
-        validate_uint(bits=128, name="user_data_128", number=obj.user_data_128)
+        account_id_u128 = c_uint128.from_param(obj.account_id, name="account_id")
+        user_data_128_u128 = c_uint128.from_param(obj.user_data_128, name="user_data_128")
         validate_uint(bits=64, name="user_data_64", number=obj.user_data_64)
         validate_uint(bits=32, name="user_data_32", number=obj.user_data_32)
         validate_uint(bits=16, name="code", number=obj.code)
@@ -517,8 +517,8 @@ class CAccountFilter(ctypes.Structure):
         validate_uint(bits=64, name="timestamp_max", number=obj.timestamp_max)
         validate_uint(bits=32, name="limit", number=obj.limit)
         return cls(
-            account_id=c_uint128.from_param(obj.account_id),
-            user_data_128=c_uint128.from_param(obj.user_data_128),
+            account_id=account_id_u128,
+            user_data_128=user_data_128_u128,
             user_data_64=obj.user_data_64,
             user_data_32=obj.user_data_32,
             code=obj.code,
@@ -559,16 +559,16 @@ CAccountFilter._fields_ = [ # noqa: SLF001
 class CAccountBalance(ctypes.Structure):
     @classmethod
     def from_param(cls, obj: Any) -> Self:
-        validate_uint(bits=128, name="debits_pending", number=obj.debits_pending)
-        validate_uint(bits=128, name="debits_posted", number=obj.debits_posted)
-        validate_uint(bits=128, name="credits_pending", number=obj.credits_pending)
-        validate_uint(bits=128, name="credits_posted", number=obj.credits_posted)
+        debits_pending_u128 = c_uint128.from_param(obj.debits_pending, name="debits_pending")
+        debits_posted_u128 = c_uint128.from_param(obj.debits_posted, name="debits_posted")
+        credits_pending_u128 = c_uint128.from_param(obj.credits_pending, name="credits_pending")
+        credits_posted_u128 = c_uint128.from_param(obj.credits_posted, name="credits_posted")
         validate_uint(bits=64, name="timestamp", number=obj.timestamp)
         return cls(
-            debits_pending=c_uint128.from_param(obj.debits_pending),
-            debits_posted=c_uint128.from_param(obj.debits_posted),
-            credits_pending=c_uint128.from_param(obj.credits_pending),
-            credits_posted=c_uint128.from_param(obj.credits_posted),
+            debits_pending=debits_pending_u128,
+            debits_posted=debits_posted_u128,
+            credits_pending=credits_pending_u128,
+            credits_posted=credits_posted_u128,
             timestamp=obj.timestamp,
         )
 
@@ -595,7 +595,7 @@ CAccountBalance._fields_ = [ # noqa: SLF001
 class CQueryFilter(ctypes.Structure):
     @classmethod
     def from_param(cls, obj: Any) -> Self:
-        validate_uint(bits=128, name="user_data_128", number=obj.user_data_128)
+        user_data_128_u128 = c_uint128.from_param(obj.user_data_128, name="user_data_128")
         validate_uint(bits=64, name="user_data_64", number=obj.user_data_64)
         validate_uint(bits=32, name="user_data_32", number=obj.user_data_32)
         validate_uint(bits=32, name="ledger", number=obj.ledger)
@@ -604,7 +604,7 @@ class CQueryFilter(ctypes.Structure):
         validate_uint(bits=64, name="timestamp_max", number=obj.timestamp_max)
         validate_uint(bits=32, name="limit", number=obj.limit)
         return cls(
-            user_data_128=c_uint128.from_param(obj.user_data_128),
+            user_data_128=user_data_128_u128,
             user_data_64=obj.user_data_64,
             user_data_32=obj.user_data_32,
             ledger=obj.ledger,

--- a/src/clients/python/src/tigerbeetle/client.py
+++ b/src/clients/python/src/tigerbeetle/client.py
@@ -137,7 +137,7 @@ class Client:
 
         # ctypes needs a reference to keep this alive through the FFI call. Having it as a temporary
         # within the call _does not_ work.
-        cluster_id_u128 = c_uint128.from_param(cluster_id)
+        cluster_id_u128 = c_uint128.from_param(cluster_id, name="cluster_id")
         init_status = bindings.tb_client_init(
             ctypes.byref(self._client),
             ctypes.cast(

--- a/src/clients/python/src/tigerbeetle/lib.py
+++ b/src/clients/python/src/tigerbeetle/lib.py
@@ -73,8 +73,8 @@ class c_uint128(ctypes.Structure):  # noqa: N801
     _fields_ = [("_low", ctypes.c_uint64), ("_high", ctypes.c_uint64)]  # noqa: RUF012
 
     @classmethod
-    def from_param(cls, obj: int) -> Self:
-        validate_uint(bits=128, name="u128", number=obj)
+    def from_param(cls, obj: int, name: str = "u128") -> Self:
+        validate_uint(bits=128, name=name, number=obj)
         return cls(_high=obj >> 64, _low=obj & 0xFFFFFFFFFFFFFFFF)
 
     def to_python(self) -> int:

--- a/src/clients/python/src/tigerbeetle/lib.py
+++ b/src/clients/python/src/tigerbeetle/lib.py
@@ -74,6 +74,7 @@ class c_uint128(ctypes.Structure):  # noqa: N801
 
     @classmethod
     def from_param(cls, obj: int) -> Self:
+        validate_uint(bits=128, name="u128", number=obj)
         return cls(_high=obj >> 64, _low=obj & 0xFFFFFFFFFFFFFFFF)
 
     def to_python(self) -> int:

--- a/src/clients/python/tests/test_basic.py
+++ b/src/clients/python/tests/test_basic.py
@@ -53,19 +53,13 @@ account_b = tb.Account(
 
 def test_range_check_u128_cannot_exceed(client):
     account = tb.Account(**{ **asdict(account_a), "id": 9999999999999999999999999999999999999999 })
-
-    try:
-        error = client.create_accounts([account])
-    except tb.IntegerOverflowError:
-        pass
+    with pytest.raises(tb.IntegerOverflowError):
+        client.create_accounts([account])
 
 def test_range_check_u128_cannot_be_negative(client):
     account = tb.Account(**{ **asdict(account_a), "id": -1 })
-
-    try:
-        error = client.create_accounts([account])
-    except tb.IntegerOverflowError:
-        pass
+    with pytest.raises(tb.IntegerOverflowError):
+        client.create_accounts([account])
 
 def test_range_check_u128_lookup_id_cannot_exceed(client):
     with pytest.raises(tb.IntegerOverflowError):

--- a/src/clients/python/tests/test_basic.py
+++ b/src/clients/python/tests/test_basic.py
@@ -70,12 +70,10 @@ def test_range_check_u128_lookup_id_cannot_be_negative(client):
         client.lookup_transfers([-1])
 
 def test_range_check_code_on_account_to_be_u16(client):
-    account = tb.Account(**{ **asdict(account_a), "id": 0, "code": 65535 + 1 })
+    account = tb.Account(**{ **asdict(account_a), "id": tb.id(), "code": 65535 + 1 })
 
-    try:
-        code_error = client.create_accounts([account])
-    except tb.IntegerOverflowError:
-        pass
+    with pytest.raises(tb.IntegerOverflowError):
+        client.create_accounts([account])
 
     accounts = client.lookup_accounts([account.id])
     assert accounts == []
@@ -536,7 +534,7 @@ def test_get_account_transfers(client):
     assert len(transfers_results) == len(transfers_created)
     for result in transfers_results:
         assert result.timestamp > 0
-        assert result.status == tb.CreateAccountStatus.CREATED
+        assert result.status == tb.CreateTransferStatus.CREATED
 
     # Query all transfers for accountC:
     filter = tb.AccountFilter(
@@ -1057,8 +1055,8 @@ def test_query_transfers(client):
     )
     account_results = client.create_accounts([account])
     assert len(account_results) == 1
-    account_results[0].timestamp > 0
-    account_results[0].status == tb.CreateAccountStatus.CREATED
+    assert account_results[0].timestamp > 0
+    assert account_results[0].status == tb.CreateAccountStatus.CREATED
 
     transfers_created = []
     # Create transfers:
@@ -1315,7 +1313,7 @@ def test_query_with_invalid_filter(client):
         code=0,
         timestamp_min=0,
         timestamp_max=0,
-        limit=0,
+        limit=BATCH_MAX,
         flags=0xFFFF,
     )
     assert client.query_accounts(filter) == []

--- a/src/clients/python/tests/test_basic.py
+++ b/src/clients/python/tests/test_basic.py
@@ -67,6 +67,14 @@ def test_range_check_u128_cannot_be_negative(client):
     except tb.IntegerOverflowError:
         pass
 
+def test_range_check_u128_lookup_id_cannot_exceed(client):
+    with pytest.raises(tb.IntegerOverflowError):
+        client.lookup_accounts([2**128])
+
+def test_range_check_u128_lookup_id_cannot_be_negative(client):
+    with pytest.raises(tb.IntegerOverflowError):
+        client.lookup_transfers([-1])
+
 def test_range_check_code_on_account_to_be_u16(client):
     account = tb.Account(**{ **asdict(account_a), "id": 0, "code": 65535 + 1 })
 


### PR DESCRIPTION
While working on the conformance tests, I noticed that one of the generated tests did *not* fail as expected.

`lookup_accounts` and `lookup_transfers` take IDs as plain ints and don't range-check them. An id larger than `2**128 - 1` gets masked down to 128 bits and looked up as that value instead. Nothing raises. For example, `lookup_accounts([2**128 + 5])` looks up id `5`.

## Root cause

IDs are converted by `c_uint128.from_param`:

```python
@classmethod
def from_param(cls, obj: int) -> Self:
    return cls(_high=obj >> 64, _low=obj & 0xFFFFFFFFFFFFFFFF)
```

`_high` and `_low` are `c_uint64`. `ctypes` masks unsigned assignment rather than raising, so both the `&` and the narrowing of `_high` happen unconditionally:

```
n = 2**128
n >> 64 # 18446744073709551616 (= 2**64)
ctypes.c_uint64(2**64).value # 0
n & 0xFFFFFFFFFFFFFFFF  # 0
```

The struct path validates. `CAccount.from_param` checks each field first:

```python
validate_uint(bits=128, name="id", number=obj.id)
```

Bare IDs don't get the same treatment. `_acquire_packet` maps `from_param` over the list directly:

```python
operations_array = operations_array_type(*map(c_event_type.from_param, operations))
``` 

## Fix

Add a check in `c_uint128.from_param`, so u128 conversions are handled the same, regardless of call site:

```python
@classmethod
def from_param(cls, obj: int) -> Self:
    validate_uint(bits=128, name="u128", number=obj)
    return cls(_high=obj >> 64, _low=obj & 0xFFFFFFFFFFFFFFFF)
```

## Related questions and comments

1. I'm not entirely sure why the existing struct tests were written like this:
    ```python
    def test_range_check_u128_cannot_exceed(client):
        account = tb.Account(**{ **asdict(account_a), "id": 9999999999999999999999999999999999999999 })

     try:
        error = client.create_accounts([account])
     except tb.IntegerOverflowError:
        pass

    def test_range_check_u128_cannot_be_negative(client):
      account = tb.Account(**{ **asdict(account_a), "id": -1 })

      try:
          error = client.create_accounts([account])
      except tb.IntegerOverflowError:
          pass
     ```
     `error` is assigned but unused, and the `except + pass` combo is a less strong assertion than `pytest.raises`.
2. I really struggled to run the Python CI steps reliably on my machine. I didn't have much time to dig into it, but the failures were intermittent. It appears there may be a race condition between some of the build steps, but I can't confirm it yet and don't have time to look into it right now.