### PR TITLE
docs: fix 5 broken relative links in sessions.md and vsr.md

### DIFF
--- a/docs/internals/vsr.md
+++ b/docs/internals/vsr.md
@@ -242,8 +242,8 @@ In response to a `get_reply`:
 
 See also:
 
-- [Integration: Client Session Lifecycle](../../reference/sessions.md#lifecycle)
-- [Integration: Client Session Eviction](../../reference/sessions.md#eviction)
+- [Integration: Client Session Lifecycle](../reference/sessions.md#lifecycle)
+- [Integration: Client Session Eviction](../reference/sessions.md#eviction)
 
 ### Protocol: Repair Grid
 

--- a/docs/reference/sessions.md
+++ b/docs/reference/sessions.md
@@ -1,6 +1,6 @@
 # Client Sessions
 
-A _client session_ is a sequence of [requests](../coding/requests/README.md) and replies sent between a
+A _client session_ is a sequence of [requests](../coding/requests.md) and replies sent between a
 client and a cluster.
 
 A client session may have **at most one in-flight request** — i.e. at most one unique request on the
@@ -49,7 +49,7 @@ to self-terminate, bubbling up to the application as an `session evicted` error.
 
 If active clients are terminating with `session evicted` errors, it most likely indicates that the
 application is trying to run too many concurrent clients. For performance reasons, it is recommended
-to [batch](../coding/requests/README.md#batching-events) as many events as possible into each request sent
+to [batch](../coding/requests.md#batching-events) as many events as possible into each request sent
 by each client.
 
 ## Retries
@@ -73,7 +73,7 @@ would be misleading. An error would imply that a request did not execute, when t
 
 ## Guarantees
 
-- A client session may have at most one in-flight [request](../coding/requests/README.md).
+- A client session may have at most one in-flight [request](../coding/requests.md).
 - A client session [reads its own writes](https://jepsen.io/consistency/models/read-your-writes),
   meaning that read operations that happen after a given write operation will observe the effects of
   the write.


### PR DESCRIPTION
Fixed broken relative doc links: sessions.md linked to nonexistent requests/README (file is requests.md), vsr.md used ../../ prefix that resolves outside docs/. Anchors verified valid.
Agent-Owner: sera