### PR TITLE
clients/ruby: Stricter integer checks

### DIFF
--- a/src/clients/ruby/ruby_bindings.zig
+++ b/src/clients/ruby/ruby_bindings.zig
@@ -471,12 +471,26 @@ fn emit_c_header_preamble(buffer: *Buffer) void {
         \\#include <stdlib.h>
         \\#include <string.h>
         \\
-        \\static inline void rb_tb_pack_u128(VALUE v, void *dst) {
+        \\static inline VALUE rb_tb_check_integer(VALUE v, const char *field) {
+        \\    if (!RB_INTEGER_TYPE_P(v)) {
+        \\        rb_raise(rb_eTypeError, "%s must be an Integer, got %s", field, rb_obj_classname(v));
+        \\    }
+        \\    return v;
+        \\}
+        \\
+        \\static inline void rb_tb_pack_u128(VALUE v, void *dst, const char *field) {
+        \\    rb_tb_check_integer(v, field);
         \\    int status = rb_integer_pack(v, dst, 16, 1, 0, INTEGER_PACK_LITTLE_ENDIAN);
         \\    if (status != 0 && status != 1) {
         \\        rb_raise(rb_eRangeError, "integer must be between 0 and 2**128 - 1");
         \\    }
         \\}
+        \\
+        \\#define rb_tb_ivar_get_checked(item_rb, field) \
+        \\    rb_tb_check_integer(rb_ivar_get(item_rb, rb_intern("@" #field)), #field)
+        \\
+        \\#define rb_tb_pack_u128_checked(item_rb, item, field) \
+        \\    rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@" #field)), &item->field, #field)
         \\
         \\static inline VALUE rb_tb_unpack_u128(const void *src) {
         \\    return rb_integer_unpack(src, 16, 1, 0, INTEGER_PACK_LITTLE_ENDIAN);
@@ -548,16 +562,17 @@ fn emit_c_status_name_function(
 fn emit_c_num_from_ruby(
     buffer: *Buffer,
     comptime FieldType: type,
-    comptime ruby_value: []const u8,
+    comptime field_name: []const u8,
 ) void {
     const bits = comptime int_bits(FieldType);
-    switch (bits) {
-        8 => buffer.print("RB_NUM2CHR({s})", .{ruby_value}),
-        16 => buffer.print("RB_NUM2USHORT({s})", .{ruby_value}),
-        32 => buffer.print("RB_NUM2UINT({s})", .{ruby_value}),
-        64 => buffer.print("RB_NUM2ULL({s})", .{ruby_value}),
+    const macro: []const u8 = switch (bits) {
+        8 => "RB_NUM2CHR",
+        16 => "RB_NUM2USHORT",
+        32 => "RB_NUM2UINT",
+        64 => "RB_NUM2ULL",
         else => @compileError("unsupported Ruby numeric field"),
-    }
+    };
+    buffer.print("{s}(rb_tb_ivar_get_checked(item_rb, {s}))", .{ macro, field_name });
 }
 
 fn emit_c_value_from_field(
@@ -600,21 +615,20 @@ fn emit_c_serialize_struct(buffer: *Buffer, comptime operation: tb.Operation) vo
             }
             continue;
         }
-        const value_expr = "rb_ivar_get(item_rb, rb_intern(\"@" ++ field.name ++ "\"))";
         switch (@typeInfo(field.type)) {
             .int => |info| if (info.bits == 128) {
                 buffer.print(
-                    "        rb_tb_pack_u128({s}, &item->{s});\n",
-                    .{ value_expr, field.name },
+                    "        rb_tb_pack_u128_checked(item_rb, item, {s});\n",
+                    .{field.name},
                 );
             } else {
                 buffer.print("        item->{s} = ", .{field.name});
-                emit_c_num_from_ruby(buffer, field.type, value_expr);
+                emit_c_num_from_ruby(buffer, field.type, field.name);
                 buffer.print(";\n", .{});
             },
             .@"enum", .@"struct" => {
                 buffer.print("        item->{s} = ", .{field.name});
-                emit_c_num_from_ruby(buffer, field.type, value_expr);
+                emit_c_num_from_ruby(buffer, field.type, field.name);
                 buffer.print(";\n", .{});
             },
             else => @compileError("unsupported serializer field: " ++ @typeName(field.type)),
@@ -687,7 +701,7 @@ fn emit_c_lookup_serializer(buffer: *Buffer) void {
         \\static void rb_tb_serialize_u128(VALUE items_rb, uint8_t *buf, long count) {
         \\    tb_uint128_t *ids = (tb_uint128_t *)buf;
         \\    for (long i = 0; i < count; i++) {
-        \\        rb_tb_pack_u128(RARRAY_AREF(items_rb, i), &ids[i]);
+        \\        rb_tb_pack_u128(RARRAY_AREF(items_rb, i), &ids[i], "id");
         \\    }
         \\}
         \\

--- a/src/clients/ruby/src/ext/tigerbeetle/rb_tb_gen.h
+++ b/src/clients/ruby/src/ext/tigerbeetle/rb_tb_gen.h
@@ -13,12 +13,26 @@
 #include <stdlib.h>
 #include <string.h>
 
-static inline void rb_tb_pack_u128(VALUE v, void *dst) {
+static inline VALUE rb_tb_check_integer(VALUE v, const char *field) {
+    if (!RB_INTEGER_TYPE_P(v)) {
+        rb_raise(rb_eTypeError, "%s must be an Integer, got %s", field, rb_obj_classname(v));
+    }
+    return v;
+}
+
+static inline void rb_tb_pack_u128(VALUE v, void *dst, const char *field) {
+    rb_tb_check_integer(v, field);
     int status = rb_integer_pack(v, dst, 16, 1, 0, INTEGER_PACK_LITTLE_ENDIAN);
     if (status != 0 && status != 1) {
         rb_raise(rb_eRangeError, "integer must be between 0 and 2**128 - 1");
     }
 }
+
+#define rb_tb_ivar_get_checked(item_rb, field) \
+    rb_tb_check_integer(rb_ivar_get(item_rb, rb_intern("@" #field)), #field)
+
+#define rb_tb_pack_u128_checked(item_rb, item, field) \
+    rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@" #field)), &item->field, #field)
 
 static inline VALUE rb_tb_unpack_u128(const void *src) {
     return rb_integer_unpack(src, 16, 1, 0, INTEGER_PACK_LITTLE_ENDIAN);
@@ -326,16 +340,16 @@ static void rb_tb_serialize_get_account_transfers(VALUE items_rb, uint8_t *buf, 
     for (long i = 0; i < count; i++) {
         VALUE item_rb = RARRAY_AREF(items_rb, i);
         tb_account_filter_t *item = &items[i];
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@account_id")), &item->account_id);
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
-        item->user_data_64 = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
-        item->code = RB_NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
+        rb_tb_pack_u128_checked(item_rb, item, account_id);
+        rb_tb_pack_u128_checked(item_rb, item, user_data_128);
+        item->user_data_64 = RB_NUM2ULL(rb_tb_ivar_get_checked(item_rb, user_data_64));
+        item->user_data_32 = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, user_data_32));
+        item->code = RB_NUM2USHORT(rb_tb_ivar_get_checked(item_rb, code));
         memset(item->reserved, 0, sizeof(item->reserved));
-        item->timestamp_min = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_min")));
-        item->timestamp_max = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_max")));
-        item->limit = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
-        item->flags = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
+        item->timestamp_min = RB_NUM2ULL(rb_tb_ivar_get_checked(item_rb, timestamp_min));
+        item->timestamp_max = RB_NUM2ULL(rb_tb_ivar_get_checked(item_rb, timestamp_max));
+        item->limit = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, limit));
+        item->flags = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, flags));
     }
 }
 
@@ -371,16 +385,16 @@ static void rb_tb_serialize_get_account_balances(VALUE items_rb, uint8_t *buf, l
     for (long i = 0; i < count; i++) {
         VALUE item_rb = RARRAY_AREF(items_rb, i);
         tb_account_filter_t *item = &items[i];
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@account_id")), &item->account_id);
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
-        item->user_data_64 = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
-        item->code = RB_NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
+        rb_tb_pack_u128_checked(item_rb, item, account_id);
+        rb_tb_pack_u128_checked(item_rb, item, user_data_128);
+        item->user_data_64 = RB_NUM2ULL(rb_tb_ivar_get_checked(item_rb, user_data_64));
+        item->user_data_32 = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, user_data_32));
+        item->code = RB_NUM2USHORT(rb_tb_ivar_get_checked(item_rb, code));
         memset(item->reserved, 0, sizeof(item->reserved));
-        item->timestamp_min = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_min")));
-        item->timestamp_max = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_max")));
-        item->limit = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
-        item->flags = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
+        item->timestamp_min = RB_NUM2ULL(rb_tb_ivar_get_checked(item_rb, timestamp_min));
+        item->timestamp_max = RB_NUM2ULL(rb_tb_ivar_get_checked(item_rb, timestamp_max));
+        item->limit = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, limit));
+        item->flags = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, flags));
     }
 }
 
@@ -410,16 +424,16 @@ static void rb_tb_serialize_query_accounts(VALUE items_rb, uint8_t *buf, long co
     for (long i = 0; i < count; i++) {
         VALUE item_rb = RARRAY_AREF(items_rb, i);
         tb_query_filter_t *item = &items[i];
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
-        item->user_data_64 = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
-        item->ledger = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
-        item->code = RB_NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
+        rb_tb_pack_u128_checked(item_rb, item, user_data_128);
+        item->user_data_64 = RB_NUM2ULL(rb_tb_ivar_get_checked(item_rb, user_data_64));
+        item->user_data_32 = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, user_data_32));
+        item->ledger = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, ledger));
+        item->code = RB_NUM2USHORT(rb_tb_ivar_get_checked(item_rb, code));
         memset(item->reserved, 0, sizeof(item->reserved));
