### PR TITLE
clients/node: Fix invalid filter test

### DIFF
--- a/src/clients/node/src/test.ts
+++ b/src/clients/node/src/test.ts
@@ -1499,7 +1499,7 @@ test('query with invalid filter', async (): Promise<void> => {
     code: 0,
     timestamp_min: 0n,
     timestamp_max: 0n,
-    limit: 0,
+    limit: BATCH_MAX,
     flags: 0xFFFF,
   }
   assert.deepStrictEqual((await client.queryAccounts(filter)), [])


### PR DESCRIPTION
As part of my recent conformance test work, I noticed some problems in the Python tests, which were addressed in https://github.com/tigerbeetle/tigerbeetle/pull/3917.

I then remembered that this specific test is pretty much the same across Python and Node, so it exhibits the same problem: setting an explicit limit of 0 instead of `BATCH_MAX` makes the assertion that an empty result set is returned meaningless. The limit test is a bit further up in the file on line 1455.