### PR TITLE
docs(rust): align quickstart Cargo edition with samples

### DIFF
--- a/src/clients/rust/README.md
+++ b/src/clients/rust/README.md
@@ -22,7 +22,7 @@ Then create `Cargo.toml` and copy this into it:
 [package]
 name = "tigerbeetle-test"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 tigerbeetle.path = "../.."

--- a/src/clients/rust/docs.zig
+++ b/src/clients/rust/docs.zig
@@ -26,7 +26,7 @@ pub const RustDocs = Docs{
     \\[package]
     \\name = "tigerbeetle-test"
     \\version = "0.1.0"
-    \\edition = "2024"
+    \\edition = "2021"
     \\
     \\[dependencies]
     \\tigerbeetle.path = "../.."


### PR DESCRIPTION
Rust client docs and README told users to paste `edition = "2024"` into a fresh Cargo.toml, but the actual crate and every sample use 2021. Fix the generator and README so copy-pasted setup matches the tree.

Re-ships #3890 against current main.

<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** sera · Platform: hermes · Claim-TTL: 24h