-        item->timestamp_min = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_min")));
-        item->timestamp_max = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_max")));
-        item->limit = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
-        item->flags = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
+        item->timestamp_min = RB_NUM2ULL(rb_tb_ivar_get_checked(item_rb, timestamp_min));
+        item->timestamp_max = RB_NUM2ULL(rb_tb_ivar_get_checked(item_rb, timestamp_max));
+        item->limit = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, limit));
+        item->flags = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, flags));
     }
 }
 
@@ -455,16 +469,16 @@ static void rb_tb_serialize_query_transfers(VALUE items_rb, uint8_t *buf, long c
     for (long i = 0; i < count; i++) {
         VALUE item_rb = RARRAY_AREF(items_rb, i);
         tb_query_filter_t *item = &items[i];
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
-        item->user_data_64 = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
-        item->ledger = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
-        item->code = RB_NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
+        rb_tb_pack_u128_checked(item_rb, item, user_data_128);
+        item->user_data_64 = RB_NUM2ULL(rb_tb_ivar_get_checked(item_rb, user_data_64));
+        item->user_data_32 = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, user_data_32));
+        item->ledger = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, ledger));
+        item->code = RB_NUM2USHORT(rb_tb_ivar_get_checked(item_rb, code));
         memset(item->reserved, 0, sizeof(item->reserved));
-        item->timestamp_min = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_min")));
-        item->timestamp_max = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp_max")));
-        item->limit = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@limit")));
-        item->flags = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@flags")));
+        item->timestamp_min = RB_NUM2ULL(rb_tb_ivar_get_checked(item_rb, timestamp_min));
+        item->timestamp_max = RB_NUM2ULL(rb_tb_ivar_get_checked(item_rb, timestamp_max));
+        item->limit = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, limit));
+        item->flags = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, flags));
     }
 }
 
@@ -500,19 +514,19 @@ static void rb_tb_serialize_create_accounts(VALUE items_rb, uint8_t *buf, long c
     for (long i = 0; i < count; i++) {
         VALUE item_rb = RARRAY_AREF(items_rb, i);
         tb_account_t *item = &items[i];
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@id")), &item->id);
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@debits_pending")), &item->debits_pending);
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@debits_posted")), &item->debits_posted);
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@credits_pending")), &item->credits_pending);
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@credits_posted")), &item->credits_posted);
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
-        item->user_data_64 = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
+        rb_tb_pack_u128_checked(item_rb, item, id);
+        rb_tb_pack_u128_checked(item_rb, item, debits_pending);
+        rb_tb_pack_u128_checked(item_rb, item, debits_posted);
+        rb_tb_pack_u128_checked(item_rb, item, credits_pending);
+        rb_tb_pack_u128_checked(item_rb, item, credits_posted);
+        rb_tb_pack_u128_checked(item_rb, item, user_data_128);
+        item->user_data_64 = RB_NUM2ULL(rb_tb_ivar_get_checked(item_rb, user_data_64));
+        item->user_data_32 = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, user_data_32));
         item->reserved = 0;
-        item->ledger = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
-        item->code = RB_NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
-        item->flags = RB_NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@flags")));
-        item->timestamp = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp")));
+        item->ledger = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, ledger));
+        item->code = RB_NUM2USHORT(rb_tb_ivar_get_checked(item_rb, code));
+        item->flags = RB_NUM2USHORT(rb_tb_ivar_get_checked(item_rb, flags));
+        item->timestamp = RB_NUM2ULL(rb_tb_ivar_get_checked(item_rb, timestamp));
     }
 }
 
@@ -543,19 +557,19 @@ static void rb_tb_serialize_create_transfers(VALUE items_rb, uint8_t *buf, long 
     for (long i = 0; i < count; i++) {
         VALUE item_rb = RARRAY_AREF(items_rb, i);
         tb_transfer_t *item = &items[i];
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@id")), &item->id);
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@debit_account_id")), &item->debit_account_id);
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@credit_account_id")), &item->credit_account_id);
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@amount")), &item->amount);
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@pending_id")), &item->pending_id);
-        rb_tb_pack_u128(rb_ivar_get(item_rb, rb_intern("@user_data_128")), &item->user_data_128);
-        item->user_data_64 = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@user_data_64")));
-        item->user_data_32 = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@user_data_32")));
-        item->timeout = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@timeout")));
-        item->ledger = RB_NUM2UINT(rb_ivar_get(item_rb, rb_intern("@ledger")));
-        item->code = RB_NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@code")));
-        item->flags = RB_NUM2USHORT(rb_ivar_get(item_rb, rb_intern("@flags")));
-        item->timestamp = RB_NUM2ULL(rb_ivar_get(item_rb, rb_intern("@timestamp")));
+        rb_tb_pack_u128_checked(item_rb, item, id);
+        rb_tb_pack_u128_checked(item_rb, item, debit_account_id);
+        rb_tb_pack_u128_checked(item_rb, item, credit_account_id);
+        rb_tb_pack_u128_checked(item_rb, item, amount);
+        rb_tb_pack_u128_checked(item_rb, item, pending_id);
+        rb_tb_pack_u128_checked(item_rb, item, user_data_128);
+        item->user_data_64 = RB_NUM2ULL(rb_tb_ivar_get_checked(item_rb, user_data_64));
+        item->user_data_32 = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, user_data_32));
+        item->timeout = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, timeout));
+        item->ledger = RB_NUM2UINT(rb_tb_ivar_get_checked(item_rb, ledger));
+        item->code = RB_NUM2USHORT(rb_tb_ivar_get_checked(item_rb, code));
+        item->flags = RB_NUM2USHORT(rb_tb_ivar_get_checked(item_rb, flags));
+        item->timestamp = RB_NUM2ULL(rb_tb_ivar_get_checked(item_rb, timestamp));
     }
 }
 
@@ -584,7 +598,7 @@ static VALUE rb_tb_deserialize_create_transfers(const uint8_t *buf, uint32_t buf
 static void rb_tb_serialize_u128(VALUE items_rb, uint8_t *buf, long count) {
     tb_uint128_t *ids = (tb_uint128_t *)buf;
     for (long i = 0; i < count; i++) {
-        rb_tb_pack_u128(RARRAY_AREF(items_rb, i), &ids[i]);
+        rb_tb_pack_u128(RARRAY_AREF(items_rb, i), &ids[i], "id");
     }
 }
 

--- a/src/clients/ruby/src/ext/tigerbeetle/tigerbeetle.c
+++ b/src/clients/ruby/src/ext/tigerbeetle/tigerbeetle.c
@@ -182,7 +182,7 @@ static VALUE rb_tb_client_initialize(
     TypedData_Get_Struct(self, tb_client_t, &rb_tb_client_type, client);
 
     uint8_t cluster_id_bytes[16] = {0};
-    rb_tb_pack_u128(cluster_id_rb, cluster_id_bytes);
+    rb_tb_pack_u128(cluster_id_rb, cluster_id_bytes, "cluster_id");
 
     const char *addr = StringValueCStr(addresses_rb);
     uint32_t addr_len = (uint32_t)RSTRING_LEN(addresses_rb);

--- a/src/clients/ruby/tests/integration/test_integer_types.rb
+++ b/src/clients/ruby/tests/integration/test_integer_types.rb
@@ -1,0 +1,38 @@
+require_relative "tiger_beetle_integration_test"
+
+class TestIntegerTypes < TigerBeetleIntegrationTest
+  def test_u128_field_rejects_float
+    transfer = TigerBeetle::Transfer.new(id: 1, amount: 1.5, ledger: 1, code: 1)
+
+    assert_type_error("amount must be an Integer, got Float") do
+      @client.create_transfers([transfer])
+    end
+  end
+
+  def test_u16_field_rejects_float
+    account = TigerBeetle::Account.new(id: 1, ledger: 1, code: 1.5)
+
+    assert_type_error("code must be an Integer, got Float") do
+      @client.create_accounts([account])
+    end
+  end
+
+  def test_id_rejects_float
+    assert_type_error("id must be an Integer, got Float") do
+      @client.lookup_accounts([1.5])
+    end
+  end
+
+  def test_cluster_id_rejects_float
+    assert_type_error("cluster_id must be an Integer, got Float") do
+      TigerBeetle::Client.new(cluster_id: 1.5, replica_addresses: @tb_address)
+    end
+  end
+
+  private
+
+  def assert_type_error(message, &block)
+    error = assert_raises(TypeError, &block)
+    assert_equal(message, error.message)
+  end
+end


### PR DESCRIPTION
## Context

During the conformance test work, @matklad and I discussed adding tests for floats where we expect integers in clients where that could be an issue (specifically Ruby and Python).

## The problem

Ruby's `rb_integer_pack` will implicitly call `to_i` on any passed-in value that's not an integer. So a `Float` would silently get truncated. This does not seem like behavior we want to rely on, and the RBS-defined types are only useful for static analysis during development.

## The solution

The solution is to add a custom `rb_tb_check_integer` function, which will raise a `TypeError` if the passed-in value is not an actual integer type (checked via `RB_INTEGER_TYPE_P`). Additionally. two new convenience macros with a `_checked` suffix were added to make these checks easier to use.

## What about Python?

Python already raises a `TypeError`:

1. For `u128` values, the bitshift causes it.
2. For smaller types, it happens in `validate_uint` when trying to assing to the ` c_uint*` fields.

Both of these feel a bit implicit, I wonder if it's worth just adding simple ` isinstance(number, int)` checks to both `c_uint128.from_param` and `validate_uint` to be more deliberate about this.